### PR TITLE
AI-367: migrate learnings path to ~/.closedloop-ai/learnings/

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -110,7 +110,7 @@ Hook that fires before a `Bash`, `Write`, or `Edit` tool call. Provides just-in-
 
 **`/process-learnings`** — Runs the full learning pipeline: find pending learnings, classify via `learning-capture` agent, validate and reword, aggregate into `org-patterns.toon`, write project patterns to `CLAUDE.md`.
 
-**`/export-closedloop-learnings`** — Exports pending closedloop learnings to `~/.claude/.learnings/closedloop-learnings.json`. Deduplicates by trigger match or 80%+ word overlap.
+**`/export-closedloop-learnings`** — Exports pending closedloop learnings to `~/.closedloop-ai/learnings/closedloop-learnings.json`. Deduplicates by trigger match or 80%+ word overlap.
 
 **`/pull-learnings`** — Imports organization patterns from a shared repository (requires `CLAUDE_ORG_ID`). Converts JSON to TOON. Prevents echo patterns from the current project.
 

--- a/plugins/code/README.md
+++ b/plugins/code/README.md
@@ -247,7 +247,7 @@ Runs when any subagent starts. Performs three tasks:
 
 1. **Loop agent state creation**: If the agent type appears in `loop-agents.json`, creates the initial state file in `{WORKDIR}/.closedloop/` if it does not already exist.
 2. **Agent type tracking**: Writes the agent type, short name, and start timestamp to `.agent-types/{agent_id}` so the stop hook can track timing and type.
-3. **Learning injection**: Reads `~/.claude/.learnings/org-patterns.toon`, filters patterns matching the agent's name, sorts by category priority (mistake > convention > pattern > insight) and confidence, and injects up to 15 patterns into the agent's context via `additionalContext`. Also injects environment variables (`CLOSEDLOOP_WORKDIR`, `CLAUDE_PLUGIN_ROOT`, etc.) into every agent's context.
+3. **Learning injection**: Reads `~/.closedloop-ai/learnings/org-patterns.toon`, filters patterns matching the agent's name, sorts by category priority (mistake > convention > pattern > insight) and confidence, and injects up to 15 patterns into the agent's context via `additionalContext`. Also injects environment variables (`CLOSEDLOOP_WORKDIR`, `CLAUDE_PLUGIN_ROOT`, etc.) into every agent's context.
 
 ### `subagent-stop-hook.sh` (SubagentStop)
 

--- a/plugins/code/hooks/pretooluse-hook.sh
+++ b/plugins/code/hooks/pretooluse-hook.sh
@@ -60,11 +60,14 @@ mkdir -p "$CLOSEDLOOP_WORKDIR/.learnings"
 DEBUG_LOG="$CLOSEDLOOP_WORKDIR/.learnings/pretooluse-hook-debug.log"
 echo "$(date): PreToolUse hook started, tool=$TOOL_NAME" >> "$DEBUG_LOG"
 
-# Path to org-patterns.toon
-PATTERNS_FILE="$HOME/.claude/.learnings/org-patterns.toon"
+# Path to org-patterns.toon (fall back to legacy location during migration)
+PATTERNS_FILE="$HOME/.closedloop-ai/learnings/org-patterns.toon"
+if [[ ! -f "$PATTERNS_FILE" ]]; then
+    PATTERNS_FILE="$HOME/.claude/.learnings/org-patterns.toon"
+fi
 
 if [[ ! -f "$PATTERNS_FILE" ]]; then
-    echo "$(date): No patterns file at $PATTERNS_FILE, exiting" >> "$DEBUG_LOG"
+    echo "$(date): No patterns file found, exiting" >> "$DEBUG_LOG"
     exit 0
 fi
 

--- a/plugins/code/hooks/subagent-start-hook.sh
+++ b/plugins/code/hooks/subagent-start-hook.sh
@@ -162,8 +162,11 @@ SUFFIX_PARTS="$ENV_INFO"
 # but not agentName. Use the short name already derived above.
 AGENT_NAME="$AGENT_NAME_ONLY"
 
-# Path to org-patterns.toon - centralized in ~/.claude/.learnings/
-PATTERNS_FILE="$HOME/.claude/.learnings/org-patterns.toon"
+# Path to org-patterns.toon (fall back to legacy location during migration)
+PATTERNS_FILE="$HOME/.closedloop-ai/learnings/org-patterns.toon"
+if [[ ! -f "$PATTERNS_FILE" ]]; then
+    PATTERNS_FILE="$HOME/.claude/.learnings/org-patterns.toon"
+fi
 
 # Only process learnings if we have agent name and patterns file
 if [[ -z "$AGENT_NAME" ]] || [[ ! -f "$PATTERNS_FILE" ]]; then

--- a/plugins/self-learning/README.md
+++ b/plugins/self-learning/README.md
@@ -25,10 +25,10 @@ The plugin also provides goal-oriented evaluation: each run is measured against 
 graph TD
     Run[Run Completes] --> Pending[".learnings/pending/*.json"]
     Pending --> Process["/process-learnings"]
-    Process --> OrgPatterns["~/.claude/.learnings/org-patterns.toon"]
+    Process --> OrgPatterns["~/.closedloop-ai/learnings/org-patterns.toon"]
     Process --> PendingCL["pending-closedloop.json"]
     PendingCL --> Export["/export-closedloop-learnings"]
-    Export --> GlobalCL["~/.claude/.learnings/closedloop-learnings.json"]
+    Export --> GlobalCL["~/.closedloop-ai/learnings/closedloop-learnings.json"]
 
     Outcomes["outcomes.log"] --> Compute["compute_success_rates.py"]
     Compute --> OrgPatterns
@@ -57,7 +57,7 @@ The primary command. Processes pending learnings from a ClosedLoop run into the 
 2. Rescues stray learnings written to the project root instead of the workdir
 3. Classifies each learning by scope (`closedloop` or `organization`) and category (`mistake`, `pattern`, `convention`, `insight`), and assigns `repo_scope` (`*` for generalizable, or a specific repo name)
 4. Validates learnings for factual accuracy, correct scope, clarity, and generalizability — rewording or rejecting problematic entries
-5. Merges approved learnings into `~/.claude/.learnings/org-patterns.toon` with deduplication
+5. Merges approved learnings into `~/.closedloop-ai/learnings/org-patterns.toon` with deduplication
 6. Prunes low-performing patterns (flags patterns with <20% success over 5+ applications, removes patterns with 0% success over 10+ applications)
 7. Extracts ClosedLoop-specific learnings to `pending-closedloop.json`
 8. Reports a summary of processed, rejected, scoped, and pruned patterns
@@ -70,7 +70,7 @@ The primary command. Processes pending learnings from a ClosedLoop run into the 
 
 ### `/export-closedloop-learnings [workdir]`
 
-Merges ClosedLoop-specific pending learnings into the global `~/.claude/.learnings/closedloop-learnings.json` with deduplication. Typically invoked automatically after each loop iteration.
+Merges ClosedLoop-specific pending learnings into the global `~/.closedloop-ai/learnings/closedloop-learnings.json` with deduplication. Typically invoked automatically after each loop iteration.
 
 **Deduplication:**
 - Exact `trigger` match: skip
@@ -342,7 +342,7 @@ $CLOSEDLOOP_WORKDIR/.learnings/
   goal-outcome.json      # Latest goal evaluation result (local only)
   pending-closedloop.json # ClosedLoop-specific learnings pending export
 
-~/.claude/.learnings/
+~/.closedloop-ai/learnings/
   org-patterns.toon      # Global cross-project pattern store
   closedloop-learnings.json  # ClosedLoop framework learnings
 ```

--- a/plugins/self-learning/commands/export-closedloop-learnings.md
+++ b/plugins/self-learning/commands/export-closedloop-learnings.md
@@ -4,7 +4,7 @@ description: Exports pending ClosedLoop learnings to global location with dedupl
 
 # Export ClosedLoop Learnings Command
 
-Merges ClosedLoop-specific learnings from the current project into a global learnings store at `~/.claude/.learnings/closedloop-learnings.json` with automatic deduplication.
+Merges ClosedLoop-specific learnings from the current project into a global learnings store at `~/.closedloop-ai/learnings/closedloop-learnings.json` with automatic deduplication.
 
 ## Purpose
 
@@ -13,7 +13,7 @@ When learnings are captured that improve ClosedLoop itself (agents, workflows, h
 ## Process
 
 1. **Read pending closedloop learnings**: Load `$CLOSEDLOOP_WORKDIR/.learnings/pending-closedloop.json`
-2. **Read existing global learnings**: Load `~/.claude/.learnings/closedloop-learnings.json` (create if missing)
+2. **Read existing global learnings**: Load `~/.closedloop-ai/learnings/closedloop-learnings.json` (create if missing)
 3. **Deduplicate**: For each pending learning:
    - If exact `trigger` match exists → skip (already exists)
    - If 80%+ word overlap on `summary` → skip (duplicate)
@@ -43,7 +43,7 @@ When learnings are captured that improve ClosedLoop itself (agents, workflows, h
 
 ## Output Format
 
-Global file at `~/.claude/.learnings/closedloop-learnings.json`:
+Global file at `~/.closedloop-ai/learnings/closedloop-learnings.json`:
 ```json
 {
   "schema_version": "1.0",
@@ -88,7 +88,7 @@ When invoked:
 1. Determine the workdir from the first argument or use current directory
 2. Check if `$workdir/.learnings/pending-closedloop.json` exists - if not, output "No pending closedloop learnings" and exit
 3. Read the pending file
-4. Read or create `~/.claude/.learnings/closedloop-learnings.json` with empty learnings array
+4. Read or create `~/.closedloop-ai/learnings/closedloop-learnings.json` with empty learnings array
 5. For each pending learning, apply deduplication logic
 6. If any new learnings were added, write the updated global file with `last_updated` timestamp
 7. Delete `$workdir/.learnings/pending-closedloop.json`

--- a/plugins/self-learning/commands/process-learnings.md
+++ b/plugins/self-learning/commands/process-learnings.md
@@ -9,7 +9,7 @@ skills: self-learning:toon-format
 <context>
 This command processes learnings captured during ClosedLoop runs and merges them into the global organization knowledge base. Learnings accumulate across all runs and projects, enabling continuous improvement of agent behavior.
 
-**Purpose:** Transform raw pending learnings into validated, deduplicated patterns stored in `~/.claude/.learnings/org-patterns.toon`.
+**Purpose:** Transform raw pending learnings into validated, deduplicated patterns stored in `~/.closedloop-ai/learnings/org-patterns.toon`.
 
 **Success criteria:**
 - All pending learnings are classified and processed
@@ -193,7 +193,7 @@ Mark all validation tasks as completed before proceeding.
 
 After classification, merge **all validated** patterns into a JSON file that a deterministic Python script will convert to TOON format:
 
-1. **Load existing** - Read `~/.claude/.learnings/org-patterns.toon` (if exists)
+1. **Load existing** - Read `~/.closedloop-ai/learnings/org-patterns.toon` (if exists)
 2. **Read session files** - Scan `sessions/run-*/iter-*.json` from the run
 3. **Filter** - Only include learnings with `validation.status != "rejected"`
 4. **Deduplicate** - See [Deduplication Rules](#deduplication-rules)
@@ -255,7 +255,7 @@ Pruning (existing patterns):
 
 Current org-patterns.toon: N patterns (cap: 50)
 
-Updated: ~/.claude/.learnings/org-patterns.toon
+Updated: ~/.closedloop-ai/learnings/org-patterns.toon
 ```
 
 ## Examples
@@ -281,7 +281,7 @@ Updated: ~/.claude/.learnings/org-patterns.toon
 - `pending-closedloop.json` - ClosedLoop-specific learnings for export
 
 **Global:**
-- `~/.claude/.learnings/org-patterns.toon` - Merged organization knowledge base (accumulates across all runs)
+- `~/.closedloop-ai/learnings/org-patterns.toon` - Merged organization knowledge base (accumulates across all runs)
 </output_files>
 
 ### TOON Output Format

--- a/plugins/self-learning/skills/learning-quality/SKILL.md
+++ b/plugins/self-learning/skills/learning-quality/SKILL.md
@@ -138,7 +138,7 @@ Templates should have type matching templateForType, not type: TEMPLATE
 Before writing:
 1. Check `$CLOSEDLOOP_WORKDIR/.learnings/pending/` for learnings in this run
 2. Check project CLAUDE.md "Learned Patterns" section
-3. Check `~/.claude/.learnings/org-patterns.toon`
+3. Check `~/.closedloop-ai/learnings/org-patterns.toon`
 
 **If contradiction exists** (existing says "do X", new says "don't do X"):
 - Verify which is correct based on evidence

--- a/plugins/self-learning/tools/python/compute_success_rates.py
+++ b/plugins/self-learning/tools/python/compute_success_rates.py
@@ -351,7 +351,7 @@ def main() -> int:
     parser.add_argument(
         "--toon-file",
         default=None,
-        help="Path to org-patterns.toon (default: ~/.claude/.learnings/org-patterns.toon)",
+        help="Path to org-patterns.toon (default: ~/.closedloop-ai/learnings/org-patterns.toon)",
     )
     parser.add_argument(
         "--dry-run",
@@ -363,7 +363,12 @@ def main() -> int:
 
     workdir = Path(args.workdir).resolve()
     outcomes_path = workdir / ".learnings" / "outcomes.log"
-    toon_path = Path(args.toon_file) if args.toon_file else Path.home() / ".claude" / ".learnings" / "org-patterns.toon"
+    toon_path = Path(args.toon_file) if args.toon_file else Path.home() / ".closedloop-ai" / "learnings" / "org-patterns.toon"
+    # Fall back to legacy location during migration
+    if not args.toon_file and not toon_path.exists():
+        legacy = Path.home() / ".claude" / ".learnings" / "org-patterns.toon"
+        if legacy.exists():
+            toon_path = legacy
 
     # Exit cleanly if files don't exist
     if not toon_path.exists():

--- a/plugins/self-learning/tools/python/test_compute_success_rates.py
+++ b/plugins/self-learning/tools/python/test_compute_success_rates.py
@@ -122,7 +122,7 @@ class TestParseToonPatterns:
         assert patterns[1]["repo"] == "my-repo"
 
     def test_parses_real_toon_format(self, tmp_path: Path) -> None:
-        """Test against the actual format from ~/.claude/.learnings/org-patterns.toon."""
+        """Test against the actual format from ~/.closedloop-ai/learnings/org-patterns.toon."""
         toon = tmp_path / "org-patterns.toon"
         toon.write_text(
             '# Organization Patterns (TOON format)\n'

--- a/plugins/self-learning/tools/python/write_merged_patterns.py
+++ b/plugins/self-learning/tools/python/write_merged_patterns.py
@@ -20,7 +20,8 @@ from compute_success_rates import parse_toon_patterns, serialize_toon
 
 # --- Constants ---
 
-DEFAULT_TOON_PATH = Path.home() / ".claude" / ".learnings" / "org-patterns.toon"
+DEFAULT_TOON_PATH = Path.home() / ".closedloop-ai" / "learnings" / "org-patterns.toon"
+LEGACY_TOON_PATH = Path.home() / ".claude" / ".learnings" / "org-patterns.toon"
 PATTERN_CAP = 50
 
 VALID_CATEGORIES = {"mistake", "pattern", "convention", "insight"}
@@ -117,6 +118,9 @@ def main() -> int:
 
     merge_result_path = Path(args.merge_result)
     toon_path = Path(args.toon_path) if args.toon_path else DEFAULT_TOON_PATH
+    # Fall back to legacy location during migration
+    if not args.toon_path and not toon_path.exists() and LEGACY_TOON_PATH.exists():
+        toon_path = LEGACY_TOON_PATH
 
     # Read merge-result.json
     if not merge_result_path.exists():


### PR DESCRIPTION
Move the org-patterns.toon and closedloop-learnings.json storage from ~/.claude/.learnings/ to ~/.closedloop-ai/learnings/. Hooks and Python tools fall back to the legacy path during migration.