### PR TITLE
AI-371: move github-review to prompts, unify session paths

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,26 @@
+# Git Commit Message Template
+#
+# Format:
+# <Short description (imperative mood, present tense)>
+#
+# <Long description (bullet points explaining what changed)>
+#
+# Testing: <Manual testing performed>
+# Risks: <Risk assessment of changes>
+#
+# Guidelines:
+# - Short description: description max 50 chars total, no period, imperative mood
+# - Long description: bullet points with dashes, wrap at 72 chars
+# - Testing: describe manual verification steps taken
+# - Risks: identify deployment/production risks or "None identified" if adequately mitigated
+#
+# Example:
+# Improve performance logging
+#
+# - Reduced performance logging to single logger.adebug call
+# - Consolidated metrics into single dictionary with elapsed_time
+# - Created perf_monitor.py to simplify performance monitoring
+#
+# Testing: Ran locally to verify no crashes and logs appear with debug enabled
+#
+# Risks: None identified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code-review v1.1.0
+
+#### Breaking
+- Removed `github-review` slash command — `/code-review:github-review` is no longer a valid entry point. Use `/code-review:review --github` instead.
+- Moved `github-review.md` from `commands/` to `prompts/` — callers using `${CLAUDE_PLUGIN_ROOT}/commands/github-review.md` must update to `${CLAUDE_PLUGIN_ROOT}/prompts/github-review.md`
+
+#### Changed
+- Unified session directory path for all modes — removed `$RUNNER_TEMP` override in GitHub CI, now uses `.closedloop-ai/code-review/cr-<RANDOM>` everywhere
+- Replaced Bash heredoc/cat usage with Write and Read tools for PR metadata file operations in `github-review.md`
+- Updated temp file path references from `$RUNNER_TEMP/cr-review/` to `<CR_DIR>/*` in GitHub mode constraints
+- Fixed usage examples from `/code-review` to `/review` to match the command filename
+- Fixed internal references from `code-review-github.md` to `github-review.md`
+
+#### Added
+- Compound Bash command prohibition in GitHub mode — no `&&`, `||`, `;`, or `|` pipes allowed
+
 ### code v1.0.5
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### code-review v1.1.0
 
 #### Breaking
-- Removed `github-review` slash command — `/code-review:github-review` is no longer a valid entry point. Use `/code-review:review --github` instead.
+- Removed `github-review` slash command — `/code-review:github-review` is no longer a valid entry point. Use `/code-review:start --github` instead.
+- Renamed `review.md` → `start.md` — slash command is now `/code-review:start`
 - Moved `github-review.md` from `commands/` to `prompts/` — callers using `${CLAUDE_PLUGIN_ROOT}/commands/github-review.md` must update to `${CLAUDE_PLUGIN_ROOT}/prompts/github-review.md`
 
 #### Changed
 - Unified session directory path for all modes — removed `$RUNNER_TEMP` override in GitHub CI, now uses `.closedloop-ai/code-review/cr-<RANDOM>` everywhere
 - Replaced Bash heredoc/cat usage with Write and Read tools for PR metadata file operations in `github-review.md`
 - Updated temp file path references from `$RUNNER_TEMP/cr-review/` to `<CR_DIR>/*` in GitHub mode constraints
-- Fixed usage examples from `/code-review` to `/review` to match the command filename
+- Fixed usage examples to use `/start` to match the command filename
 - Fixed internal references from `code-review-github.md` to `github-review.md`
 
 #### Added

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -19,6 +19,7 @@ plugins/code-review/
   .claude-plugin/plugin.json         Plugin manifest
   commands/
     review.md                        Main /code-review command (orchestrator)
+  prompts/
     github-review.md                 GitHub-mode constraints and output steps (loaded conditionally)
   tools/
     prompts/shared_prompt.txt        Shared reviewer constraints injected into every agent prompt

--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -18,7 +18,7 @@ A multi-agent code review plugin for Claude Code that performs deep, partitioned
 plugins/code-review/
   .claude-plugin/plugin.json         Plugin manifest
   commands/
-    review.md                        Main /code-review command (orchestrator)
+    start.md                         Main /start command (orchestrator)
   prompts/
     github-review.md                 GitHub-mode constraints and output steps (loaded conditionally)
   tools/
@@ -32,21 +32,21 @@ plugins/code-review/
 
 | Component | Role |
 |---|---|
-| `review.md` | Orchestrator command. Parses flags, sets up the session, invokes the helper CLI subcommands in sequence, spawns reviewer sub-agents, collects results, and presents findings |
+| `start.md` | Orchestrator command. Parses flags, sets up the session, invokes the helper CLI subcommands in sequence, spawns reviewer sub-agents, collects results, and presents findings |
 | `github-review.md` | Loaded by the orchestrator only in GitHub mode. Contains PR metadata resolution, file-based handoff format for CI, and summary format |
 | `code_review_helpers.py` | Python CLI that handles all deterministic work: git diff parsing, hygiene pattern matching, file partitioning, risk scoring/model routing, finding validation, cache management, and GitHub comment posting |
 | `shared_prompt.txt` | Constraints injected into every reviewer agent prompt: file assignment rules, evidence standards, severity definitions, and output format |
 
 ## Commands
 
-### `/code-review`
+### `/start`
 
 Runs a comprehensive code review. Invokes the full pipeline: diff parsing, hygiene checks, agent spawning, finding validation, and result presentation.
 
 **Syntax:**
 
 ```
-/code-review [scope] [--github] [--hygiene-only] [--base <ref>] [--since-last-review] [--full-review]
+/start [scope] [--github] [--hygiene-only] [--base <ref>] [--since-last-review] [--full-review]
 ```
 
 **Scope arguments:**
@@ -72,16 +72,16 @@ Runs a comprehensive code review. Invokes the full pipeline: diff parsing, hygie
 **Examples:**
 
 ```bash
-/code-review                         # All changes on current branch vs main
-/code-review staged                  # Only staged changes
-/code-review src/auth.ts src/user.ts # Specific files
-/code-review 123                     # PR #123 diff locally
-/code-review --github                # CI: auto-detect PR, post comments
-/code-review --github 123            # CI: PR #123, post comments
-/code-review --hygiene-only          # Hygiene checks only
-/code-review --base develop          # Diff against develop instead of main
-/code-review --since-last-review     # Only new commits since last review
-/code-review --full-review           # Disable incremental narrowing
+/start                               # All changes on current branch vs main
+/start staged                        # Only staged changes
+/start src/auth.ts src/user.ts       # Specific files
+/start 123                           # PR #123 diff locally
+/start --github                      # CI: auto-detect PR, post comments
+/start --github 123                  # CI: PR #123, post comments
+/start --hygiene-only                # Hygiene checks only
+/start --base develop                # Diff against develop instead of main
+/start --since-last-review           # Only new commits since last review
+/start --full-review                 # Disable incremental narrowing
 ```
 
 **Flag incompatibilities:**

--- a/plugins/code-review/commands/review.md
+++ b/plugins/code-review/commands/review.md
@@ -13,23 +13,23 @@ Run a multi-agent code review with partitioned deep review, deterministic hygien
 ## Usage
 
 ```
-/code-review                         # Review all changes on current branch vs main (default)
-/code-review staged                  # Review only staged changes
-/code-review file1 file2             # Review specific files
-/code-review 123                     # Review PR #123 diff locally (no posting)
-/code-review --github                # GitHub CI: auto-detect PR from branch, post inline comments
-/code-review --github 123            # GitHub CI: review PR #123, post inline comments
-/code-review --hygiene-only          # Fast hygiene-only check (zero LLM tokens)
-/code-review --base develop          # Diff against a specific base branch
-/code-review --since-last-review     # Review only changes since last successful review
-/code-review --full-review           # Force full diff (disable auto-incremental)
+/review                              # Review all changes on current branch vs main (default)
+/review staged                       # Review only staged changes
+/review file1 file2                  # Review specific files
+/review 123                          # Review PR #123 diff locally (no posting)
+/review --github                     # GitHub CI: auto-detect PR from branch, post inline comments
+/review --github 123                 # GitHub CI: review PR #123, post inline comments
+/review --hygiene-only               # Fast hygiene-only check (zero LLM tokens)
+/review --base develop               # Diff against a specific base branch
+/review --since-last-review          # Review only changes since last successful review
+/review --full-review                # Force full diff (disable auto-incremental)
 ```
 
 ## GitHub Mode Constraints
 
 **If MODE=github**, read the GitHub-specific instructions:
 ```
-Read ${CLAUDE_PLUGIN_ROOT}/commands/code-review-github.md
+Read ${CLAUDE_PLUGIN_ROOT}/prompts/github-review.md
 ```
 This file contains posting constraints, PR metadata resolution (Step 5b), and output steps (Steps 6+8).
 Local mode does not need this file.
@@ -53,7 +53,7 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 
 ### Task 2: Create TodoWrite + session setup
 - Create the TodoWrite task list (depends on MODE and HYGIENE_ONLY)
-- If MODE=github: Read `${CLAUDE_PLUGIN_ROOT}/commands/code-review-github.md` for GitHub-specific constraints and steps
+- If MODE=github: Read `${CLAUDE_PLUGIN_ROOT}/prompts/github-review.md` for GitHub-specific constraints and steps
 - Resolve HELPERS path: `echo "${CLAUDE_PLUGIN_ROOT}/tools/python/code_review_helpers.py"` — track the resolved path internally
 - Create CR_DIR: `mkdir -p .closedloop-ai/code-review/cr-<RANDOM>` — generate a unique suffix, track the resolved path internally
 - Run setup: `python <HELPERS> setup --mode <MODE> > <CR_DIR>/setup.json` — inline all resolved paths, NO shell variables
@@ -76,7 +76,7 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 - See: [Auto Incremental Mode](#auto-incremental-mode-phase-4--local-only)
 
 ### Task 5: Get diff data (GitHub: also get PR metadata)
-- GitHub mode: follow PR Metadata section from `code-review-github.md`
+- GitHub mode: follow PR Metadata section from `github-review.md`
 - Run Bash: `python <HELPERS> parse-diff --scope=<DIFF_SCOPE> > <CR_DIR>/diff_data.json`
 - Mark todo "Parse scope and get diff data" as `completed`
 - See: [Get Diff Data](#get-diff-data-both-modes), [GitHub Mode: Get PR Metadata](#github-mode-get-pr-metadata)
@@ -119,7 +119,7 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 - See: [Step 5](#step-5-collect-normalize-and-validate-findings), [Step 5.5](#step-55-bha-cache-update-when-caching-is-active)
 
 ### Task 11: Present results
-- **GitHub mode**: follow Steps 6 and 8 in `code-review-github.md` — write findings JSON, threads JSON, and summary.md to `.claude/`
+- **GitHub mode**: follow Steps 6 and 8 in `github-review.md` — write findings JSON, threads JSON, and summary.md to `.claude/`
 - **Local mode**: present findings by severity in terminal — see [Local Mode: Present Results](#local-mode-present-results)
 - Mark remaining todos as `completed`
 
@@ -233,9 +233,7 @@ Read the output. This is the resolved HELPERS path (e.g., `/Users/me/.claude/plu
 ```bash
 mkdir -p .closedloop-ai/code-review/cr-38291
 ```
-Track the CR_DIR value internally (e.g., `.closedloop-ai/code-review/cr-38291`). **All subsequent commands must inline this resolved path, NOT `$CR_DIR`**. Generate a unique suffix yourself (e.g., a 5-digit random number) — do NOT use `$$` (it changes per shell invocation).
-
-**GitHub mode override:** Use `RUNNER_TEMP` when available: `${RUNNER_TEMP}/cr-review`.
+Track the CR_DIR value internally (e.g., `.closedloop-ai/code-review/cr-38291`). **All subsequent commands must inline this resolved path, NOT `$CR_DIR`**. Generate a unique suffix yourself (e.g., a 5-digit random number) — do NOT use `$$` (it changes per shell invocation). Use this same `.closedloop-ai/code-review/cr-<RANDOM>` path in **all modes** including GitHub CI — do NOT use `$RUNNER_TEMP` or any shell variables.
 
 **Step 3 — Run setup subcommand:**
 ```bash
@@ -349,7 +347,7 @@ Print `<REVIEW_MODE_LINE>` (always, at the start of every run). Use the EXACT st
 
 **Skip this section entirely if MODE=local.**
 
-Follow the "PR Metadata Resolution" section in `code-review-github.md` (already loaded in Task 2 for GitHub mode). It sets: `PR_NUMBER`, `HEAD_SHA`, `BASE_REF`, `HEAD_REF`, `OWNER`, `REPO_NAME`, `DIFF_SCOPE`, `DIFF_TIP`, and writes `<CR_DIR>/github_pr.json`.
+Follow the "PR Metadata Resolution" section in `github-review.md` (already loaded in Task 2 for GitHub mode). It sets: `PR_NUMBER`, `HEAD_SHA`, `BASE_REF`, `HEAD_REF`, `OWNER`, `REPO_NAME`, `DIFF_SCOPE`, `DIFF_TIP`, and writes `<CR_DIR>/github_pr.json`.
 
 ### Get Diff Data (Both Modes)
 
@@ -961,7 +959,7 @@ This writes the updated manifest to `<CACHE_DIR>/manifest.json`. In GitHub mode,
 
 **If MODE=local, skip to "Local Mode: Present Results" below.**
 
-Follow Steps 6 and 8 in `code-review-github.md` (already loaded in Task 2 for GitHub mode).
+Follow Steps 6 and 8 in `github-review.md` (already loaded in Task 2 for GitHub mode).
 
 ---
 

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -13,16 +13,16 @@ Run a multi-agent code review with partitioned deep review, deterministic hygien
 ## Usage
 
 ```
-/review                              # Review all changes on current branch vs main (default)
-/review staged                       # Review only staged changes
-/review file1 file2                  # Review specific files
-/review 123                          # Review PR #123 diff locally (no posting)
-/review --github                     # GitHub CI: auto-detect PR from branch, post inline comments
-/review --github 123                 # GitHub CI: review PR #123, post inline comments
-/review --hygiene-only               # Fast hygiene-only check (zero LLM tokens)
-/review --base develop               # Diff against a specific base branch
-/review --since-last-review          # Review only changes since last successful review
-/review --full-review                # Force full diff (disable auto-incremental)
+/start                              # Review all changes on current branch vs main (default)
+/start staged                       # Review only staged changes
+/start file1 file2                  # Review specific files
+/start 123                          # Review PR #123 diff locally (no posting)
+/start --github                     # GitHub CI: auto-detect PR from branch, post inline comments
+/start --github 123                 # GitHub CI: review PR #123, post inline comments
+/start --hygiene-only               # Fast hygiene-only check (zero LLM tokens)
+/start --base develop               # Diff against a specific base branch
+/start --since-last-review          # Review only changes since last successful review
+/start --full-review                # Force full diff (disable auto-incremental)
 ```
 
 ## GitHub Mode Constraints

--- a/plugins/code-review/prompts/github-review.md
+++ b/plugins/code-review/prompts/github-review.md
@@ -1,7 +1,3 @@
----
-description: "GitHub-specific steps for /code-review — loaded conditionally by the main command"
----
-
 # GitHub Mode: Constraints and Output Steps
 
 ## Allowed Actions (read-only review + file-based handoff)
@@ -12,7 +8,8 @@ These constraints apply ONLY when `MODE=github`. Local mode has no restrictions.
 - ✅ Write validated findings to `.claude/code-review-findings.json` (workflow posts inline comments)
 - ✅ Write outdated thread IDs to `.claude/code-review-threads.json` (workflow resolves threads)
 - ✅ Write review summary to `.claude/code-review-summary.md` (workflow handles posting)
-- ✅ Write temp files to `$RUNNER_TEMP/cr-review/`
+- ✅ Write temp files to `<CR_DIR>/*` (session directory created during setup)
+- ❌ Do NOT use compound Bash commands — no `&&`, `||`, `;`, or `|` pipes. Each Bash call must be a single simple command. CI permissions deny compound commands by design.
 - ❌ Do NOT checkout, switch branches, or modify any code
 - ❌ Do NOT create, edit, or modify any files in the repository (except `.claude/code-review-summary.md`, `.claude/code-review-findings.json`, `.claude/code-review-threads.json`, and `$CR_DIR/*`)
 - ❌ Do NOT call `resolveReviewThread` mutations directly
@@ -85,16 +82,14 @@ DIFF_TIP="origin/${HEAD_REF}"
 Always use the PR head ref (`origin/<headRefName>`) so detached HEAD checkouts and
 cross-branch reviews diff the correct commits.
 
-Write PR metadata to disk for Steps 6-8:
-```bash
-cat > $CR_DIR/github_pr.json <<EOF
+Write PR metadata to disk for Steps 6-8 using the Write tool (NOT Bash) — write to `<CR_DIR>/github_pr.json`:
+```json
 {
-  "pr_number": $PR_NUMBER,
-  "head_sha": "$HEAD_SHA",
-  "owner": "$OWNER",
-  "repo_name": "$REPO_NAME"
+  "pr_number": <PR_NUMBER>,
+  "head_sha": "<HEAD_SHA>",
+  "owner": "<OWNER>",
+  "repo_name": "<REPO_NAME>"
 }
-EOF
 ```
 
 ---
@@ -103,11 +98,7 @@ EOF
 
 Mark todo "Write findings and thread data to files" as `in_progress`.
 
-Read PR metadata from disk:
-```bash
-cat $CR_DIR/github_pr.json
-```
-
+Read PR metadata from disk using the Read tool on `<CR_DIR>/github_pr.json`.
 Extract `PR_NUMBER`, `HEAD_SHA`, `OWNER`, `REPO_NAME`.
 
 ### 6a: Identify Outdated Threads


### PR DESCRIPTION
- Move `github-review.md` from commands/ to prompts/ so it is no longer exposed as a standalone slash command
- Update review.md references, fix usage examples to use `/review`, unify session directory path across all modes, and bump version to 1.1.0.