### PR TITLE
AI-372: sort pattern cap by staleness instead of confidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### self-learning v1.0.3
+
+#### Fixed
+- Fixed pattern cap trimming to sort by staleness flags only instead of confidence — low-confidence patterns were always dropped before being observed, preventing them from ever earning higher confidence
+- Fixed extraneous f-string prefix lint warning in `write_merged_patterns.py` default header
+
+#### Changed
+- Updated `process-learnings` cap strategy to trim `[PRUNE]` then `[STALE]` then `[REVIEW]`, with `seen_count` as tiebreaker
+
 ### code-review v1.1.0
 
 #### Breaking

--- a/plugins/self-learning/.claude-plugin/plugin.json
+++ b/plugins/self-learning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "self-learning",
   "description": "Self-learning plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/self-learning/commands/process-learnings.md
+++ b/plugins/self-learning/commands/process-learnings.md
@@ -209,10 +209,10 @@ After classification, merge **all validated** patterns into a JSON file that a d
    - `*` → pattern is generalizable across repos
    - repo-specific → use the classified repo name
 8. **Extract closedloop learnings** → append to `pending-closedloop.json`
-9. **Limit patterns** - Cap at 50 to prevent context bloat. When at cap, prefer keeping:
-   - High confidence patterns over low confidence
-   - Patterns with success_rate > 0.5 over lower
-   - Patterns with `[UNTESTED]` flag (give them a chance) over `[PRUNE]`
+9. **Limit patterns** - Cap at 50 to prevent context bloat. When at cap, trim by staleness only:
+   - Drop `[PRUNE]` flagged patterns first, then `[STALE]`, then `[REVIEW]`
+   - Never trim by confidence — low-confidence patterns need exposure to earn higher confidence
+   - Among patterns with the same flag tier, prefer keeping higher `seen_count` (more observed)
 10. **Write output** - Save to `$CLOSEDLOOP_WORKDIR/.learnings/merge-result.json` with the following schema:
 
 ```json

--- a/plugins/self-learning/tools/python/write_merged_patterns.py
+++ b/plugins/self-learning/tools/python/write_merged_patterns.py
@@ -38,12 +38,12 @@ DEFAULT_HEADER = [
     "# Organization Patterns (TOON format)",
     f"# Last updated: {__import__('datetime').datetime.now(__import__('datetime').timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}",
     "",
-    f"patterns[0]{{id,category,summary,confidence,seen_count,success_rate,flags,applies_to,context,repo}}:",
+    "patterns[0]{id,category,summary,confidence,seen_count,success_rate,flags,applies_to,context,repo}:",
 ]
 
-# Priority sort: confidence then flags
-CONFIDENCE_ORDER = {"high": 0, "medium": 1, "low": 2}
-FLAGS_ORDER = {"[UNTESTED]": 0, "": 1, "[REVIEW]": 2, "[STALE]": 3, "[PRUNE]": 4}
+# Priority sort: trim by staleness/prune flags only — confidence is earned through
+# exposure, so we never deprioritize low-confidence patterns (they'd never get seen).
+FLAGS_ORDER = {"": 0, "[UNTESTED]": 0, "[REVIEW]": 1, "[STALE]": 2, "[PRUNE]": 3}
 
 
 def validate_pattern(pattern: dict, index: int) -> list[str]:
@@ -88,10 +88,17 @@ def validate_pattern(pattern: dict, index: int) -> list[str]:
 
 
 def priority_sort_key(pattern: dict) -> tuple:
-    """Sort key: high confidence first, then UNTESTED > empty > REVIEW > STALE > PRUNE."""
-    conf = CONFIDENCE_ORDER.get(pattern.get("confidence", "low"), 2)
-    flag = FLAGS_ORDER.get(pattern.get("flags", ""), 1)
-    return (conf, flag)
+    """Sort key: trim by staleness only. PRUNE/STALE sort last, everything else equal.
+
+    Within the same flag tier, sort by seen_count descending so more-observed
+    patterns are kept when trimming at the cap boundary.
+    """
+    flag = FLAGS_ORDER.get(pattern.get("flags", ""), 0)
+    try:
+        seen = -int(pattern.get("seen_count", "0"))
+    except (ValueError, TypeError):
+        seen = 0
+    return (flag, seen)
 
 
 def main() -> int:


### PR DESCRIPTION
Low-confidence patterns were always trimmed first, preventing them from ever being injected into agent context to earn higher confidence. Now trims by staleness flags only (PRUNE > STALE > REVIEW) with seen_count as tiebreaker. Also fixes extraneous f-string prefix lint warning.