### PR TITLE
AI-375: migrate session data directory from .claude/.closedloop/ to .closedloop-ai/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 .env
 .env.local
 .env.*.local
+.ruff_cache/
 
 # Tests
 **/route-knowledge.json
@@ -16,7 +17,6 @@ __pycache__/
 .claude/.token-stats/
 
 # ClosedLoop session-level artifacts (cleaned up by SessionEnd hook)
-.claude/.closedloop/
 .claude/closedloop-loop.local.md
 .closedloop/
 .agent-types/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code v1.1.0
+
+#### Changed
+- Migrated session/hook data directory from `.claude/.closedloop/` to `.closedloop-ai/` across all hooks (`session-start`, `session-end`, `subagent-start`, `subagent-stop`, `pretooluse`, `loop-stop`) and `setup-closedloop.sh`, with legacy fallback for mid-upgrade sessions
+- Added legacy directory cleanup in `session-end-hook.sh` — removes stale PID mappings, expired session files, and deletes empty legacy directory on session end
+
 ### self-learning v1.0.3
 
 #### Fixed

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -90,7 +90,7 @@ A lifecycle script registered in `hooks.json` that fires on a Claude Code event.
 Hooks that fire when a Claude Code session opens or closes. `SessionStart` creates PID-to-session-ID mappings. `SessionEnd` cleans up stale mappings and orphaned state files.
 
 **SubagentStart**
-Hook that fires when a subagent begins. Performs three key functions: (1) writes base environment variables to `.claude/.closedloop/env`, (2) injects `<closedloop-environment>` block with paths and config, and (3) filters and injects relevant patterns from `org-patterns.toon` as `<organization-learnings>`.
+Hook that fires when a subagent begins. Performs three key functions: (1) writes base environment variables to `.closedloop-ai/env`, (2) injects `<closedloop-environment>` block with paths and config, and (3) filters and injects relevant patterns from `org-patterns.toon` as `<organization-learnings>`.
 
 **SubagentStop**
 Hook that fires when a subagent completes. Handles learning acknowledgment enforcement, outcome logging to `outcomes.log`, build result tracking, performance telemetry to `perf.jsonl`, and cleanup.

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/README.md
+++ b/plugins/code/README.md
@@ -213,7 +213,7 @@ Syncs `plan.md` with `plan.json` after any edit. Runs the `extract.py` script wh
 
 ### `closedloop-env`
 
-Provides ClosedLoop environment paths to agents by reading `.claude/.closedloop/env`. Returns `CLOSEDLOOP_WORKDIR`, `CLAUDE_PLUGIN_ROOT`, `CLOSEDLOOP_PRD_FILE`, and `CLOSEDLOOP_MAX_ITERATIONS`. Used by agents that need to construct file paths dynamically.
+Provides ClosedLoop environment paths to agents by reading `.closedloop-ai/env`. Returns `CLOSEDLOOP_WORKDIR`, `CLAUDE_PLUGIN_ROOT`, `CLOSEDLOOP_PRD_FILE`, and `CLOSEDLOOP_MAX_ITERATIONS`. Used by agents that need to construct file paths dynamically.
 
 ### `prd-creator`
 
@@ -235,7 +235,7 @@ Hooks are shell scripts that fire at Claude Code lifecycle events. Registered in
 
 ### `session-start-hook.sh` (SessionStart)
 
-Creates a PID-to-session-ID mapping file at `.claude/.closedloop/pid-{PPID}.session`. This mapping allows `setup-closedloop.sh` — which runs as a child process — to discover the session ID by walking up the process tree. Essential for associating a work directory with a session.
+Creates a PID-to-session-ID mapping file at `.closedloop-ai/pid-{PPID}.session`. This mapping allows `setup-closedloop.sh` — which runs as a child process — to discover the session ID by walking up the process tree. Essential for associating a work directory with a session.
 
 ### `session-end-hook.sh` (SessionEnd)
 

--- a/plugins/code/hooks/loop-stop-hook.sh
+++ b/plugins/code/hooks/loop-stop-hook.sh
@@ -39,7 +39,11 @@ SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // empty')
 # Discover WORKDIR via session_id mapping (created by setup-closedloop.sh)
 CLOSEDLOOP_WORKDIR=""
 if [[ -n "$SESSION_ID" ]]; then
-  WORKDIR_FILE="$CWD/.claude/.closedloop/session-$SESSION_ID.workdir"
+  WORKDIR_FILE="$CWD/.closedloop-ai/session-$SESSION_ID.workdir"
+  # Fallback: check legacy path for mid-upgrade sessions
+  if [[ ! -f "$WORKDIR_FILE" ]] && [[ -f "$CWD/.claude/.closedloop/session-$SESSION_ID.workdir" ]]; then
+      WORKDIR_FILE="$CWD/.claude/.closedloop/session-$SESSION_ID.workdir"
+  fi
   if [[ -f "$WORKDIR_FILE" ]]; then
     CLOSEDLOOP_WORKDIR=$(cat "$WORKDIR_FILE")
   fi

--- a/plugins/code/hooks/pretooluse-hook.sh
+++ b/plugins/code/hooks/pretooluse-hook.sh
@@ -114,7 +114,11 @@ esac
 # Discover WORKDIR via session_id mapping (same pattern as subagent-start-hook.sh)
 CLOSEDLOOP_WORKDIR=""
 if [[ -n "$SESSION_ID" ]]; then
-    WORKDIR_FILE="$CWD/.claude/.closedloop/session-$SESSION_ID.workdir"
+    WORKDIR_FILE="$CWD/.closedloop-ai/session-$SESSION_ID.workdir"
+    # Fallback: check legacy path for mid-upgrade sessions
+    if [[ ! -f "$WORKDIR_FILE" ]] && [[ -f "$CWD/.claude/.closedloop/session-$SESSION_ID.workdir" ]]; then
+        WORKDIR_FILE="$CWD/.claude/.closedloop/session-$SESSION_ID.workdir"
+    fi
     if [[ -f "$WORKDIR_FILE" ]]; then
         CLOSEDLOOP_WORKDIR=$(cat "$WORKDIR_FILE")
     fi

--- a/plugins/code/hooks/session-end-hook.sh
+++ b/plugins/code/hooks/session-end-hook.sh
@@ -16,22 +16,57 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 REASON=$(echo "$INPUT" | jq -r '.reason // empty')
 
 # Redirect debug logs into project dir (not shared /tmp)
-if [[ -n "$CWD" ]] && [[ -d "$CWD/.claude/.closedloop" ]]; then
-    DEBUG_LOG="$CWD/.claude/.closedloop/session-end-hook-debug.log"
+if [[ -n "$CWD" ]]; then
+    mkdir -p "$CWD/.closedloop-ai"
+    DEBUG_LOG="$CWD/.closedloop-ai/session-end-hook-debug.log"
 fi
 echo "$(date): Session end hook started, session=$SESSION_ID, reason=$REASON" >> "$DEBUG_LOG"
 
 # ============================================================================
 # CLEANUP: Session Mappings
-# Remove session-specific files from .claude/.closedloop/
+# Remove session-specific files from .closedloop-ai/
 # ============================================================================
 
-CLOSEDLOOP_DIR="$CWD/.claude/.closedloop"
+CLOSEDLOOP_DIR="$CWD/.closedloop-ai"
+LEGACY_DIR="$CWD/.claude/.closedloop"
 
 # Discover CLOSEDLOOP_WORKDIR before cleaning up mappings
 CLOSEDLOOP_WORKDIR=""
-if [[ -n "$SESSION_ID" ]] && [[ -f "$CLOSEDLOOP_DIR/session-$SESSION_ID.workdir" ]]; then
-    CLOSEDLOOP_WORKDIR=$(cat "$CLOSEDLOOP_DIR/session-$SESSION_ID.workdir")
+if [[ -n "$SESSION_ID" ]]; then
+    if [[ -f "$CLOSEDLOOP_DIR/session-$SESSION_ID.workdir" ]]; then
+        CLOSEDLOOP_WORKDIR=$(cat "$CLOSEDLOOP_DIR/session-$SESSION_ID.workdir")
+    elif [[ -f "$LEGACY_DIR/session-$SESSION_ID.workdir" ]]; then
+        CLOSEDLOOP_WORKDIR=$(cat "$LEGACY_DIR/session-$SESSION_ID.workdir")
+    fi
+fi
+
+# Clean up legacy directory if it exists (only this session's files + stale PIDs)
+if [[ -d "$LEGACY_DIR" ]]; then
+    echo "$(date): Cleaning up legacy directory: $LEGACY_DIR" >> "$DEBUG_LOG"
+
+    # Remove only this session's workdir mapping
+    rm -f "$LEGACY_DIR/session-$SESSION_ID.workdir" 2>/dev/null || true
+
+    # Remove stale PID mappings (processes that no longer exist)
+    for pid_file in "$LEGACY_DIR"/pid-*.session; do
+        if [[ -f "$pid_file" ]]; then
+            PID=$(basename "$pid_file" | sed 's/pid-\(.*\)\.session/\1/')
+            if ! ps -p "$PID" &>/dev/null; then
+                rm -f "$pid_file"
+            fi
+        fi
+    done
+
+    # Remove stale session workdir mappings (older than 24 hours)
+    find "$LEGACY_DIR" -name "session-*.workdir" -mmin +1440 -delete 2>/dev/null || true
+
+    # Remove ephemeral files only if no active sessions remain
+    if ! ls "$LEGACY_DIR"/pid-*.session &>/dev/null && ! ls "$LEGACY_DIR"/session-*.workdir &>/dev/null; then
+        rm -f "$LEGACY_DIR"/learnings-* "$LEGACY_DIR"/env 2>/dev/null || true
+    fi
+
+    # Remove directory if empty
+    rmdir "$LEGACY_DIR" 2>/dev/null || true
 fi
 
 if [[ -d "$CLOSEDLOOP_DIR" ]]; then

--- a/plugins/code/hooks/session-start-hook.sh
+++ b/plugins/code/hooks/session-start-hook.sh
@@ -19,16 +19,16 @@ if [[ -z "$SESSION_ID" ]] || [[ -z "$CWD" ]]; then
     exit 0
 fi
 
-# Create .claude/.closedloop directory at project root
-mkdir -p "$CWD/.claude/.closedloop"
+# Create .closedloop-ai directory at project root
+mkdir -p "$CWD/.closedloop-ai"
 
 # Redirect debug logs into project dir (not shared /tmp)
-DEBUG_LOG="$CWD/.claude/.closedloop/session-start-hook-debug.log"
+DEBUG_LOG="$CWD/.closedloop-ai/session-start-hook-debug.log"
 echo "$(date): SessionStart hook started, PPID=$PPID" >> "$DEBUG_LOG"
 
 # Write PID -> session_id mapping using Claude Code's PID (our PPID)
 # ! commands will walk up their process tree to find this
-echo "$SESSION_ID" > "$CWD/.claude/.closedloop/pid-$PPID.session"
+echo "$SESSION_ID" > "$CWD/.closedloop-ai/pid-$PPID.session"
 echo "$(date): Wrote session mapping: pid-$PPID.session -> $SESSION_ID" >> "$DEBUG_LOG"
 
 exit 0

--- a/plugins/code/hooks/subagent-start-hook.sh
+++ b/plugins/code/hooks/subagent-start-hook.sh
@@ -17,14 +17,18 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 
 # Early debug log (before WORKDIR discovery) to catch all SubagentStart events
-EARLY_DEBUG_LOG="${CWD:-.}/.claude/.closedloop/subagent-start-hook-debug.log"
+EARLY_DEBUG_LOG="${CWD:-.}/.closedloop-ai/subagent-start-hook-debug.log"
 mkdir -p "$(dirname "$EARLY_DEBUG_LOG")" 2>/dev/null
 echo "$(date): SubagentStart hook fired — agent_type=$AGENT_TYPE agent_id=$AGENT_ID session_id=$SESSION_ID" >> "$EARLY_DEBUG_LOG"
 
 # Discover WORKDIR via session_id mapping (created by setup-closedloop.sh)
 CLOSEDLOOP_WORKDIR=""
 if [[ -n "$SESSION_ID" ]]; then
-    WORKDIR_FILE="$CWD/.claude/.closedloop/session-$SESSION_ID.workdir"
+    WORKDIR_FILE="$CWD/.closedloop-ai/session-$SESSION_ID.workdir"
+    # Fallback: check legacy path for mid-upgrade sessions
+    if [[ ! -f "$WORKDIR_FILE" ]] && [[ -f "$CWD/.claude/.closedloop/session-$SESSION_ID.workdir" ]]; then
+        WORKDIR_FILE="$CWD/.claude/.closedloop/session-$SESSION_ID.workdir"
+    fi
     if [[ -f "$WORKDIR_FILE" ]]; then
         CLOSEDLOOP_WORKDIR=$(cat "$WORKDIR_FILE")
         echo "$(date): Found WORKDIR=$CLOSEDLOOP_WORKDIR from session mapping" >> "$DEBUG_LOG"
@@ -124,8 +128,14 @@ if [[ -z "$CLOSEDLOOP_WORKDIR" ]]; then
 fi
 
 # Write base environment (same for all agents, only write once)
-mkdir -p "$CWD/.claude/.closedloop"
-BASE_ENV_FILE="$CWD/.claude/.closedloop/env"
+mkdir -p "$CWD/.closedloop-ai"
+BASE_ENV_FILE="$CWD/.closedloop-ai/env"
+# If legacy env exists but new one doesn't, copy it forward
+LEGACY_ENV_FILE="$CWD/.claude/.closedloop/env"
+if [[ ! -f "$BASE_ENV_FILE" ]] && [[ -f "$LEGACY_ENV_FILE" ]]; then
+    cp "$LEGACY_ENV_FILE" "$BASE_ENV_FILE"
+    echo "$(date): Copied legacy env to $BASE_ENV_FILE" >> "$DEBUG_LOG"
+fi
 if [[ ! -f "$BASE_ENV_FILE" ]]; then
     cat > "$BASE_ENV_FILE" << EOF
 CLOSEDLOOP_WORKDIR=$CLOSEDLOOP_WORKDIR
@@ -394,7 +404,7 @@ if [[ -n "$LEARNINGS" ]]; then
 
 $LEARNINGS"
     # Write learnings to agent-specific file
-    LEARNINGS_FILE="$CWD/.claude/.closedloop/learnings-$AGENT_NAME_LOWER"
+    LEARNINGS_FILE="$CWD/.closedloop-ai/learnings-$AGENT_NAME_LOWER"
     echo "$LEARNINGS" > "$LEARNINGS_FILE"
     echo "$(date): Wrote learnings to $LEARNINGS_FILE" >> "$DEBUG_LOG"
 fi

--- a/plugins/code/hooks/subagent-stop-hook.sh
+++ b/plugins/code/hooks/subagent-stop-hook.sh
@@ -25,7 +25,11 @@ SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 # Discover WORKDIR via session_id mapping (created by setup-closedloop.sh)
 CLOSEDLOOP_WORKDIR=""
 if [[ -n "$SESSION_ID" ]]; then
-    WORKDIR_FILE="$CWD/.claude/.closedloop/session-$SESSION_ID.workdir"
+    WORKDIR_FILE="$CWD/.closedloop-ai/session-$SESSION_ID.workdir"
+    # Fallback: check legacy path for mid-upgrade sessions
+    if [[ ! -f "$WORKDIR_FILE" ]] && [[ -f "$CWD/.claude/.closedloop/session-$SESSION_ID.workdir" ]]; then
+        WORKDIR_FILE="$CWD/.claude/.closedloop/session-$SESSION_ID.workdir"
+    fi
     if [[ -f "$WORKDIR_FILE" ]]; then
         CLOSEDLOOP_WORKDIR=$(cat "$WORKDIR_FILE")
         echo "$(date): Found WORKDIR=$CLOSEDLOOP_WORKDIR from session mapping" >> "$DEBUG_LOG"
@@ -171,14 +175,18 @@ fi
 
 # ============================================================================
 # ALWAYS write injected patterns to outcomes.log (regardless of acknowledgment)
-# The start hook writes injected learnings to .claude/.closedloop/learnings-{agent}
+# The start hook writes injected learnings to .closedloop-ai/learnings-{agent}
 # Read that file and log each injected pattern with its actual outcome status:
 #   - "applied" if agent explicitly cited it (already written above)
 #   - "injected" if patterns were sent but agent didn't cite them
 # This ensures compute_success_rates.py always has data to work with.
 # ============================================================================
 AGENT_NAME_LOWER=$(echo "$AGENT_NAME" | tr '[:upper:]' '[:lower:]')
-LEARNINGS_FILE="$CWD/.claude/.closedloop/learnings-$AGENT_NAME_LOWER"
+LEARNINGS_FILE="$CWD/.closedloop-ai/learnings-$AGENT_NAME_LOWER"
+# Fallback: check legacy path for mid-upgrade sessions
+if [[ ! -f "$LEARNINGS_FILE" ]] && [[ -f "$CWD/.claude/.closedloop/learnings-$AGENT_NAME_LOWER" ]]; then
+    LEARNINGS_FILE="$CWD/.claude/.closedloop/learnings-$AGENT_NAME_LOWER"
+fi
 
 if [[ -f "$LEARNINGS_FILE" ]]; then
     echo "$(date): Reading injected patterns from $LEARNINGS_FILE" >> "$DEBUG_LOG"

--- a/plugins/code/scripts/setup-closedloop.sh
+++ b/plugins/code/scripts/setup-closedloop.sh
@@ -77,12 +77,16 @@ if [[ -z "$PRD_FILE" ]]; then
 fi
 
 # Step 1: Find session_id by walking up process tree
-# SessionStart hook wrote to .claude/.closedloop/pid-<Claude Code PID>.session
+# SessionStart hook wrote to .closedloop-ai/pid-<Claude Code PID>.session
 # Claude Code's PID is an ancestor of this process
 SESSION_ID=""
 CURRENT_PID=$$
 while [[ $CURRENT_PID -gt 1 ]]; do
-    SESSION_FILE=".claude/.closedloop/pid-$CURRENT_PID.session"
+    SESSION_FILE=".closedloop-ai/pid-$CURRENT_PID.session"
+    # Fallback: check legacy path for mid-upgrade sessions
+    if [[ ! -f "$SESSION_FILE" ]] && [[ -f ".claude/.closedloop/pid-$CURRENT_PID.session" ]]; then
+        SESSION_FILE=".claude/.closedloop/pid-$CURRENT_PID.session"
+    fi
     echo "$(date): Checking $SESSION_FILE" >> "$DEBUG_LOG"
     if [[ -f "$SESSION_FILE" ]]; then
         SESSION_ID=$(cat "$SESSION_FILE")
@@ -98,8 +102,8 @@ done
 
 if [[ -n "$SESSION_ID" ]]; then
     # Step 2: Write workdir mapping so hooks can find it via session_id
-    echo "$WORKDIR" > ".claude/.closedloop/session-$SESSION_ID.workdir"
-    echo "$(date): Wrote workdir mapping: .claude/.closedloop/session-$SESSION_ID.workdir -> $WORKDIR" >> "$DEBUG_LOG"
+    echo "$WORKDIR" > ".closedloop-ai/session-$SESSION_ID.workdir"
+    echo "$(date): Wrote workdir mapping: .closedloop-ai/session-$SESSION_ID.workdir -> $WORKDIR" >> "$DEBUG_LOG"
 else
     echo "$(date): WARNING: Could not find session_id in process tree" >> "$DEBUG_LOG"
 fi

--- a/plugins/code/skills/closedloop-env/SKILL.md
+++ b/plugins/code/skills/closedloop-env/SKILL.md
@@ -11,7 +11,7 @@ This skill provides access to ClosedLoop environment variables needed for file o
 
 Read the base environment file:
 
-    .claude/.closedloop/env
+    .closedloop-ai/env
 
 The file contains KEY=VALUE pairs:
 - `CLOSEDLOOP_WORKDIR` - The run directory for this session
@@ -29,7 +29,7 @@ After reading the env file, construct paths like:
 
 Also read your agent-specific learnings file if it exists:
 
-    .claude/.closedloop/learnings-{your-agent-name}
+    .closedloop-ai/learnings-{your-agent-name}
 
 Where `{your-agent-name}` is your `name:` from your frontmatter in lowercase (e.g., `plan-validator`).
 


### PR DESCRIPTION
Move all hook and script file operations to .closedloop-ai/ at the project root, decoupling ClosedLoop runtime state from the .claude/ directory.

- Update all 6 hooks and setup-closedloop.sh to use .closedloop-ai/
- Add legacy fallback for mid-upgrade sessions
- Add legacy directory cleanup in session-end-hook.sh