### PR TITLE
feat(code): add autonomous plugin system with gate-based execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code v1.2.0
+
+#### Added
+- Autonomous plugin system with gate-based execution (`scripts/plugin-dispatcher.py`)
+- TOML frontmatter parser for `plugin.md` definitions with `+++` delimiters
+- Gate evaluator supporting cooldown, cron, condition, event, and manual gate types
+- Plugin scanner with dual-path discovery (bundled + custom) and name-based deduplication
+- JSONL append-only run history at `.plugins/run-history.jsonl` with corruption recovery
+- Dispatch queue writer at `.plugins/dispatch-queue.json`
+- SessionStart hook integration to call dispatcher on session start
+- SubagentStop hook integration to record plugin run results in run history
+- Phase 0.8 (Plugin Dispatch) in orchestrator prompt for non-blocking background task dispatch
+- `session-cleanup` plugin: cleans stale PID mappings, orphaned agent-type files on 30m cooldown
+- `ci-monitor` plugin: polls GitHub for failed CI checks on open PRs on 5m cooldown
+- `plugin-dispatch` skill for manual plugin invocation via `/code:plugin-dispatch`
+- Comprehensive test suite for plugin-dispatcher.py (28 tests)
+
 ### code v1.1.2
 
 #### Fixed

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/hooks/session-start-hook.sh
+++ b/plugins/code/hooks/session-start-hook.sh
@@ -31,4 +31,19 @@ echo "$(date): SessionStart hook started, PPID=$PPID" >> "$DEBUG_LOG"
 echo "$SESSION_ID" > "$CWD/.closedloop-ai/pid-$PPID.session"
 echo "$(date): Wrote session mapping: pid-$PPID.session -> $SESSION_ID" >> "$DEBUG_LOG"
 
+# --- Plugin Dispatch ---
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DISPATCHER="$PLUGIN_ROOT/scripts/plugin-dispatcher.py"
+if [[ -f "$DISPATCHER" ]]; then
+    # Create plugin state directory
+    mkdir -p "$CWD/.plugins"
+    # Run dispatcher for session-start event + cooldown/cron/condition gates
+    python3 "$DISPATCHER" \
+        --trigger session-start \
+        --workdir "$CWD" \
+        --plugin-root "$PLUGIN_ROOT" \
+        2>>"$CWD/.closedloop-ai/plugin-dispatcher-debug.log" || true
+    echo "$(date): Plugin dispatcher completed" >> "$DEBUG_LOG"
+fi
+
 exit 0

--- a/plugins/code/hooks/subagent-stop-hook.sh
+++ b/plugins/code/hooks/subagent-stop-hook.sh
@@ -455,6 +455,29 @@ if [[ -n "$AGENT_ID" ]] && [[ -n "$CLOSEDLOOP_WORKDIR" ]] && [[ -f "$AGENT_TYPES
     fi
 fi
 
+# --- Plugin Run History ---
+if [[ "$AGENT_TYPE" == plugin:* ]]; then
+    PLUGIN_NAME="${AGENT_TYPE#plugin:}"
+    RESULT="success"
+    # Check if the subagent exited with error
+    EXIT_STATUS=$(echo "$INPUT" | jq -r '.exit_status // "0"')
+    if [[ -n "$EXIT_STATUS" ]] && [[ "$EXIT_STATUS" != "0" ]]; then
+        RESULT="failure"
+    fi
+    HISTORY_FILE="$CLOSEDLOOP_WORKDIR/.plugins/run-history.jsonl"
+    mkdir -p "$(dirname "$HISTORY_FILE")"
+    # Get started_at from agent-type tracking file
+    PLUGIN_STARTED_AT=""
+    if [[ -n "$AGENT_ID" ]] && [[ -f "$AGENT_TYPES_DIR/$AGENT_ID" ]]; then
+        PLUGIN_STARTED_AT=$(cut -d'|' -f3 "$AGENT_TYPES_DIR/$AGENT_ID")
+    fi
+    if [[ -z "$PLUGIN_STARTED_AT" ]]; then
+        PLUGIN_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    fi
+    echo "{\"format_version\":1,\"plugin\":\"$PLUGIN_NAME\",\"result\":\"$RESULT\",\"started_at\":\"$PLUGIN_STARTED_AT\",\"finished_at\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"trigger\":\"auto\"}" >> "$HISTORY_FILE"
+    echo "$(date): Recorded plugin run history: plugin=$PLUGIN_NAME result=$RESULT" >> "$DEBUG_LOG"
+fi
+
 # Clean up agent_type file
 if [[ -n "$AGENT_ID" ]] && [[ -f "$AGENT_TYPES_DIR/$AGENT_ID" ]]; then
     rm -f "$AGENT_TYPES_DIR/$AGENT_ID"

--- a/plugins/code/plugins/ci-monitor/plugin.md
+++ b/plugins/code/plugins/ci-monitor/plugin.md
@@ -1,0 +1,79 @@
++++
+name = "ci-monitor"
+description = "Poll GitHub for failed CI checks on open PRs"
+version = 1
+
+[gate]
+type = "cooldown"
+duration = "5m"
+
+[tracking]
+labels = ["plugin:ci-monitor", "category:ci-monitoring"]
+digest = true
+
+[execution]
+timeout = "2m"
+notify_on_failure = false
+severity = "low"
++++
+
+# CI Monitor
+
+You are a CI monitoring agent. Check for failed CI checks on open PRs in the current repository.
+
+## 1. Verify GitHub CLI Access
+
+Confirm `gh` is available and authenticated:
+```bash
+gh auth status
+```
+
+If `gh` is not available or not authenticated, output "SKIPPED: gh CLI not available or not authenticated" and exit.
+
+## 2. List Open PRs
+
+Get all open PRs for the current repository:
+
+```bash
+gh pr list --state open --json number,title,headRefName --limit 50
+```
+
+If no open PRs, output "No open PRs found. Nothing to check." and exit.
+
+## 3. Check CI Status for Each PR
+
+For each open PR, check its CI status:
+
+```bash
+gh pr checks <PR_NUMBER> --json name,state,conclusion
+```
+
+Collect any checks with `conclusion` of `failure` or `state` of `FAILURE`.
+
+## 4. Record Findings
+
+If failed checks are found, write findings to `$WORKDIR/.plugins/ci-monitor-findings.json`:
+
+```json
+[
+  {
+    "pr_number": 123,
+    "pr_title": "Feature X",
+    "branch": "feat/x",
+    "failed_checks": [
+      {"name": "lint", "conclusion": "failure"}
+    ],
+    "checked_at": "2026-02-27T12:00:00Z"
+  }
+]
+```
+
+Compare against previous findings file to avoid duplicate alerts: only report NEW failures that were not in the previous run's findings.
+
+## 5. Summary
+
+Output a summary:
+
+- If new failures found: "CI Monitor: Found {N} new CI failure(s) across {M} PR(s): PR #{num1} ({check_name}), PR #{num2} ({check_name})"
+- If no new failures: "CI Monitor: All CI checks passing on {N} open PR(s)."
+- If no open PRs: "CI Monitor: No open PRs to monitor."

--- a/plugins/code/plugins/session-cleanup/plugin.md
+++ b/plugins/code/plugins/session-cleanup/plugin.md
@@ -1,0 +1,56 @@
++++
+name = "session-cleanup"
+description = "Clean up stale session mappings, orphaned agent-type files, and zombie state"
+version = 1
+
+[gate]
+type = "cooldown"
+duration = "30m"
+
+[tracking]
+labels = ["plugin:session-cleanup", "category:cleanup"]
+digest = true
+
+[execution]
+timeout = "5m"
+notify_on_failure = false
+severity = "low"
++++
+
+# Session Cleanup
+
+You are a cleanup agent. Perform the following tasks in order, logging each action to stdout.
+
+## 1. Stale PID Mapping Cleanup
+
+Find all PID-to-session mapping files in `$WORKDIR/.closedloop-ai/`:
+```bash
+ls $WORKDIR/.closedloop-ai/pid-*.session 2>/dev/null
+```
+
+For each file, extract the PID from the filename and check if the process is still running:
+
+```bash
+kill -0 <PID> 2>/dev/null
+```
+
+If the process is NOT running, delete the stale mapping file. Log: "Removed stale PID mapping: pid-<PID>.session"
+
+## 2. Orphaned Agent-Type File Cleanup
+
+Find all agent-type tracking files older than 24 hours:
+
+```bash
+find $WORKDIR/.closedloop-ai/.agent-types/ -type f -mmin +1440 2>/dev/null
+```
+
+Delete each orphaned file. Log: "Removed orphaned agent-type file: <filename>"
+
+## 3. Stale Session-Workdir File Cleanup
+
+Find session workdir tracking files in `$WORKDIR/.closedloop-ai/` that reference sessions no longer active (PID not running). Remove them. Log: "Removed stale session-workdir: <filename>"
+
+## 4. Summary
+
+Output a summary line: "Session hygiene complete: removed N stale PID mappings, M orphaned agent-type files, K stale session-workdir files."
+If nothing was cleaned, output: "Session hygiene complete: no stale state found."

--- a/plugins/code/prompts/prompt.md
+++ b/plugins/code/prompts/prompt.md
@@ -115,6 +115,7 @@ See the skill documentation for the 4-phase protocol (Initial Dispatch → Suffi
 
 ```json
 TodoWrite([
+  {"content": "Phase 0.8: Plugin Dispatch", "status": "pending", "activeForm": "Dispatching plugins"},
   {"content": "Phase 1: Planning", "status": "pending", "activeForm": "Planning"},
   {"content": "Phase 1.1: Plan review checkpoint", "status": "pending", "activeForm": "Awaiting plan review decision"},
   {"content": "Phase 1.2: Process answered questions", "status": "pending", "activeForm": "Processing answered questions"},
@@ -163,6 +164,30 @@ Mark each todo as `in_progress` when starting, `completed` when done. NEVER skip
 **Self-check before ANY `<promise>` output:** "Did I write state.json with the correct status? If not, write it NOW before outputting the promise tag."
 
 Here are the key phases you must complete:
+
+**PHASE 0.8: PLUGIN DISPATCH** (non-blocking background tasks)
+
+- Check if `$CLOSEDLOOP_WORKDIR/.plugins/dispatch-queue.json` exists:
+  ```bash
+  ls $CLOSEDLOOP_WORKDIR/.plugins/dispatch-queue.json 2>/dev/null
+  ```
+
+- If file does NOT exist or is empty array `[]`: log "No plugins ready to dispatch." and skip to Phase 0.9
+- If file exists with entries, for EACH plugin in the queue:
+  1. Log: "Dispatching plugin '{name}' ({gate_type} gate open)"
+  2. Launch a Task() with prompt:
+    "You are executing plugin '{name}'. Follow the instructions below exactly.
+      After completion, output your result summary.
+      WORKDIR=$CLOSEDLOOP_WORKDIR
+      {instructions}"
+  3. Use agent_type `plugin:{name}` so SubagentStop can track the result
+  4. Do NOT wait for plugin subagents to complete -- dispatch all and continue
+- After dispatching all entries, log summary: "Dispatched {N} plugin(s): {comma-separated names}."
+- Clear the dispatch queue after dispatching:
+  ```bash
+  echo '[]' > $CLOSEDLOOP_WORKDIR/.plugins/dispatch-queue.json
+  ```
+- Proceed to Phase 0.9
 
 **PHASE 0.9: PRE-EXPLORATION** (only if plan.json does NOT exist)
 

--- a/plugins/code/scripts/plugin-dispatcher.py
+++ b/plugins/code/scripts/plugin-dispatcher.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Plugin dispatcher: scan, parse, evaluate gates, and write dispatch queue.
+
+Discovers autonomous workflow plugins from plugin.md files with TOML frontmatter,
+evaluates their gate conditions against run history, and produces a dispatch queue
+for the orchestrator to consume.
+"""
+
+import sys
+
+if sys.version_info < (3, 11):
+    print(
+        "ERROR: plugin-dispatcher.py requires Python 3.11+ (for tomllib). "
+        f"Current version: {sys.version}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+import argparse
+import json
+import re
+import subprocess
+import tomllib
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Type System
+# ---------------------------------------------------------------------------
+
+
+class GateType(Enum):
+    COOLDOWN = "cooldown"
+    CRON = "cron"
+    CONDITION = "condition"
+    EVENT = "event"
+    MANUAL = "manual"
+
+
+@dataclass
+class Gate:
+    type: GateType = GateType.MANUAL
+    duration: Optional[str] = None  # cooldown: "30m", "1h", "7d"
+    schedule: Optional[str] = None  # cron: interval as duration "4h"
+    check: Optional[str] = None  # condition: shell command
+    on: Optional[str] = None  # event: trigger name e.g. "session-start"
+
+
+@dataclass
+class Tracking:
+    labels: list[str] = field(default_factory=list)
+    digest: bool = False
+
+
+@dataclass
+class Execution:
+    timeout: Optional[str] = None
+    notify_on_failure: bool = False
+    severity: str = "low"
+
+
+@dataclass
+class Plugin:
+    name: str
+    description: str = ""
+    version: int = 1
+    gate: Gate = field(default_factory=Gate)
+    tracking: Tracking = field(default_factory=Tracking)
+    execution: Execution = field(default_factory=Execution)
+    instructions: str = ""  # markdown body after TOML frontmatter
+    path: str = ""  # filesystem path to plugin.md
+    location: str = "bundled"  # "bundled" or "custom"
+
+
+# ---------------------------------------------------------------------------
+# Duration Parsing
+# ---------------------------------------------------------------------------
+
+_DURATION_RE = re.compile(r"^(\d+)([smhd])$")
+_DURATION_MULTIPLIERS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def parse_duration(duration_str: str) -> timedelta:
+    """Parse duration strings like '30m', '1h', '7d', '300s'."""
+    match = _DURATION_RE.match(duration_str)
+    if not match:
+        raise ValueError(f"Invalid duration format: {duration_str}")
+    value, unit = int(match.group(1)), match.group(2)
+    return timedelta(seconds=value * _DURATION_MULTIPLIERS[unit])
+
+
+# ---------------------------------------------------------------------------
+# TOML Frontmatter Parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_plugin_file(filepath: str) -> tuple[dict, str]:
+    """Parse a plugin.md file into (frontmatter_dict, markdown_body).
+
+    File format:
+        +++
+        name = "my-plugin"
+        [gate]
+        type = "cooldown"
+        duration = "30m"
+        +++
+
+        # Plugin Title
+        Instructions here...
+
+    Returns:
+        (toml_dict, markdown_body)
+
+    Raises:
+        ValueError if +++ delimiters are missing or TOML is malformed.
+    """
+    content = Path(filepath).read_text()
+
+    first = content.find("+++")
+    if first == -1:
+        raise ValueError(f"No +++ delimiter found in {filepath}")
+
+    second = content.find("+++", first + 3)
+    if second == -1:
+        raise ValueError(f"No closing +++ delimiter found in {filepath}")
+
+    toml_str = content[first + 3 : second].strip()
+    markdown_body = content[second + 3 :].strip()
+
+    frontmatter = tomllib.loads(toml_str)
+    return frontmatter, markdown_body
+
+
+def validate_frontmatter(frontmatter: dict, filepath: str) -> None:
+    """Validate TOML frontmatter fields based on gate type."""
+    name = frontmatter.get("name", "")
+    if not name:
+        raise ValueError(f"Plugin at {filepath}: 'name' field is required and non-empty")
+
+    gate = frontmatter.get("gate", {})
+    gate_type = gate.get("type")
+
+    if gate_type == "cooldown" and "duration" not in gate:
+        raise ValueError(f"Plugin '{name}': cooldown gate requires 'duration' field")
+    if gate_type == "cron" and "schedule" not in gate:
+        raise ValueError(f"Plugin '{name}': cron gate requires 'schedule' field")
+    if gate_type == "condition" and "check" not in gate:
+        raise ValueError(f"Plugin '{name}': condition gate requires 'check' field")
+    if gate_type == "event" and "on" not in gate:
+        raise ValueError(f"Plugin '{name}': event gate requires 'on' field")
+
+
+def _parse_gate(raw: dict) -> Gate:
+    gate_type_str = raw.get("type", "manual")
+    try:
+        gate_type = GateType(gate_type_str)
+    except ValueError:
+        gate_type = GateType.MANUAL
+    return Gate(
+        type=gate_type,
+        duration=raw.get("duration"),
+        schedule=raw.get("schedule"),
+        check=raw.get("check"),
+        on=raw.get("on"),
+    )
+
+
+def _parse_tracking(raw: dict) -> Tracking:
+    return Tracking(
+        labels=raw.get("labels", []),
+        digest=raw.get("digest", False),
+    )
+
+
+def _parse_execution(raw: dict) -> Execution:
+    return Execution(
+        timeout=raw.get("timeout"),
+        notify_on_failure=raw.get("notify_on_failure", False),
+        severity=raw.get("severity", "low"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plugin Scanner
+# ---------------------------------------------------------------------------
+
+
+def discover_plugins(scan_dirs: list[str]) -> list[Plugin]:
+    """Scan directories for plugin.md files. Later dirs override earlier by name."""
+    plugins: dict[str, Plugin] = {}
+
+    for scan_dir in scan_dirs:
+        dir_path = Path(scan_dir)
+        if not dir_path.is_dir():
+            continue
+
+        for entry in sorted(dir_path.iterdir()):
+            if not entry.is_dir() or entry.name.startswith("."):
+                continue
+
+            plugin_file = entry / "plugin.md"
+            if not plugin_file.exists():
+                continue
+
+            try:
+                frontmatter, body = parse_plugin_file(str(plugin_file))
+                validate_frontmatter(frontmatter, str(plugin_file))
+
+                name = frontmatter["name"]
+
+                if name in plugins:
+                    print(
+                        f"Warning: plugin '{name}' from {plugin_file} "
+                        f"overrides version at {plugins[name].path}",
+                        file=sys.stderr,
+                    )
+
+                plugins[name] = Plugin(
+                    name=name,
+                    description=frontmatter.get("description", ""),
+                    version=frontmatter.get("version", 1),
+                    gate=_parse_gate(frontmatter.get("gate", {})),
+                    tracking=_parse_tracking(frontmatter.get("tracking", {})),
+                    execution=_parse_execution(frontmatter.get("execution", {})),
+                    instructions=body,
+                    path=str(plugin_file),
+                    location="custom" if "custom" in str(scan_dir) else "bundled",
+                )
+            except Exception as e:
+                print(f"Warning: failed to parse {plugin_file}: {e}", file=sys.stderr)
+                continue
+
+    return list(plugins.values())
+
+
+# ---------------------------------------------------------------------------
+# Run History
+# ---------------------------------------------------------------------------
+
+
+def count_runs_since(history_path: str, plugin_name: str, since: datetime) -> int:
+    """Count non-skipped runs for a plugin after the given timestamp.
+
+    Reads JSONL, skips malformed lines (corruption recovery).
+    """
+    count = 0
+    path = Path(history_path)
+    if not path.exists():
+        return 0
+
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue  # skip corrupted lines
+
+        if entry.get("plugin") != plugin_name:
+            continue
+        if entry.get("result") == "skipped":
+            continue
+
+        started = datetime.fromisoformat(entry["started_at"])
+        if started.tzinfo is None:
+            started = started.replace(tzinfo=timezone.utc)
+        if started >= since:
+            count += 1
+
+    return count
+
+
+def get_last_run(history_path: str, plugin_name: str) -> Optional[datetime]:
+    """Get the most recent non-skipped run time for a plugin."""
+    path = Path(history_path)
+    if not path.exists():
+        return None
+
+    last: Optional[datetime] = None
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if entry.get("plugin") != plugin_name:
+            continue
+        if entry.get("result") == "skipped":
+            continue
+
+        started = datetime.fromisoformat(entry["started_at"])
+        if started.tzinfo is None:
+            started = started.replace(tzinfo=timezone.utc)
+        if last is None or started > last:
+            last = started
+
+    return last
+
+
+def record_run(
+    history_path: str,
+    plugin_name: str,
+    result: str,
+    started_at: str,
+    trigger: str = "auto",
+) -> None:
+    """Append a run record to the JSONL history file."""
+    record = {
+        "format_version": 1,
+        "plugin": plugin_name,
+        "result": result,
+        "started_at": started_at,
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "trigger": trigger,
+    }
+
+    path = Path(history_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(path, "a") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Gate Evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_gate(plugin: Plugin, history_path: str, trigger: str) -> bool:
+    """Evaluate a plugin's gate. Returns True if gate is open (should dispatch)."""
+    gate = plugin.gate
+
+    if gate.type == GateType.MANUAL:
+        return False
+
+    if gate.type == GateType.COOLDOWN:
+        assert gate.duration is not None
+        duration = parse_duration(gate.duration)
+        since = datetime.now(timezone.utc) - duration
+        return count_runs_since(history_path, plugin.name, since) == 0
+
+    if gate.type == GateType.CRON:
+        assert gate.schedule is not None
+        interval = parse_duration(gate.schedule)
+        last_run = get_last_run(history_path, plugin.name)
+        if last_run is None:
+            return True  # never run, overdue
+        return (datetime.now(timezone.utc) - last_run) >= interval
+
+    if gate.type == GateType.CONDITION:
+        assert gate.check is not None
+        try:
+            result = subprocess.run(
+                gate.check, shell=True, timeout=5, capture_output=True
+            )
+            return result.returncode == 0
+        except subprocess.TimeoutExpired:
+            return False
+
+    if gate.type == GateType.EVENT:
+        assert gate.on is not None
+        return gate.on == trigger
+
+    return False  # unknown gate type
+
+
+# ---------------------------------------------------------------------------
+# Dispatch Queue
+# ---------------------------------------------------------------------------
+
+
+def write_dispatch_queue(
+    plugins: list[Plugin], history_path: str, trigger: str, workdir: str
+) -> list[dict]:
+    """Evaluate gates and write dispatch queue. Returns the queue entries."""
+    queue = []
+    for plugin in plugins:
+        if evaluate_gate(plugin, history_path, trigger):
+            entry: dict = {
+                "name": plugin.name,
+                "path": plugin.path,
+                "instructions": plugin.instructions,
+            }
+            execution: dict = {}
+            if plugin.execution.timeout:
+                execution["timeout"] = plugin.execution.timeout
+            execution["notify_on_failure"] = plugin.execution.notify_on_failure
+            execution["severity"] = plugin.execution.severity
+            entry["execution"] = execution
+            queue.append(entry)
+
+    queue_path = Path(workdir) / ".plugins" / "dispatch-queue.json"
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+    queue_path.write_text(json.dumps(queue, indent=2) + "\n")
+    return queue
+
+
+def force_dispatch(
+    plugins: list[Plugin], plugin_name: str, workdir: str
+) -> list[dict]:
+    """Force-dispatch a single plugin by name regardless of gate."""
+    matching = [p for p in plugins if p.name == plugin_name]
+    if not matching:
+        print(f"Error: plugin '{plugin_name}' not found", file=sys.stderr)
+        sys.exit(1)
+
+    plugin = matching[0]
+    entry: dict = {
+        "name": plugin.name,
+        "path": plugin.path,
+        "instructions": plugin.instructions,
+    }
+    execution: dict = {}
+    if plugin.execution.timeout:
+        execution["timeout"] = plugin.execution.timeout
+    execution["notify_on_failure"] = plugin.execution.notify_on_failure
+    execution["severity"] = plugin.execution.severity
+    entry["execution"] = execution
+    queue = [entry]
+
+    queue_path = Path(workdir) / ".plugins" / "dispatch-queue.json"
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+    queue_path.write_text(json.dumps(queue, indent=2) + "\n")
+    return queue
+
+
+def list_plugins(plugins: list[Plugin], history_path: str) -> str:
+    """Return JSON array of all discovered plugins with their status."""
+    result = []
+    for plugin in sorted(plugins, key=lambda p: p.name):
+        last_run = get_last_run(history_path, plugin.name)
+        result.append(
+            {
+                "name": plugin.name,
+                "description": plugin.description,
+                "version": plugin.version,
+                "gate_type": plugin.gate.type.value,
+                "gate_status": "open"
+                if evaluate_gate(plugin, history_path, "")
+                else "closed",
+                "last_run": last_run.isoformat() if last_run else None,
+            }
+        )
+    return json.dumps(result, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Plugin dispatcher: scan, evaluate gates, write dispatch queue."
+    )
+    parser.add_argument(
+        "--trigger",
+        default="",
+        help="Event trigger name (e.g. session-start, session-end, manual)",
+    )
+    parser.add_argument("--workdir", required=True, help="Working directory path")
+    parser.add_argument(
+        "--plugin-root", required=True, help="Plugin root directory path"
+    )
+    parser.add_argument(
+        "--plugin", default=None, help="Force-dispatch a single plugin by name"
+    )
+    parser.add_argument(
+        "--list", action="store_true", help="List all plugins with status"
+    )
+
+    args = parser.parse_args()
+
+    # Build scan directories
+    bundled_dir = str(Path(args.plugin_root) / "plugins")
+    custom_dir = str(Path(args.workdir) / ".plugins" / "custom")
+    scan_dirs = [bundled_dir, custom_dir]
+
+    plugins = discover_plugins(scan_dirs)
+    history_path = str(Path(args.workdir) / ".plugins" / "run-history.jsonl")
+
+    if args.list:
+        print(list_plugins(plugins, history_path))
+        return
+
+    if args.plugin:
+        queue = force_dispatch(plugins, args.plugin, args.workdir)
+        if queue:
+            print(f"Force-dispatched plugin: {queue[0]['name']}")
+        return
+
+    queue = write_dispatch_queue(plugins, history_path, args.trigger, args.workdir)
+    if queue:
+        names = ", ".join(e["name"] for e in queue)
+        print(f"Dispatched {len(queue)} plugin(s): {names}")
+    else:
+        print("No plugins ready to dispatch.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/code/scripts/test_plugin_dispatcher.py
+++ b/plugins/code/scripts/test_plugin_dispatcher.py
@@ -1,0 +1,559 @@
+"""Tests for plugin-dispatcher.py."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import importlib
+
+import pytest
+
+# Ensure the script directory is importable
+sys.path.insert(0, str(Path(__file__).parent))
+
+# Import the hyphenated module name
+_mod = importlib.import_module("plugin-dispatcher")
+
+Gate = _mod.Gate
+GateType = _mod.GateType
+Plugin = _mod.Plugin
+count_runs_since = _mod.count_runs_since
+discover_plugins = _mod.discover_plugins
+evaluate_gate = _mod.evaluate_gate
+force_dispatch = _mod.force_dispatch
+get_last_run = _mod.get_last_run
+list_plugins = _mod.list_plugins
+parse_duration = _mod.parse_duration
+parse_plugin_file = _mod.parse_plugin_file
+validate_frontmatter = _mod.validate_frontmatter
+write_dispatch_queue = _mod.write_dispatch_queue
+record_run = _mod.record_run
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+@pytest.fixture
+def sample_plugin_content():
+    return """\
++++
+name = "test-plugin"
+description = "A test plugin"
+version = 1
+
+[gate]
+type = "cooldown"
+duration = "30m"
+
+[tracking]
+labels = ["plugin:test", "category:test"]
+digest = true
+
+[execution]
+timeout = "5m"
+notify_on_failure = false
+severity = "low"
++++
+
+# Test Plugin
+
+You are a test plugin. Do test things.
+"""
+
+
+@pytest.fixture
+def minimal_plugin_content():
+    return """\
++++
+name = "minimal"
++++
+
+# Minimal Plugin
+
+Do nothing.
+"""
+
+
+def _write_plugin(base_dir: Path, name: str, content: str) -> Path:
+    plugin_dir = base_dir / name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    plugin_file = plugin_dir / "plugin.md"
+    plugin_file.write_text(content)
+    return plugin_file
+
+
+def _write_history(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# TOML Frontmatter Parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseTomlFrontmatter:
+    def test_valid(self, tmp_dir, sample_plugin_content):
+        plugin_file = _write_plugin(tmp_dir, "test", sample_plugin_content)
+        frontmatter, body = parse_plugin_file(str(plugin_file))
+        assert frontmatter["name"] == "test-plugin"
+        assert frontmatter["description"] == "A test plugin"
+        assert frontmatter["gate"]["type"] == "cooldown"
+        assert frontmatter["gate"]["duration"] == "30m"
+        assert "# Test Plugin" in body
+
+    def test_minimal(self, tmp_dir, minimal_plugin_content):
+        plugin_file = _write_plugin(tmp_dir, "minimal", minimal_plugin_content)
+        frontmatter, body = parse_plugin_file(str(plugin_file))
+        assert frontmatter["name"] == "minimal"
+        assert "gate" not in frontmatter
+        assert "# Minimal Plugin" in body
+
+    def test_missing_name(self, tmp_dir):
+        content = """\
++++
+description = "no name"
++++
+
+Body here.
+"""
+        plugin_file = _write_plugin(tmp_dir, "noname", content)
+        frontmatter, _ = parse_plugin_file(str(plugin_file))
+        with pytest.raises(ValueError, match="'name' field is required"):
+            validate_frontmatter(frontmatter, str(plugin_file))
+
+    def test_no_delimiters(self, tmp_dir):
+        content = "# Just markdown\n\nNo TOML here."
+        plugin_file = _write_plugin(tmp_dir, "nodelimt", content)
+        with pytest.raises(ValueError, match="No .* delimiter"):
+            parse_plugin_file(str(plugin_file))
+
+
+# ---------------------------------------------------------------------------
+# TOML Validation
+# ---------------------------------------------------------------------------
+
+
+class TestTomlValidation:
+    def test_cooldown_requires_duration(self, tmp_dir):
+        content = """\
++++
+name = "bad-cooldown"
+[gate]
+type = "cooldown"
++++
+Body.
+"""
+        plugin_file = _write_plugin(tmp_dir, "bad", content)
+        frontmatter, _ = parse_plugin_file(str(plugin_file))
+        with pytest.raises(ValueError, match="cooldown gate requires 'duration'"):
+            validate_frontmatter(frontmatter, str(plugin_file))
+
+    def test_cron_requires_schedule(self, tmp_dir):
+        content = """\
++++
+name = "bad-cron"
+[gate]
+type = "cron"
++++
+Body.
+"""
+        plugin_file = _write_plugin(tmp_dir, "bad", content)
+        frontmatter, _ = parse_plugin_file(str(plugin_file))
+        with pytest.raises(ValueError, match="cron gate requires 'schedule'"):
+            validate_frontmatter(frontmatter, str(plugin_file))
+
+    def test_condition_requires_check(self, tmp_dir):
+        content = """\
++++
+name = "bad-condition"
+[gate]
+type = "condition"
++++
+Body.
+"""
+        plugin_file = _write_plugin(tmp_dir, "bad", content)
+        frontmatter, _ = parse_plugin_file(str(plugin_file))
+        with pytest.raises(ValueError, match="condition gate requires 'check'"):
+            validate_frontmatter(frontmatter, str(plugin_file))
+
+    def test_event_requires_on(self, tmp_dir):
+        content = """\
++++
+name = "bad-event"
+[gate]
+type = "event"
++++
+Body.
+"""
+        plugin_file = _write_plugin(tmp_dir, "bad", content)
+        frontmatter, _ = parse_plugin_file(str(plugin_file))
+        with pytest.raises(ValueError, match="event gate requires 'on'"):
+            validate_frontmatter(frontmatter, str(plugin_file))
+
+
+# ---------------------------------------------------------------------------
+# Directory Scanning
+# ---------------------------------------------------------------------------
+
+
+class TestScanDirectory:
+    def test_discovers_plugins(self, tmp_dir, sample_plugin_content, minimal_plugin_content):
+        _write_plugin(tmp_dir / "bundled", "test-plugin", sample_plugin_content)
+        _write_plugin(tmp_dir / "bundled", "minimal-plugin", minimal_plugin_content)
+        plugins = discover_plugins([str(tmp_dir / "bundled")])
+        assert len(plugins) == 2
+        names = {p.name for p in plugins}
+        assert names == {"test-plugin", "minimal"}
+
+    def test_empty_directory(self, tmp_dir):
+        plugins = discover_plugins([str(tmp_dir / "nonexistent")])
+        assert plugins == []
+
+    def test_deduplication(self, tmp_dir, sample_plugin_content):
+        _write_plugin(tmp_dir / "bundled", "test-plugin", sample_plugin_content)
+        override = """\
++++
+name = "test-plugin"
+description = "Override version"
++++
+Override body.
+"""
+        _write_plugin(tmp_dir / "custom", "test-plugin", override)
+        plugins = discover_plugins([str(tmp_dir / "bundled"), str(tmp_dir / "custom")])
+        assert len(plugins) == 1
+        assert plugins[0].description == "Override version"
+
+    def test_skips_dot_dirs(self, tmp_dir, sample_plugin_content):
+        _write_plugin(tmp_dir / "bundled", ".hidden", sample_plugin_content)
+        _write_plugin(tmp_dir / "bundled", "visible", sample_plugin_content)
+        plugins = discover_plugins([str(tmp_dir / "bundled")])
+        assert len(plugins) == 1
+
+
+# ---------------------------------------------------------------------------
+# Gate Evaluation
+# ---------------------------------------------------------------------------
+
+
+class TestCooldownGate:
+    def test_open_no_history(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.COOLDOWN, duration="30m"),
+        )
+        history = str(tmp_dir / "run-history.jsonl")
+        assert evaluate_gate(plugin, history, "") is True
+
+    def test_open_old_runs(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.COOLDOWN, duration="30m"),
+        )
+        history = tmp_dir / "run-history.jsonl"
+        old_time = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        _write_history(
+            history,
+            [{"plugin": "test", "result": "success", "started_at": old_time}],
+        )
+        assert evaluate_gate(plugin, str(history), "") is True
+
+    def test_closed_recent_run(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.COOLDOWN, duration="30m"),
+        )
+        history = tmp_dir / "run-history.jsonl"
+        recent_time = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        _write_history(
+            history,
+            [{"plugin": "test", "result": "success", "started_at": recent_time}],
+        )
+        assert evaluate_gate(plugin, str(history), "") is False
+
+
+class TestCronGate:
+    def test_open_never_run(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.CRON, schedule="4h"),
+        )
+        history = str(tmp_dir / "run-history.jsonl")
+        assert evaluate_gate(plugin, history, "") is True
+
+    def test_open_overdue(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.CRON, schedule="1h"),
+        )
+        history = tmp_dir / "run-history.jsonl"
+        old_time = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        _write_history(
+            history,
+            [{"plugin": "test", "result": "success", "started_at": old_time}],
+        )
+        assert evaluate_gate(plugin, str(history), "") is True
+
+    def test_closed_within_interval(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.CRON, schedule="4h"),
+        )
+        history = tmp_dir / "run-history.jsonl"
+        recent_time = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        _write_history(
+            history,
+            [{"plugin": "test", "result": "success", "started_at": recent_time}],
+        )
+        assert evaluate_gate(plugin, str(history), "") is False
+
+
+class TestEventGate:
+    def test_match(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.EVENT, on="session-start"),
+        )
+        assert evaluate_gate(plugin, str(tmp_dir / "h.jsonl"), "session-start") is True
+
+    def test_no_match(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.EVENT, on="session-start"),
+        )
+        assert evaluate_gate(plugin, str(tmp_dir / "h.jsonl"), "session-end") is False
+
+
+class TestConditionGate:
+    def test_success(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.CONDITION, check="true"),
+        )
+        assert evaluate_gate(plugin, str(tmp_dir / "h.jsonl"), "") is True
+
+    def test_failure(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.CONDITION, check="false"),
+        )
+        assert evaluate_gate(plugin, str(tmp_dir / "h.jsonl"), "") is False
+
+    def test_timeout(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.CONDITION, check="sleep 10"),
+        )
+        with patch.object(_mod.subprocess, "run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="sleep 10", timeout=5)
+            assert evaluate_gate(plugin, str(tmp_dir / "h.jsonl"), "") is False
+
+
+class TestManualGate:
+    def test_always_closed(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.MANUAL),
+        )
+        assert evaluate_gate(plugin, str(tmp_dir / "h.jsonl"), "") is False
+
+    def test_no_gate_treated_as_manual(self, tmp_dir):
+        plugin = Plugin(name="test")  # default gate is MANUAL
+        assert evaluate_gate(plugin, str(tmp_dir / "h.jsonl"), "") is False
+
+
+# ---------------------------------------------------------------------------
+# Duration Parsing
+# ---------------------------------------------------------------------------
+
+
+class TestDurationParsing:
+    def test_seconds(self):
+        assert parse_duration("300s") == timedelta(seconds=300)
+
+    def test_minutes(self):
+        assert parse_duration("30m") == timedelta(minutes=30)
+
+    def test_hours(self):
+        assert parse_duration("1h") == timedelta(hours=1)
+
+    def test_days(self):
+        assert parse_duration("7d") == timedelta(days=7)
+
+    def test_invalid(self):
+        with pytest.raises(ValueError, match="Invalid duration"):
+            parse_duration("abc")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch Queue
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchQueue:
+    def test_write_dispatch_queue(self, tmp_dir):
+        plugin = Plugin(
+            name="test",
+            gate=Gate(type=GateType.COOLDOWN, duration="30m"),
+            instructions="Do things.",
+            path="/path/to/plugin.md",
+        )
+        workdir = str(tmp_dir / "workdir")
+        history = str(tmp_dir / "run-history.jsonl")
+        queue = write_dispatch_queue([plugin], history, "", workdir)
+        assert len(queue) == 1
+        assert queue[0]["name"] == "test"
+
+        queue_file = Path(workdir) / ".plugins" / "dispatch-queue.json"
+        assert queue_file.exists()
+        parsed = json.loads(queue_file.read_text())
+        assert len(parsed) == 1
+
+    def test_creates_plugins_directory(self, tmp_dir):
+        workdir = str(tmp_dir / "new" / "workdir")
+        queue = write_dispatch_queue([], str(tmp_dir / "h.jsonl"), "", workdir)
+        assert queue == []
+        queue_file = Path(workdir) / ".plugins" / "dispatch-queue.json"
+        assert queue_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# JSONL Handling
+# ---------------------------------------------------------------------------
+
+
+class TestJsonlHandling:
+    def test_skip_malformed_lines(self, tmp_dir):
+        history = tmp_dir / "run-history.jsonl"
+        now = datetime.now(timezone.utc)
+        recent = (now - timedelta(minutes=5)).isoformat()
+        history.parent.mkdir(parents=True, exist_ok=True)
+        with open(history, "w") as f:
+            f.write("this is not json\n")
+            f.write(json.dumps({"plugin": "test", "result": "success", "started_at": recent}) + "\n")
+            f.write("{broken json\n")
+
+        count = count_runs_since(str(history), "test", now - timedelta(hours=1))
+        assert count == 1
+
+    def test_format_version(self, tmp_dir):
+        history = str(tmp_dir / "run-history.jsonl")
+        record_run(history, "test", "success", datetime.now(timezone.utc).isoformat())
+        with open(history) as f:
+            entry = json.loads(f.readline())
+        assert entry["format_version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI Integration
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_trigger_session_start(self, tmp_dir, sample_plugin_content):
+        _write_plugin(tmp_dir / "plugins", "test-plugin", sample_plugin_content)
+        workdir = str(tmp_dir / "workdir")
+        script = str(Path(__file__).parent / "plugin-dispatcher.py")
+        result = subprocess.run(
+            [
+                sys.executable,
+                script,
+                "--trigger",
+                "session-start",
+                "--workdir",
+                workdir,
+                "--plugin-root",
+                str(tmp_dir),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        queue_file = Path(workdir) / ".plugins" / "dispatch-queue.json"
+        assert queue_file.exists()
+        queue = json.loads(queue_file.read_text())
+        assert len(queue) == 1
+        assert queue[0]["name"] == "test-plugin"
+
+    def test_force_dispatch(self, tmp_dir, sample_plugin_content):
+        _write_plugin(tmp_dir / "plugins", "test-plugin", sample_plugin_content)
+        workdir = str(tmp_dir / "workdir")
+        script = str(Path(__file__).parent / "plugin-dispatcher.py")
+        result = subprocess.run(
+            [
+                sys.executable,
+                script,
+                "--trigger",
+                "manual",
+                "--workdir",
+                workdir,
+                "--plugin-root",
+                str(tmp_dir),
+                "--plugin",
+                "test-plugin",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "Force-dispatched" in result.stdout
+
+    def test_list_mode(self, tmp_dir, sample_plugin_content):
+        _write_plugin(tmp_dir / "plugins", "test-plugin", sample_plugin_content)
+        workdir = str(tmp_dir / "workdir")
+        script = str(Path(__file__).parent / "plugin-dispatcher.py")
+        result = subprocess.run(
+            [
+                sys.executable,
+                script,
+                "--list",
+                "--workdir",
+                workdir,
+                "--plugin-root",
+                str(tmp_dir),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        plugins = json.loads(result.stdout)
+        assert len(plugins) == 1
+        assert plugins[0]["name"] == "test-plugin"
+        assert plugins[0]["gate_type"] == "cooldown"
+
+    def test_empty_dispatch(self, tmp_dir):
+        workdir = str(tmp_dir / "workdir")
+        script = str(Path(__file__).parent / "plugin-dispatcher.py")
+        result = subprocess.run(
+            [
+                sys.executable,
+                script,
+                "--trigger",
+                "session-start",
+                "--workdir",
+                workdir,
+                "--plugin-root",
+                str(tmp_dir),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        queue_file = Path(workdir) / ".plugins" / "dispatch-queue.json"
+        assert queue_file.exists()
+        assert json.loads(queue_file.read_text()) == []

--- a/plugins/code/skills/plugin-dispatch/SKILL.md
+++ b/plugins/code/skills/plugin-dispatch/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: plugin-dispatch
+description: Manually dispatch a plugin by name, bypassing gate evaluation. Lists available plugins if no name given.
+---
+
+# Plugin Dispatch Skill
+
+This skill enables manual invocation of autonomous workflow plugins.
+
+## Usage
+
+- **List plugins:** `/code:plugin-dispatch` (no arguments)
+- **Dispatch plugin:** `/code:plugin-dispatch <plugin-name>`
+
+## Instructions
+
+### Step 1: Resolve environment
+
+Find the plugin root path by reading the closedloop config:
+
+```bash
+# Check for CLOSEDLOOP_WORKDIR from session mapping
+WORKDIR_CANDIDATES=(
+  "$CWD/.closedloop-ai"
+  "$CWD/.claude/.closedloop"
+)
+for candidate in "${WORKDIR_CANDIDATES[@]}"; do
+  if [[ -d "$candidate" ]]; then
+    CLOSEDLOOP_DIR="$candidate"
+    break
+  fi
+done
+```
+
+Resolve `PLUGIN_ROOT` — the root of the `code` plugin distribution. Use the `code:find-plugin-file` skill to locate `scripts/plugin-dispatcher.py` and derive the root from its path.
+
+### Step 2: List or dispatch
+
+**If no plugin name argument is provided:**
+
+Run the dispatcher in list mode:
+```bash
+python3 "$PLUGIN_ROOT/scripts/plugin-dispatcher.py" \
+    --list \
+    --plugin-root "$PLUGIN_ROOT" \
+    --workdir "$CWD"
+```
+
+Parse the JSON output and format as a human-readable table:
+
+| Name | Gate Type | Status | Last Run |
+|------|-----------|--------|----------|
+
+**If a plugin name is provided:**
+
+Run the dispatcher in force-dispatch mode:
+```bash
+python3 "$PLUGIN_ROOT/scripts/plugin-dispatcher.py" \
+    --trigger manual \
+    --workdir "$CWD" \
+    --plugin-root "$PLUGIN_ROOT" \
+    --plugin "<name>"
+```
+
+Then read the resulting `$CWD/.plugins/dispatch-queue.json` and execute the plugin instructions inline in the current agent context (since this is user-invoked, it runs directly rather than as a background subagent).
+
+### Step 3: Record result
+
+After executing the plugin, record the result to run history:
+```bash
+echo '{"format_version":1,"plugin":"<name>","result":"success","started_at":"<start_time>","finished_at":"<end_time>","trigger":"manual"}' >> "$CWD/.plugins/run-history.jsonl"
+```


### PR DESCRIPTION
## Summary
- **Plugin dispatcher** (`plugin-dispatcher.py`): discovers TOML-frontmatter plugin files, evaluates gate conditions (cooldown, cron, condition, event, manual), and writes a dispatch queue JSON for the orchestrator
- **Hook integration**: session-start hook triggers dispatch; subagent-stop hook records plugin run results to JSONL history
- **Orchestrator Phase 0.8**: new non-blocking plugin dispatch phase in the run-loop prompt, executing queued plugins via the Task tool
- **Initial plugins**: `session-cleanup` (cooldown-gated, 30m) and `ci-monitor` (cooldown-gated, 5m) as bundled examples
- **Plugin-dispatch skill**: manual invocation skill for listing and force-dispatching plugins
- **38 passing tests** covering TOML parsing, gate evaluation, plugin discovery, CLI integration, and JSONL handling

## Test plan
- [x] `pytest plugins/code/scripts/test_plugin_dispatcher.py` — 38/38 pass
- [ ] End-to-end: run `session-start-hook.sh` and verify `.plugins/dispatch-queue.json` is created
- [ ] Verify subagent-stop hook appends to `run-history.jsonl` for `plugin:*` agent types
- [ ] Confirm Phase 0.8 in orchestrator prompt dispatches queued plugins without blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)