### PR TITLE
Export token usage from stream_formatter.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code v1.1.3
+
+#### Added
+- `stream_formatter.py` now accumulates per-model token usage from assistant events and prints a summary in the format the harness expects, fixing zero token counts for PLAN/EXECUTE loops
+
+#### Fixed
+- `stream_formatter.py` returns early on `BrokenPipeError` before printing usage summary, preventing tracebacks when used in pipelines with early-exit consumers
+
 ### code v1.1.2
 
 #### Fixed

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.2.1",
+  "version": "1.1.3",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.1.3",
+  "version": "1.2.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/README.md
+++ b/plugins/code/README.md
@@ -353,7 +353,7 @@ Counts tokens in a file or stdin using the Anthropic API's token counting endpoi
 
 ### `stream_formatter.py`
 
-Formats Claude stream-JSON output (from `claude --output-format stream-json`) into human-readable terminal output with ANSI colors. Used in pipeline with the external loop runner to display progress.
+Formats Claude stream-JSON output (from `claude --output-format stream-json`) into human-readable terminal output with ANSI colors. Accumulates per-model token usage from assistant events and prints a summary at exit in the format the harness expects. Used in pipeline with the external loop runner to display progress and report token consumption.
 
 ### `requirements.txt`
 

--- a/plugins/code/tools/python/stream_formatter.py
+++ b/plugins/code/tools/python/stream_formatter.py
@@ -270,7 +270,7 @@ def main() -> int:
     except KeyboardInterrupt:
         pass
     except BrokenPipeError:
-        pass
+        return 0
 
     _print_usage_summary(tokens_by_model)
 

--- a/plugins/code/tools/python/stream_formatter.py
+++ b/plugins/code/tools/python/stream_formatter.py
@@ -198,8 +198,58 @@ def format_event(event: dict[str, object]) -> str | None:
     return None
 
 
+def _accumulate_usage(
+    tokens_by_model: dict[str, dict[str, int]],
+    event: dict[str, object],
+) -> None:
+    """Accumulate token usage from an assistant event into tokens_by_model."""
+    msg = event.get("message")
+    if not isinstance(msg, dict):
+        return
+    usage = msg.get("usage")
+    if not isinstance(usage, dict):
+        return
+    model = str(msg.get("model", "unknown"))
+    if model not in tokens_by_model:
+        tokens_by_model[model] = {
+            "input": 0,
+            "output": 0,
+            "cache_creation": 0,
+            "cache_read": 0,
+        }
+    entry = tokens_by_model[model]
+    entry["input"] += int(usage.get("input_tokens", 0))
+    entry["output"] += int(usage.get("output_tokens", 0))
+    entry["cache_creation"] += int(usage.get("cache_creation_input_tokens", 0))
+    entry["cache_read"] += int(usage.get("cache_read_input_tokens", 0))
+
+
+def _print_usage_summary(tokens_by_model: dict[str, dict[str, int]]) -> None:
+    """Print a token usage summary in the format the harness expects."""
+    if not tokens_by_model:
+        return
+    total_input = 0
+    total_output = 0
+    for model, usage in sorted(tokens_by_model.items()):
+        parts = [
+            f"Model: {model}",
+            f"Input: {usage['input']}",
+            f"Output: {usage['output']}",
+        ]
+        if usage.get("cache_creation"):
+            parts.append(f"Cache creation: {usage['cache_creation']}")
+        if usage.get("cache_read"):
+            parts.append(f"Cache read: {usage['cache_read']}")
+        print("  ".join(parts), flush=True)
+        total_input += usage["input"]
+        total_output += usage["output"]
+    print(f"Total input tokens: {total_input}", flush=True)
+    print(f"Total output tokens: {total_output}", flush=True)
+
+
 def main() -> int:
     """Read JSONL from stdin, print formatted text to stdout."""
+    tokens_by_model: dict[str, dict[str, int]] = {}
     try:
         for line in sys.stdin:
             line = line.strip()
@@ -210,6 +260,9 @@ def main() -> int:
             except json.JSONDecodeError:
                 continue
 
+            if event.get("type") == "assistant":
+                _accumulate_usage(tokens_by_model, event)
+
             formatted = format_event(event)
             if formatted:
                 print(formatted, flush=True)
@@ -218,6 +271,8 @@ def main() -> int:
         pass
     except BrokenPipeError:
         pass
+
+    _print_usage_summary(tokens_by_model)
 
     return 0
 

--- a/plugins/judges/.claude-plugin/plugin.json
+++ b/plugins/judges/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "judges",
   "description": "LLM Judges plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/judges/.claude-plugin/plugin.json
+++ b/plugins/judges/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "judges",
   "description": "LLM Judges plugin",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"


### PR DESCRIPTION
## Summary
- The harness-agent parses stdout for per-model token usage lines to populate `tokensUsed` and `tokensByModel` in completed events
- For PLAN/EXECUTE commands, `run-loop.sh` uses `--output-format stream-json` piped through `stream_formatter.py`, which never printed usage summary lines
- This resulted in all loops having zero token counts and $0.00 cost in the UI

`stream_formatter.py` now accumulates usage from `assistant` events and prints a per-model summary plus totals at the end, matching the regex format the harness expects:
```
Model: claude-opus-4-6  Input: 12345  Output: 6789  Cache creation: 100  Cache read: 200
Total input tokens: 12345
Total output tokens: 6789
```

## Test plan
- [ ] Run a PLAN or EXECUTE loop and verify token usage appears in completed event
- [ ] Verify the loops table shows non-zero token counts for new loops
- [ ] Verify cost calculation works with the tokensByModel data

🤖 Generated with [Claude Code](https://claude.com/claude-code)