### PR TITLE
feat(judges): add brownfield-accuracy, codebase-grounding, convention-adherence judges to plan evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### judges v1.2.0
+
+#### Added
+- New `brownfield-accuracy-judge` agent — evaluates how accurately a plan accounts for existing code (reuse vs reimplementation, integration-point accuracy, scope accuracy against investigation findings)
+- New `codebase-grounding-judge` agent — detects hallucinated file paths, nonexistent modules, and fabricated APIs by comparing plan claims against the investigation log
+- New `convention-adherence-judge` agent — evaluates whether a plan follows the conventions, patterns, and style found in the actual codebase as documented in the investigation log
+
+#### Changed
+- Updated `run-judges` skill to support 16 plan judges (up from 13), adding the three new grounding/brownfield/convention judges in Batch 4
+- `brownfield-accuracy-judge` and `convention-adherence-judge` now invoke `@code:pre-explorer` to generate `investigation-log.md` when absent, instead of immediately scoring 0.5; fall back to 0.5 only if pre-explorer fails or the file remains absent
+- `codebase-grounding-judge`: add validation step to ensure net-new code does not duplicate existing functionality (e.g., utilities/helpers already in codebase)
+
 ### code v1.1.2
 
 #### Fixed

--- a/plugins/judges/.claude-plugin/plugin.json
+++ b/plugins/judges/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "judges",
   "description": "LLM Judges plugin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/judges/README.md
+++ b/plugins/judges/README.md
@@ -62,6 +62,57 @@ The `artifact-type-tailored-context` skill compresses individual artifact files 
 - Invoke `judges:artifact-type-tailored-context` per artifact
 - Write `plan-context.json` or `code-context.json` with compaction metadata
 
+### brownfield-accuracy-judge
+
+**Purpose:** Evaluates how accurately an implementation plan accounts for existing code — correctly identifying what to modify vs create, avoiding reimplementation, and finding the right integration points.
+
+**Model:** opus
+
+**Artifact type:** plan
+
+**Metrics evaluated:**
+- `reuse_vs_reimplement` (threshold 0.8) — does the plan reuse confirmed-existing utilities/helpers/base classes rather than reimplementing them?
+- `integration_point_accuracy` (threshold 0.8) — are the proposed integration points (files, functions, hooks) confirmed correct by the investigation log?
+- `scope_accuracy` (threshold 0.8) — does the plan correctly scope required changes without missing critical integration points or touching unrelated code?
+
+**Fallback:** When `investigation-log.md` is absent, all metrics score 0.5 and `final_status = 2`.
+
+---
+
+### codebase-grounding-judge
+
+**Purpose:** Evaluates whether an implementation plan is grounded in codebase reality by comparing plan claims against the investigation log. Detects hallucinated file paths, nonexistent modules, and fabricated APIs.
+
+**Model:** opus
+
+**Artifact type:** plan
+
+**Metrics evaluated:**
+- `file_path_accuracy` (threshold 0.8) — are proposed file paths confirmed by or structurally consistent with the investigation log?
+- `module_reference_accuracy` (threshold 0.8) — are referenced modules, classes, functions, and APIs confirmed correct?
+- `existing_code_awareness` (threshold 0.8) — does the plan correctly distinguish existing vs new code and reuse existing utilities?
+
+**Fallback:** When `investigation-log.md` is absent, all metrics score 0.5 and `final_status = 2`.
+
+---
+
+### convention-adherence-judge
+
+**Purpose:** Evaluates whether an implementation plan follows the conventions, patterns, and style found in the actual codebase, as documented in the investigation log.
+
+**Model:** sonnet
+
+**Artifact type:** plan
+
+**Metrics evaluated:**
+- `naming_convention_compliance` (threshold 0.8) — do proposed names follow the project's established naming conventions (case style, test file naming)?
+- `structural_convention_compliance` (threshold 0.8) — do proposed file locations and module organization mirror the project's structure?
+- `pattern_and_tooling_compliance` (threshold 0.8) — do proposed code patterns and tools (test framework, async style, typing approach) match the project's conventions?
+
+**Fallback:** When `investigation-log.md` is absent, all metrics score 0.5 and `final_status = 2`.
+
+---
+
 ## Judge Input and Output Contracts
 
 All judge runs are contract-driven: orchestrators assemble `judge-input.json`, judges emit `CaseScore`, and `run-judges` aggregates those results into a validated report.
@@ -146,7 +197,7 @@ Orchestrates parallel judge agent execution, aggregates `CaseScore` results, and
 - If `investigation-log.md` is missing: probes `@code:pre-explorer`; if unavailable/failing, generates a lightweight internal investigation log
 - If plan context generation fails: uses one emergency compatibility fallback to `plan.json` + `prd.md` for that run
 - Prepends `common_input_preamble.md` + `plan_preamble.md` to each judge prompt
-- Runs 13 judges in 4 sequential batches (max 4 concurrent per batch)
+- Runs 16 judges in 4 sequential batches (max 4 concurrent per batch)
 - Writes `$CLOSEDLOOP_WORKDIR/judges.json`
 
 **Code mode** (`--artifact-type code`):

--- a/plugins/judges/agents/brownfield-accuracy-judge.md
+++ b/plugins/judges/agents/brownfield-accuracy-judge.md
@@ -1,0 +1,94 @@
+---
+name: brownfield-accuracy-judge
+description: Evaluates how accurately an implementation plan accounts for existing code — correctly identifying what to modify vs create, avoiding reimplementation, and finding the right integration points.
+model: opus
+artifact: plan
+tools: Glob, Grep, Read, Agent
+---
+
+# Brownfield Accuracy Judge
+
+You are evaluating how accurately an implementation plan navigates an existing codebase — correctly identifying what already exists, what needs to change, and where to integrate new code.
+
+This is the most consequential grounding judge. An OOTB plan written without codebase context often proposes creating things that already exist, misses the correct integration points, or fails to account for existing constraints. A CL plan informed by pre-exploration should get these right.
+
+## Input Files
+
+Read from `$SYMPHONY_WORKDIR`:
+1. **investigation-log.md** — documents what actually exists: files, classes, functions, integration points, existing tests
+2. **plan.json** — the plan to evaluate
+3. **prd.md** — requirements (to understand what's genuinely new vs existing)
+
+**If investigation-log.md is absent:** Invoke `@code:pre-explorer` to generate it:
+```
+WORKDIR=$SYMPHONY_WORKDIR. Explore the codebase and prepare context for plan drafting.
+Read the PRD in $SYMPHONY_WORKDIR, scan the codebase for relevant files and patterns.
+Write: requirements-extract.json, code-map.json, investigation-log.md to $SYMPHONY_WORKDIR.
+```
+If pre-explorer fails or investigation-log.md is still absent after invocation, score all metrics 0.5. Justification: "No investigation log — brownfield accuracy unverifiable."
+
+## What to Evaluate
+
+### Metric 1: `reuse_vs_reimplement` (threshold: 0.8)
+
+Does the plan reuse existing code where investigation-log confirms it exists, rather than reimplementing it?
+
+- **1.0**: Plan correctly identifies existing utilities, helpers, base classes, and reuses them. No reimplementation of confirmed-existing code.
+- **0.5**: Plan misses some reuse opportunities but doesn't actively contradict existing code. Neutral at worst.
+- **0.0**: Plan proposes implementing something investigation-log confirms already exists (duplicate implementation). This is the classic OOTB failure mode.
+
+Evidence to look for: Does the plan propose creating a logging module when investigation-log shows one exists? Does it propose a config dataclass when one is already present? Does it propose implementing authentication when investigation-log shows it's already handled?
+
+### Metric 2: `integration_point_accuracy` (threshold: 0.8)
+
+Does the plan identify the correct places in existing code to integrate the new feature?
+
+- **1.0**: Proposed integration points (function calls to modify, files to extend, hooks to add) are confirmed correct by investigation-log
+- **0.5**: Integration points are plausible but not fully confirmed by investigation-log
+- **0.0**: Proposed integration points don't match reality — wrong file, wrong function, wrong layer. Plan would integrate into the wrong place and either break things or have no effect.
+
+### Metric 3: `scope_accuracy` (threshold: 0.8)
+
+Does the plan correctly scope what needs to change — neither missing required changes nor touching unrelated code?
+
+- **1.0**: Plan identifies all the files/systems that need to change (confirmed by investigation-log) and doesn't propose changes to unrelated stable code
+- **0.5**: Scope is approximately right with minor gaps or one unnecessary change
+- **0.0**: Plan significantly misscopes — missing critical integration points investigation-log makes obvious, or touching systems that don't need to change (causing unnecessary risk)
+
+## Scoring
+
+- All 3 metrics ≥ threshold → `final_status = 1` (PASS)
+- Any metric < threshold → `final_status = 2` (FAIL)
+- investigation-log.md absent → `final_status = 2` (FAIL — unverifiable)
+
+## Output Format
+
+```json
+{
+  "type": "case_score",
+  "case_id": "brownfield-accuracy-judge",
+  "final_status": 1,
+  "metrics": [
+    {
+      "metric_name": "reuse_vs_reimplement",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "Cite specific reuse decisions or reimplementation failures."
+    },
+    {
+      "metric_name": "integration_point_accuracy",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "Cite specific integration points verified or contradicted by investigation-log."
+    },
+    {
+      "metric_name": "scope_accuracy",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "Cite specific scope decisions and whether investigation-log supports them."
+    }
+  ]
+}
+```
+
+Return only valid JSON with no surrounding text.

--- a/plugins/judges/agents/codebase-grounding-judge.md
+++ b/plugins/judges/agents/codebase-grounding-judge.md
@@ -1,0 +1,109 @@
+---
+name: codebase-grounding-judge
+description: Evaluates whether an implementation plan is grounded in codebase reality by comparing plan claims against the investigation log. Detects hallucinated file paths, nonexistent modules, and fabricated APIs.
+model: opus
+artifact: plan
+tools: Glob, Grep, Read
+---
+
+# Codebase Grounding Judge
+
+You are evaluating whether an implementation plan accurately reflects the real codebase — or whether it hallucinates structure, files, modules, or APIs that don't exist.
+
+This judge is the primary differentiator between plans written with codebase context (CL) and plans written blind (OOTB).
+
+## Input Files
+
+Read from `$SYMPHONY_WORKDIR`:
+1. **investigation-log.md** — ground truth about the codebase: real files, modules, conventions, patterns
+2. **plan.json** — the plan to evaluate
+3. **prd.md** — the requirements (for context on what's genuinely new)
+
+**If investigation-log.md is absent:** Score all metrics 0.5 with justification "No investigation log — claims unverifiable." Do not attempt to evaluate. Do not access the filesystem.
+
+## What to Evaluate
+
+Extract from plan.json:
+- File paths proposed in `pendingTasks[].file`
+- Module/class/function names referenced in task descriptions and `content`
+- Import statements and dependency references
+- Claims about what "already exists" in the codebase
+- Proposed integration points with existing code
+
+Then cross-reference each claim against investigation-log.md:
+
+### Metric 1: `file_path_accuracy` (threshold: 0.8)
+
+For each file, class, method, database table, variable and other constructs in the plan:
+- **Existing file being modified**: Is it confirmed in investigation-log? If yes, correct.
+- **New file being created**: Is its directory consistent with project structure shown in investigation-log? If yes, plausible.
+- **Hallucinated path**: Path contradicts investigation-log structure (wrong directory depth, wrong naming convention, module doesn't match project layout). Flag as hallucination.
+
+Score:
+- **1.0**: All paths either confirmed by investigation-log or structurally consistent with it
+- **0.5**: 1–2 paths are unverifiable or inconsistent but no clear contradictions
+- **0.0**: One or more paths directly contradict investigation-log (e.g., file claimed to exist that doesn't, path uses wrong module structure)
+
+### Metric 2: `module_reference_accuracy` (threshold: 0.8)
+
+For each module, class, function, or API referenced:
+- Is it confirmed in investigation-log?
+- Does it use the correct import path?
+- Is the API usage consistent with what investigation-log shows?
+
+Score:
+- **1.0**: All references confirmed or consistent with investigation-log
+- **0.5**: Some references unverifiable (not mentioned in investigation-log, but plausible)
+- **0.0**: One or more references directly contradict investigation-log (wrong class name, wrong module path, API that doesn't exist in the codebase)
+
+### Metric 3: `existing_code_awareness` (threshold: 0.8)
+
+Does the plan correctly identify what already exists and what needs to be built?
+- Does it avoid reimplementing things investigation-log shows already exist?
+- Does it correctly identify files to modify vs files to create?
+- Does it correctly identify existing utilities/helpers it should reuse?
+- For any net-new code it proposes (especially utility/helper functions), does it explicitly verify no existing function provides the same or materially similar behavior?
+
+Score:
+- **1.0**: Plan correctly distinguishes existing vs new; reuses existing code where appropriate
+- **0.5**: Plan is neutral — doesn't claim things exist that don't, but misses some reuse opportunities
+- **0.0**: Plan proposes reimplementing code investigation-log confirms already exists, or claims files don't exist when they do
+
+## Scoring
+
+Compute `final_status`:
+- All 3 metrics ≥ threshold → `final_status = 1` (PASS)
+- Any metric < threshold → `final_status = 2` (FAIL)
+- investigation-log.md absent → `final_status = 2` (FAIL — unverifiable)
+
+## Output Format
+
+```json
+{
+  "type": "case_score",
+  "case_id": "codebase-grounding-judge",
+  "final_status": 1,
+  "metrics": [
+    {
+      "metric_name": "file_path_accuracy",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "Cite specific paths verified or contradicted."
+    },
+    {
+      "metric_name": "module_reference_accuracy",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "Cite specific module/class references verified or contradicted."
+    },
+    {
+      "metric_name": "existing_code_awareness",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "Cite specific reuse decisions or missed opportunities."
+    }
+  ]
+}
+```
+
+Return only valid JSON with no surrounding text.

--- a/plugins/judges/agents/convention-adherence-judge.md
+++ b/plugins/judges/agents/convention-adherence-judge.md
@@ -33,6 +33,7 @@ Extract from investigation-log.md the project's actual conventions:
 - Naming conventions (snake_case, camelCase, PascalCase for files/classes/functions)
 - File organization (where tests live, how modules are structured, directory layout)
 - Code patterns (error handling style, type annotation approach, logging patterns, async patterns)
+- Design patterns (gang of 4)
 - Tooling (test framework, linter, dependency management)
 
 Then evaluate how well the plan's proposals align:

--- a/plugins/judges/agents/convention-adherence-judge.md
+++ b/plugins/judges/agents/convention-adherence-judge.md
@@ -1,0 +1,100 @@
+---
+name: convention-adherence-judge
+description: Evaluates whether an implementation plan follows the conventions, patterns, and style found in the actual codebase, as documented in the investigation log.
+model: sonnet
+artifact: plan
+tools: Glob, Grep, Read, Agent
+---
+
+# Convention Adherence Judge
+
+You are evaluating whether an implementation plan proposes code that follows the conventions actually used in the codebase — naming, structure, patterns, tooling — or whether it imposes foreign conventions.
+
+A plan written without codebase context may propose idioms, structures, or tools that are inconsistent with what the project actually uses. This judge detects that gap.
+
+## Input Files
+
+Read from `$SYMPHONY_WORKDIR`:
+1. **investigation-log.md** — documents actual conventions: naming patterns, file structure, existing tools, testing approach, error handling style
+2. **plan.json** — the plan to evaluate
+3. **prd.md** — requirements context
+
+**If investigation-log.md is absent:** Invoke `@code:pre-explorer` to generate it:
+```
+WORKDIR=$SYMPHONY_WORKDIR. Explore the codebase and prepare context for plan drafting.
+Read the PRD in $SYMPHONY_WORKDIR, scan the codebase for relevant files and patterns.
+Write: requirements-extract.json, code-map.json, investigation-log.md to $SYMPHONY_WORKDIR.
+```
+If pre-explorer fails or investigation-log.md is still absent after invocation, score all metrics 0.5. Justification: "No investigation log — convention compliance unverifiable."
+
+## What to Evaluate
+
+Extract from investigation-log.md the project's actual conventions:
+- Naming conventions (snake_case, camelCase, PascalCase for files/classes/functions)
+- File organization (where tests live, how modules are structured, directory layout)
+- Code patterns (error handling style, type annotation approach, logging patterns, async patterns)
+- Tooling (test framework, linter, dependency management)
+
+Then evaluate how well the plan's proposals align:
+
+### Metric 1: `naming_convention_compliance` (threshold: 0.8)
+
+Do proposed names (files, classes, functions, variables) follow the project's established conventions?
+
+- **1.0**: All proposed names follow conventions documented in investigation-log
+- **0.5**: Mostly consistent with 1–2 minor deviations (wrong case style in one place, etc.)
+- **0.0**: Proposed names systematically contradict investigation-log conventions (e.g., camelCase files in a snake_case project, wrong test file naming pattern)
+
+### Metric 2: `structural_convention_compliance` (threshold: 0.8)
+
+Do proposed file locations and module organization follow the project's structure?
+
+- **1.0**: Proposed structure mirrors patterns found in investigation-log (tests alongside source, modules in right directories, config in right location)
+- **0.5**: Mostly correct with one structural inconsistency
+- **0.0**: Proposed structure fundamentally mismatches the project layout (e.g., proposing a `tests/` root directory in a project that co-locates tests, proposing a flat structure in a nested project)
+
+### Metric 3: `pattern_and_tooling_compliance` (threshold: 0.8)
+
+Do proposed code patterns and tools match what the project uses?
+
+- **1.0**: Proposed patterns (error handling, async approach, typing style, test framework) match investigation-log findings
+- **0.5**: Mostly consistent; one proposed tool or pattern differs from project conventions but isn't contradictory
+- **0.0**: Plan proposes tools or patterns that directly conflict with investigation-log (e.g., proposing `unittest` in a `pytest` project, proposing callbacks in an `async/await` codebase, ignoring existing abstractions)
+
+## Scoring
+
+- All 3 metrics ≥ threshold → `final_status = 1` (PASS)
+- Any metric < threshold → `final_status = 2` (FAIL)
+- investigation-log.md absent → `final_status = 2` (FAIL — unverifiable)
+
+## Output Format
+
+```json
+{
+  "type": "case_score",
+  "case_id": "convention-adherence-judge",
+  "final_status": 1,
+  "metrics": [
+    {
+      "metric_name": "naming_convention_compliance",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "Specific evidence from investigation-log vs plan."
+    },
+    {
+      "metric_name": "structural_convention_compliance",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "..."
+    },
+    {
+      "metric_name": "pattern_and_tooling_compliance",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "..."
+    }
+  ]
+}
+```
+
+Return only valid JSON with no surrounding text.

--- a/plugins/judges/skills/run-judges/SKILL.md
+++ b/plugins/judges/skills/run-judges/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-judges
-description: Orchestrate parallel judge agent execution, aggregate CaseScore results, write judges.json or code-judges.json, and validate output. Supports evaluating both implementation plans (13 judges) and code artifacts (11 judges) via --artifact-type parameter.
+description: Orchestrate parallel judge agent execution, aggregate CaseScore results, write judges.json or code-judges.json, and validate output. Supports evaluating both implementation plans (16 judges) and code artifacts (11 judges) via --artifact-type parameter.
 context: fork
 ---
 
@@ -8,13 +8,13 @@ context: fork
 
 ## Purpose
 
-Execute specialized judge agents in parallel to evaluate implementation plan quality (13 judges) or code quality (11 judges). Aggregates results into `$CLOSEDLOOP_WORKDIR/judges.json` (plan) or `$CLOSEDLOOP_WORKDIR/code-judges.json` (code) with validated output format.
+Execute specialized judge agents in parallel to evaluate implementation plan quality (16 judges) or code quality (11 judges). Aggregates results into `$CLOSEDLOOP_WORKDIR/judges.json` (plan) or `$CLOSEDLOOP_WORKDIR/code-judges.json` (code) with validated output format.
 
 ## Parameters
 
 **--artifact-type**: Artifact category to evaluate (plan | code), default: plan
 
-- **plan** (default): Evaluate implementation plan with 13 judges, 4 batches, output to judges.json
+- **plan** (default): Evaluate implementation plan with 16 judges, 4 batches, output to judges.json
 - **code**: Evaluate implemented code with 11 judges, 3 batches, output to code-judges.json
 
 ## Judge Input Contract (`judge-input.json`)
@@ -32,7 +32,7 @@ You are orchestrating quality evaluation for a ClosedLoop artifact (implementati
 **For plan artifacts (default):**
 1. Launch context-manager-for-judges agent to prepare compressed plan context
 2. Build `judge-input.json` with plan task/context mapping
-3. Launch all 13 judge agents in parallel batches
+3. Launch all 16 judge agents in parallel batches
 4. Aggregate their CaseScore outputs into a valid EvaluationReport
 5. Write the report to `$CLOSEDLOOP_WORKDIR/judges.json`
 6. Validate output structure and completeness
@@ -291,7 +291,7 @@ After validating `prd.md` and `plan.json`, resolve supporting context for plan j
 
 8. **Build plan-mode `judge-input.json`**
    - Set `evaluation_type` = `plan`.
-   - Set `task` to plan quality evaluation objective (13-plan-judge workflow).
+   - Set `task` to plan quality evaluation objective (16-plan-judge workflow).
    - Set `primary_artifact` to `plan-context.json` in normal mode.
    - In compatibility mode, set primary to `plan.json` and include `prd.md` as supporting.
    - Include `investigation-log.md` as supporting artifact when available.
@@ -340,11 +340,11 @@ fi
 The run-judges skill supports two artifact types with different judge configurations:
 
 ### Plan Artifacts (Default)
-- **Judges**: 13 total
+- **Judges**: 16 total
 - **Batches**: 4 sequential batches (max 4 concurrent per batch)
 - **Output**: `judges.json`
 - **Report ID**: `{RUN_ID}-judges`
-- **Validation**: `--category plan` (13 judges expected)
+- **Validation**: `--category plan` (16 judges expected)
 
 ### Code Artifacts (--artifact-type code)
 - **Judges**: 11 total (excludes goal-alignment-judge, verbosity-judge)
@@ -384,7 +384,7 @@ The run-judges skill supports two artifact types with different judge configurat
 
 <judge_batches>
 
-### Plan Artifact Judge Batches (13 judges, 4 batches)
+### Plan Artifact Judge Batches (16 judges, 4 batches)
 
 **Batch 1: Core Principles (DRY/SSOT/KISS + Organization)**
 
@@ -413,11 +413,14 @@ The run-judges skill supports two artifact types with different judge configurat
 | `judges:solid-open-closed-judge` | Open/Closed Principle adherence |
 | `judges:technical-accuracy-judge` | Technical accuracy (API usage, algorithms) |
 
-**Batch 4: Testing**
+**Batch 4: Plan Grounding + Testing**
 
 | Agent Type | Evaluates |
 |------------|-----------|
 | `judges:test-judge` | Test coverage, assertions, structure, best practices |
+| `judges:brownfield-accuracy-judge` | Reuse vs reimplementation, integration-point accuracy, scope accuracy against investigation findings |
+| `judges:codebase-grounding-judge` | File-path/module-reference accuracy and existing-code awareness grounded in investigation findings |
+| `judges:convention-adherence-judge` | Alignment with established naming, structural, and tooling conventions in the codebase |
 
 </judge_batches>
 
@@ -527,8 +530,8 @@ Each judge returns a **CaseScore** JSON object:
 ```
 
 **Continue-on-failure semantics:**
-- Even if ALL 13 judges fail, you MUST aggregate error CaseScores
-- Always produce a complete report with 13 CaseScore entries (plan) or 11 CaseScore entries (code)
+- Even if ALL 16 judges fail, you MUST aggregate error CaseScores
+- Always produce a complete report with 16 CaseScore entries (plan) or 11 CaseScore entries (code)
 - Never abort the workflow due to judge failures
 
 </error_handling>
@@ -568,7 +571,10 @@ output_path = $CLOSEDLOOP_WORKDIR / report_filename
     { /* CaseScore from solid-liskov-substitution-judge */ },
     { /* CaseScore from solid-open-closed-judge */ },
     { /* CaseScore from technical-accuracy-judge */ },
-    { /* CaseScore from test-judge */ }
+    { /* CaseScore from test-judge */ },
+    { /* CaseScore from brownfield-accuracy-judge */ },
+    { /* CaseScore from codebase-grounding-judge */ },
+    { /* CaseScore from convention-adherence-judge */ }
   ]
 }
 ```
@@ -600,7 +606,7 @@ output_path = $CLOSEDLOOP_WORKDIR / report_filename
 |-------|--------|---------------|
 | `report_id` | `{RUN_ID}-judges` or `{RUN_ID}-code-judges` | Extract RUN_ID from `$CLOSEDLOOP_WORKDIR` directory name, append suffix based on artifact type |
 | `timestamp` | ISO 8601 | Generate with `date -u +%Y-%m-%dT%H:%M:%SZ` |
-| `stats` | Array[CaseScore] | 13 CaseScore objects for plan, 11 for code (one per judge) |
+| `stats` | Array[CaseScore] | 16 CaseScore objects for plan, 11 for code (one per judge) |
 
 </output_structure>
 
@@ -649,7 +655,7 @@ uv run "$SCRIPT_PATH" --workdir "$CLOSEDLOOP_WORKDIR" --category "$CATEGORY"
 
 **Argument requirements:**
 - `--workdir` must be the **absolute path** to `$CLOSEDLOOP_WORKDIR`
-- `--category` must be `plan` (13 judges) or `code` (11 judges)
+- `--category` must be `plan` (16 judges) or `code` (11 judges)
 - This is where `judges.json` or `code-judges.json` is located
 
 </validation_workflow>
@@ -666,14 +672,17 @@ The script validates using strict Pydantic models:
 |-------|-------------|
 | **JSON syntax** | Valid JSON format |
 | **Required fields** | report_id, timestamp, stats array |
-| **Judge coverage** | All expected judges present (13 for plan, 11 for code) |
+| **Judge coverage** | All expected judges present (16 for plan, 11 for code) |
 | **Status values** | final_status ∈ {1, 2, 3} |
 | **Metric completeness** | Each judge has ≥1 metric |
 | **Report ID format** | Ends with '-judges' (plan) or '-code-judges' (code) |
 
-**Expected judge case_ids for plan artifacts (13 total):**
+**Expected judge case_ids for plan artifacts (16 total):**
 ```
+brownfield-accuracy-judge
 code-organization-judge
+codebase-grounding-judge
+convention-adherence-judge
 custom-best-practices-judge
 dry-judge
 goal-alignment-judge
@@ -781,8 +790,8 @@ Before marking this task complete, verify:
 - [ ] **Plan context validation** - `plan-context.json` exists, or compatibility mode explicitly activated
 - [ ] **Judge input contract** - `judge-input.json` exists with required fields
 - [ ] **Investigation context resolution** - `investigation-log.md` reused, generated via pre-explorer, or best-effort generated internally
-- [ ] **Parallel execution** - All 13 judges launched in 4 batches (max 4 per batch)
-- [ ] **Result aggregation** - Valid EvaluationReport with 13 CaseScore entries
+- [ ] **Parallel execution** - All 16 judges launched in 4 batches (max 4 per batch)
+- [ ] **Result aggregation** - Valid EvaluationReport with 16 CaseScore entries
 - [ ] **File output** - `judges.json` written to `$CLOSEDLOOP_WORKDIR`
 - [ ] **Validation passed** - Script exits with code 0 using `--category plan`
 
@@ -810,7 +819,7 @@ Before marking this task complete, verify:
 |---------------|------------|----------|
 | "Report file does not exist" | File not written to correct location | Verify `$CLOSEDLOOP_WORKDIR` is set; check write path matches artifact type (judges.json or code-judges.json) |
 | "Invalid JSON" | Syntax error in output file | Run `python3 -m json.tool "$CLOSEDLOOP_WORKDIR/[code-]judges.json"` to identify syntax error |
-| "Missing expected judges" | Incomplete batch execution | Verify all batches launched (4 for plan, 3 for code); check error CaseScores for failures; plan expects 13 judges, code expects 11 |
+| "Missing expected judges" | Incomplete batch execution | Verify all batches launched (4 for plan, 3 for code); check error CaseScores for failures; plan expects 16 judges, code expects 11 |
 | "final_status must be 1, 2, or 3" | Invalid status code | Use only: 1 (pass), 2 (fail), 3 (error) |
 | "report_id should end with '-judges'" | Incorrect ID format for plan | Use pattern: `{RUN_ID}-judges` for plan artifacts |
 | "report_id should end with '-code-judges'" | Incorrect ID format for code | Use pattern: `{RUN_ID}-code-judges` for code artifacts |
@@ -863,7 +872,7 @@ If a single judge Task call fails during execution:
 ### Plan Mode Execution Flow
 
 When `--artifact-type` is not specified or equals 'plan':
-- Execute standard 13-judge plan logic
+- Execute standard 16-judge plan logic
 - Launch 4 batches with existing judge assignments
 - Write to `judges.json` (not `code-judges.json`)
 - Launch context-manager-for-judges for plan context preparation


### PR DESCRIPTION
# Adding brownfield-accuracy, codebase-grounding, convention-adherence judges

This PR adds three codebase-grounding judges to implementation plan evaluation, enabling ClosedLoop to distinguish plans written with real codebase context from plans written without it. Plans are now scored on brownfield accuracy (reuse vs reimplementation, integration points, scope), codebase grounding (file-path/module-reference accuracy, hallucination detection), and convention adherence (naming, structure, tooling alignment with the project).

## Key Changes

**Core Feature:**
- **brownfield-accuracy-judge** — Evaluates reuse vs reimplementation, integration-point accuracy, and scope accuracy against investigation-log findings. Detects plans that propose creating things that already exist or miss correct integration points.
- **codebase-grounding-judge** — Detects hallucinated file paths, nonexistent modules, and fabricated APIs by cross-referencing plan claims against investigation-log. Primary differentiator for CL vs OOTB plans.
- **convention-adherence-judge** — Evaluates plan alignment with naming, structural, and tooling conventions documented in the investigation log.
- All three judges run in Batch 4 (Plan Grounding + Testing) alongside test-judge; each uses investigation-log.md as ground truth and scores 0.5 / fails when it is absent.

**Supporting Changes:**
- Updated run-judges skill: plan evaluation from 13 → 16 judges, Batch 4 renamed to "Plan Grounding + Testing", expected case_ids, aggregation, validation, and troubleshooting docs updated.

**Impact:**
- Plan evaluation now produces 16 CaseScore entries (was 13). Update `validate_judge_report.py` JUDGE_REGISTRY to include `brownfield-accuracy-judge`, `codebase-grounding-judge`, and `convention-adherence-judge` for `--category plan` validation to pass.
