### PR TITLE
FEAT-84: speed up review pipeline and move orchestration into helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code-review v1.2.0
+
+#### Added
+- New `resolve-scope` subcommand in `code_review_helpers.py` -- deterministic scope resolution replacing inline shell logic for PR branch lookup, git fetch, base-ref overrides, and path filter preservation
+- New `fetch-intent` subcommand -- fetches PR description or commit messages as intent context for the Premise Reviewer
+- New `classify-intent` subcommand -- classifies diff intent (`feature`, `fix`, `refactor`, `mixed`) from PR metadata and file statuses for model routing
+- New `collect-findings` subcommand -- merges `agent_*.json` files and hygiene findings into a single `findings.json`, replacing inline Python-in-Bash merge logic
+- New `verdict` subcommand -- computes deterministic PR verdict (`approve`, `needs_attention`, `decline`) from validated findings, replacing inline orchestrator logic
+- New `prep-assets` subcommand -- copies `shared_prompt.txt` and `bha_suffix.txt` from plugin to CR_DIR in a single step, consolidating scattered `cp` commands
+- New `extract-patches` subcommand -- extracts per-partition and full-diff patches to disk with batched extraction for large diffs (>200 files)
+- New `bha_suffix.txt` prompt file -- Bug Hunter A persona and focus areas extracted from inline heredoc in `start.md`
+- Intent-aware model routing: Premise Reviewer uses Opus for fix/refactor/mixed intents, Sonnet for feature intents; BHA uses Opus for implementation partitions, Sonnet for test-only partitions
+- Mixed-partition splitting in `partition` subcommand -- separates test files from implementation files when impl LOC exceeds threshold
+- Agent cap enforcement via `--max-bha-agents` parameter in `partition`, computed from `route` output
+- Trivial partition merging -- partitions below 20 LOC are absorbed into same-type normal partitions
+- Cache status message (`status_kind`, `status_message`) appended to `cache_result.json` by `cache-check`, replacing orchestrator-side message formatting
+- `--exclude-test-partitions` flag on `cache-update` to skip caching files from Sonnet-reviewed test-only partitions
+- Self-discard validation rule (check 7) in `shared_prompt.txt` -- agents must discard findings they conclude are not actually problems
+
+#### Changed
+- Refactored `start.md` orchestrator to delegate workflow steps to Python subcommands instead of inline shell logic
+- `setup` subcommand now accepts `--cr-dir-prefix` and creates CR_DIR with random suffix, removing the need for the orchestrator to generate random directory names
+- `route` subcommand now accepts `--intent` parameter and outputs `max_bha_agents` for downstream partition cap enforcement
+- Reduced default partition LOC budget from 800 to 500
+
 ### judges v1.3.1
 
 #### Changed

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -23,9 +23,9 @@ plugins/code-review/
     github-review.md                 GitHub-mode constraints and output steps (loaded conditionally)
   tools/
     prompts/shared_prompt.txt        Shared reviewer constraints injected into every agent prompt
+    prompts/bha_suffix.txt           Bug Hunter A reviewer persona and focus areas
     python/code_review_helpers.py    Deterministic helper CLI (parse-diff, hygiene, partition, route, validate, cache, etc.)
     python/test_code_review_helpers.py   Unit tests for the helper CLI
-    python/test_validate_judge_report.py Tests for judge report validation
 ```
 
 ### Component Roles
@@ -36,6 +36,7 @@ plugins/code-review/
 | `github-review.md` | Loaded by the orchestrator only in GitHub mode. Contains PR metadata resolution, file-based handoff format for CI, and summary format |
 | `code_review_helpers.py` | Python CLI that handles all deterministic work: git diff parsing, hygiene pattern matching, file partitioning, risk scoring/model routing, finding validation, cache management, and GitHub comment posting |
 | `shared_prompt.txt` | Constraints injected into every reviewer agent prompt: file assignment rules, evidence standards, severity definitions, and output format |
+| `bha_suffix.txt` | Bug Hunter A reviewer persona and focus areas (syntax errors, security, state management, error handling, data transformations) — appended to the Bug Hunter A agent prompt |
 
 ## Commands
 
@@ -133,6 +134,13 @@ The helper script is a multi-subcommand Python CLI. The orchestrator invokes it 
 | `resolve-threads` | Resolves outdated bot review threads on a PR (GitHub mode) |
 | `session-tokens` | Collects token usage stats from the session |
 | `footer` | Computes the formatted review footer string |
+| `resolve-scope` | Resolves diff scope (branch, PR number, base ref, path filter) from CLI arguments and git context |
+| `fetch-intent` | Fetches context (PR description, recent commits) used to classify the diff intent |
+| `classify-intent` | Classifies the diff intent (feature, bugfix, refactor, etc.) for model routing |
+| `collect-findings` | Merges agent findings with hygiene findings into a single list |
+| `verdict` | Computes the PR verdict (APPROVED / NEEDS_ATTENTION / CHANGES_REQUESTED) from validated findings |
+| `prep-assets` | Copies prompt assets from the plugin root into the session CR_DIR |
+| `extract-patches` | Extracts git diff patches to per-file disk files for reviewer agents to read |
 
 ## GitHub CI Mode
 

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -55,17 +55,15 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 - Create the TodoWrite task list (depends on MODE and HYGIENE_ONLY)
 - If MODE=github: Read `${CLAUDE_PLUGIN_ROOT}/prompts/github-review.md` for GitHub-specific constraints and steps
 - Resolve HELPERS path: `echo "${CLAUDE_PLUGIN_ROOT}/tools/python/code_review_helpers.py"` — track the resolved path internally
-- Create CR_DIR: `mkdir -p .closedloop-ai/code-review/cr-<RANDOM>` — generate a unique suffix, track the resolved path internally
-- Run setup: `python <HELPERS> setup --mode <MODE> > <CR_DIR>/setup.json` — inline all resolved paths, NO shell variables
-- Read `<CR_DIR>/setup.json` for `CR_START_TIME`, `REPO_NAME`, `GLOBAL_CACHE`, and default `REVIEW_BRANCH`; initialize `CACHE_DIR=""` (final cache path is resolved after scope parsing)
+- Run setup with CR_DIR creation: `python <HELPERS> setup --mode <MODE> --cr-dir-prefix .closedloop-ai/code-review/cr-` -- read stdout JSON for `cr_dir`, `start_time`, `repo_name`, `current_branch`, `global_cache`. Then write the JSON to `<CR_DIR>/setup.json` for downstream helpers.
+- Initialize `CACHE_DIR=""` (final cache path is resolved after scope parsing)
+- Run prep-assets: `python <HELPERS> prep-assets --plugin-root <PLUGIN_ROOT> --cr-dir <CR_DIR>`
 - See: [Session Setup](#session-setup)
 
 ### Task 3: Parse scope and resolve diff
 - Mark todo "Parse scope and get diff data" as `in_progress`
-- If PR number: resolve `BASE_REF`, `HEAD_REF` via `gh pr view`, fetch `origin/<HEAD_REF>`, set `DIFF_SCOPE="origin/<BASE_REF>...origin/<HEAD_REF>"`, `REVIEW_BRANCH=<HEAD_REF>`, `DIFF_TIP="origin/<HEAD_REF>"`
-- If no PR number + local mode: set `DIFF_SCOPE`, `REVIEW_BRANCH` from local branch, `DIFF_TIP="HEAD"`
-- If no PR number + GitHub mode: leave `DIFF_SCOPE` unset (resolved in GitHub metadata step)
-- Apply `--base <ref>` override if set
+- Run Bash: `python <HELPERS> resolve-scope --mode <MODE> --setup-json <CR_DIR>/setup.json [--pr-number <N>] [--scope-args "<REMAINING_ARGS>"] [--base-ref-override <REF>] > <CR_DIR>/scope.json`
+- Read `<CR_DIR>/scope.json` for `DIFF_SCOPE`, `BASE_REF`, `HEAD_REF`, `REVIEW_BRANCH`, `DIFF_TIP`, `PR_NUMBER`, `PATH_FILTER`, `SCOPE_KIND`
 - Finalize `CACHE_DIR` now that scope/PR context is known (must happen before auto-incremental)
 - See: [Step 2 — Parse Arguments](#parse-arguments-remaining-after-flag-removal)
 
@@ -75,17 +73,20 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 - Print `<REVIEW_MODE_LINE>`
 - See: [Auto Incremental Mode](#auto-incremental-mode-phase-4--local-only)
 
-### Task 5: Get diff data (GitHub: also get PR metadata)
+### Task 5: Get diff data + fetch intent (GitHub: also get PR metadata)
 - GitHub mode: follow PR Metadata section from `github-review.md`
 - Run Bash: `python <HELPERS> parse-diff --scope=<DIFF_SCOPE> > <CR_DIR>/diff_data.json`
+- Run Bash: `python <HELPERS> fetch-intent --scope-kind <SCOPE_KIND> --cr-dir <CR_DIR> [--pr-number <N>] [--base-ref <BASE_REF>] [--diff-tip <DIFF_TIP>]`
+- Run Bash: `python <HELPERS> classify-intent --intent-context <CR_DIR>/intent_context.json --diff-data <CR_DIR>/diff_data.json > <CR_DIR>/intent.json`
+- Read `<CR_DIR>/intent.json` for `INTENT` value
 - Mark todo "Parse scope and get diff data" as `completed`
 - See: [Get Diff Data](#get-diff-data-both-modes), [GitHub Mode: Get PR Metadata](#github-mode-get-pr-metadata)
 
 ### Task 6: Compute prompt hash + cache check (if CACHE_DIR set)
-- Copy `shared_prompt.txt` from plugin to `<CR_DIR>`, write `bha_suffix.txt` to `<CR_DIR>`
+- Prompt assets already copied in Task 2 (prep-assets)
 - Compute `PROMPT_HASH` and `CONTEXT_KEY` using `<DIFF_TIP>`
 - Run cache-check via `python <HELPERS> cache-check ...`
-- Report cache status to user using the **exact** prescribed format
+- Print `cache_result.json -> status_message` to report cache status
 - Skip if `CACHE_DIR` is empty
 - See: [Step 2.1](#step-21-compute-prompt-hash--context-key-when-caching-is-active), [Step 2.2](#step-22-bha-cache-check-when-caching-is-active)
 
@@ -98,14 +99,16 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 
 ### Task 8: Route models + partition + extract patches
 - Mark todo "Assess scope and route models" as `in_progress`
-- Run route and partition subcommands
-- Pre-extract patches to `<CR_DIR>/patches_p{N}.txt` and `<CR_DIR>/patches_all.txt`
+- Run Bash: `python <HELPERS> route --diff-data <CR_DIR>/diff_data.json --critic-gates .claude/settings/critic-gates.json --intent <INTENT> > <CR_DIR>/route.json`
+- Read `<CR_DIR>/route.json` for `models`, `domain_critics`, `max_bha_agents`
+- Run Bash: `python <HELPERS> partition --diff-data <CR_DIR>/diff_data.json --loc-budget 500 --max-files 25 --max-bha-agents <MAX_BHA_AGENTS> > <CR_DIR>/partitions.json` (use `uncached_diff_data.json` when caching is active)
+- Run Bash: `python <HELPERS> extract-patches --partitions-file <CR_DIR>/partitions.json --diff-scope "<DIFF_SCOPE>" --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>`
 - Mark todo as `completed`
-- See: [Step 3](#step-3-assess-scope-and-route-models), [Step 4 — Partitioning](#file-partitioning-critical-for-large-diffs), [Pre-Extract Patches](#pre-extract-patches-to-disk-critical--eliminates-sub-agent-bash-dependency)
+- See: [Step 3](#step-3-assess-scope-and-route-models), [Step 4 — Partitioning](#file-partitioning-critical-for-large-diffs)
 
 ### Task 9: Spawn agents
 - Mark todo "Spawn reviewer agents in parallel" as `in_progress`
-- Copy `shared_prompt.txt` from plugin to `<CR_DIR>` if not already copied in Task 6
+- Prompt assets already in `<CR_DIR>` from Task 2 (prep-assets)
 - Spawn ALL agents using `subagent_type: "code:code-review-worker"` with `run_in_background: true`
 - Use the exact per-agent prompt template from the reference section
 - See: [Step 4 — Spawn Reviewer Agents](#step-4-spawn-reviewer-agents)
@@ -113,8 +116,9 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 ### Task 10: Collect + validate findings
 - Mark todo "Collect, normalize, and validate findings" as `in_progress`
 - Collect ALL agent outputs via `TaskOutput` (block=true for each)
-- Merge agent JSON files + hygiene findings, then run `python <HELPERS> validate ...`
-- Run cache-update if `CACHE_DIR` is set
+- Run Bash: `python <HELPERS> collect-findings --cr-dir <CR_DIR> --hygiene <CR_DIR>/hygiene.json`
+- Run Bash: `python <HELPERS> validate --findings <CR_DIR>/findings.json --diff-data <CR_DIR>/diff_data.json > <CR_DIR>/validate_output.json`
+- Run cache-update if `CACHE_DIR` is set (add `--exclude-test-partitions` flag)
 - Mark todo as `completed`
 - See: [Step 5](#step-5-collect-normalize-and-validate-findings), [Step 5.5](#step-55-bha-cache-update-when-caching-is-active)
 
@@ -129,7 +133,8 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 - See: [Review Footer](#review-footer-final-output)
 
 ### Task 13: PR verdict tag
-- Compute the deterministic verdict from validated findings and emit the `<pr_verdict>` tag
+- Run Bash: `python <HELPERS> verdict --validate-output <CR_DIR>/validate_output.json > <CR_DIR>/verdict.json`
+- Read `<CR_DIR>/verdict.json` and print the `tag` value as the last line of output
 - See: [PR Verdict](#pr-verdict)
 
 ---
@@ -223,45 +228,36 @@ If SINCE_LAST_REVIEW AND FULL_REVIEW:
 
 Resolve the helpers path and create a session-scoped working directory.
 
-**Step 1 — Resolve HELPERS path.** Run this single Bash command to discover the plugin root:
+**Step 1 -- Resolve HELPERS path.** Run this single Bash command to discover the plugin root:
 ```bash
 echo "${CLAUDE_PLUGIN_ROOT}/tools/python/code_review_helpers.py"
 ```
-Read the output. This is the resolved HELPERS path (e.g., `/Users/me/.claude/plugins/cache/closedloop-ai/code-review/1.24.0/tools/python/code_review_helpers.py`). Track it internally — **all subsequent Bash commands must inline this resolved path, NOT `$HELPERS`**.
+Read the output. This is the resolved HELPERS path. Track it internally -- **all subsequent Bash commands must inline this resolved path, NOT `$HELPERS`**. Also track `PLUGIN_ROOT` = resolved `${CLAUDE_PLUGIN_ROOT}`.
 
-**Step 2 — Create CR_DIR.** Generate a random 5-digit number as a suffix and create the directory:
+**Step 2 -- Run setup subcommand (creates CR_DIR):**
 ```bash
-mkdir -p .closedloop-ai/code-review/cr-38291
+python <HELPERS> setup --mode <MODE> --cr-dir-prefix .closedloop-ai/code-review/cr-
 ```
-Track the CR_DIR value internally (e.g., `.closedloop-ai/code-review/cr-38291`). **All subsequent commands must inline this resolved path, NOT `$CR_DIR`**. Generate a unique suffix yourself (e.g., a 5-digit random number) — do NOT use `$$` (it changes per shell invocation). Use this same `.closedloop-ai/code-review/cr-<RANDOM>` path in **all modes** including GitHub CI — do NOT use `$RUNNER_TEMP` or any shell variables.
-
-**Step 3 — Run setup subcommand:**
-```bash
-python <HELPERS> setup --mode <MODE> > <CR_DIR>/setup.json
-```
-Where `<HELPERS>`, `<MODE>`, and `<CR_DIR>` are the resolved literal values (no shell variables).
-
-Read `<CR_DIR>/setup.json` with the Read tool. It contains:
+Read stdout JSON. It contains:
 ```json
-{ "start_time": 1700000000, "repo_name": "my-repo", "current_branch": "feature-x", "global_cache": "1" }
+{ "start_time": 1700000000, "repo_name": "my-repo", "current_branch": "feature-x", "global_cache": "1", "cr_dir": ".closedloop-ai/code-review/cr-38291" }
 ```
 
 Assign from the JSON:
 - `CR_START_TIME` = `start_time`
 - `REPO_NAME` = `repo_name`
 - `GLOBAL_CACHE` = `global_cache`
+- `CR_DIR` = `cr_dir` (the setup helper creates this directory with a random suffix)
 
-The `current_branch` value is used as the default `REVIEW_BRANCH` in Step 2 (overridden when a PR number is provided).
+Write the JSON to `<CR_DIR>/setup.json` so downstream helpers can read it.
 
-Initialize cache path as empty in session setup. Final cache selection happens in Step 2
-after scope parsing (so PR-based legacy cache can use `PR_NUMBER` when available):
+**Step 3 -- Copy prompt assets to CR_DIR:**
 ```bash
-CACHE_DIR=""
+python <HELPERS> prep-assets --plugin-root <PLUGIN_ROOT> --cr-dir <CR_DIR>
 ```
+This copies `shared_prompt.txt` and `bha_suffix.txt` from the plugin to `<CR_DIR>`. Both cache and non-cache paths use these assets.
 
-`CACHE_DIR` stays empty until finalized in Step 2 after scope parsing (so `PR_NUMBER` is available for legacy cache paths).
-
-`CR_DIR` isolates temp files. All intermediate data (shared prompt, agent findings, PR metadata) goes here.
+Initialize `CACHE_DIR=""` -- final cache path is resolved after scope parsing.
 
 ---
 
@@ -269,34 +265,17 @@ CACHE_DIR=""
 
 Mark todo "Parse scope and get diff data" as `in_progress`.
 
-### Parse Arguments (remaining after flag removal)
+### Resolve Scope (via Python helper)
 
-**If a PR number is provided (either mode)** — remaining arg is a bare integer:
-- Store as `PR_NUMBER`
-- Resolve both branches: `gh pr view <PR_NUMBER> --json baseRefName,headRefName -q '.baseRefName,.headRefName'`
-  - `BASE_REF` = base branch (e.g. `main`)
-  - `HEAD_REF` = PR head branch (e.g. `feature-xyz`)
-- Fetch the PR head ref to ensure it's available locally: `git fetch origin <HEAD_REF> 2>/dev/null || true`
-- Set `DIFF_SCOPE="origin/${BASE_REF}...origin/${HEAD_REF}"`
-- Set `REVIEW_BRANCH=<HEAD_REF>` (used for auto-incremental state key — NOT the local checked-out branch)
+Run the `resolve-scope` subcommand to handle all scope resolution deterministically:
 
-**Important:** When a PR number is given, always diff `origin/BASE...origin/HEAD_REF`. Do NOT use bare `HEAD` — the user may be on a different local branch than the PR's head branch.
+```bash
+python <HELPERS> resolve-scope --mode <MODE> --setup-json <CR_DIR>/setup.json [--pr-number <N>] [--scope-args "<REMAINING_ARGS>"] [--base-ref-override <REF>] > <CR_DIR>/scope.json
+```
 
-**Otherwise:**
-- If MODE=local and empty or "branch": `DIFF_SCOPE="main...HEAD"`, `BASE_REF="main"`, `PATH_FILTER=""`
-- If "staged": `DIFF_SCOPE="--cached"`
-- If MODE=local and file paths: `PATH_FILTER="-- <files>"`, `DIFF_SCOPE="main...HEAD ${PATH_FILTER}"`, `BASE_REF="main"`
-- If MODE=github and no PR number: leave `DIFF_SCOPE` unset (GitHub metadata step resolves PR and sets it)
-- Set `REVIEW_BRANCH` from `current_branch` in `<CR_DIR>/setup.json` (already read in Task 2)
+Read `<CR_DIR>/scope.json` for: `DIFF_SCOPE`, `BASE_REF`, `HEAD_REF`, `REVIEW_BRANCH`, `DIFF_TIP`, `PR_NUMBER`, `PATH_FILTER`, `SCOPE_KIND`.
 
-**`--base <ref>` override** (Phase 3):
-If `BASE_REF_OVERRIDE` is set:
-- `BASE_REF = BASE_REF_OVERRIDE`
-- If PR number: `DIFF_SCOPE="origin/${BASE_REF_OVERRIDE}...origin/${HEAD_REF}"`
-- Otherwise (non-staged local scopes): `DIFF_SCOPE="origin/${BASE_REF_OVERRIDE}...HEAD ${PATH_FILTER}"`
-
-**Important:** Do NOT drop the file filter when `--base` is used with file-path scope.
-Preserve `PATH_FILTER` in the final `DIFF_SCOPE`.
+The helper handles PR branch lookup (`gh pr view`), `git fetch`, `origin/` prefixes, `--base` overrides, path filter preservation, and scope kind classification.
 
 ### Finalize Cache Path (must run here, after scope parsing)
 
@@ -375,26 +354,18 @@ Use these values for `total_loc` and file count reporting. The full diff data (i
 
 Mark todo as `completed`.
 
-### Fetch Intent Context (for Premise Reviewer)
+### Fetch Intent Context + Classify Intent (for Premise Reviewer)
 
-After `parse-diff` completes, fetch the stated motivation for the changes so the Premise Reviewer can evaluate whether they were necessary. Write the result to `<CR_DIR>/intent_context.json`.
+After `parse-diff` completes, fetch the stated motivation and classify intent:
 
-**If a PR number is set:**
 ```bash
-gh pr view <PR_NUMBER> --json title,body -q '{title: .title, body: .body, commits: ""}' > <CR_DIR>/intent_context.json 2>/dev/null || echo '{"title":"","body":"","commits":""}' > <CR_DIR>/intent_context.json
+python <HELPERS> fetch-intent --scope-kind <SCOPE_KIND> --cr-dir <CR_DIR> [--pr-number <PR_NUMBER>] [--base-ref <BASE_REF>] [--diff-tip <DIFF_TIP>]
+python <HELPERS> classify-intent --intent-context <CR_DIR>/intent_context.json --diff-data <CR_DIR>/diff_data.json > <CR_DIR>/intent.json
 ```
 
-**If local branch (no PR number) and DIFF_SCOPE is not `--cached`:**
-```bash
-echo "{\"title\":\"\",\"body\":\"\",\"commits\":$(git log <BASE_REF>..<DIFF_TIP> --oneline --no-merges --format='%s' | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))')}" > <CR_DIR>/intent_context.json
-```
+Read `<CR_DIR>/intent.json` for the `INTENT` value (`feature`, `fix`, `refactor`, or `mixed`). This is passed to the `route` subcommand for Premise Reviewer model routing.
 
-**If staged or file scope (no branch range available):**
-```bash
-echo '{"title":"","body":"","commits":""}' > <CR_DIR>/intent_context.json
-```
-
-The Premise Reviewer reads this file to understand what the author claims the changes accomplish. If the file is empty or has blank fields, the agent degrades gracefully by inferring intent from the diff itself.
+The `fetch-intent` helper handles PR description retrieval (`gh pr view`), local branch commit messages (`git log`), and empty context for staged/file-path scopes. The Premise Reviewer reads `intent_context.json` directly.
 
 ---
 
@@ -402,32 +373,12 @@ The Premise Reviewer reads this file to understand what the author claims the ch
 
 **Skip this step if `CACHE_DIR` is empty.**
 
-The prompt hash is needed by cache-check, so copy the shared prompt **here** (before Step 2.5). The canonical copy ships at `${CLAUDE_PLUGIN_ROOT}/tools/prompts/shared_prompt.txt`.
-
-**SSOT design:** Write the canonical BHA suffix to `<CR_DIR>/bha_suffix.txt` here (the ONLY copy). Step 4 reads from this file instead of having a second inline copy.
+Prompt assets (`shared_prompt.txt` and `bha_suffix.txt`) were already copied to `<CR_DIR>` by `prep-assets` in Task 2. Compute the prompt hash:
 
 ```bash
-# Copy shared prompt from plugin (canonical copy — do NOT recreate via heredoc)
-cp "${CLAUDE_PLUGIN_ROOT}/tools/prompts/shared_prompt.txt" <CR_DIR>/shared_prompt.txt"
-
-# Write canonical BHA suffix (the ONLY copy)
-cat > <CR_DIR>/bha_suffix.txt <<'BHA_EOF'
-You are Bug Hunter A — a diff-only reviewer focused on correctness.
-
-Focus areas:
-- Syntax/type errors, null/undefined handling, logic bugs
-- Security: injection, auth bypass, path traversal, data exposure
-- State management: race conditions, stale closures, double-trigger patterns
-- Error handling: missing try-catch on async, unhandled promise rejections
-- Data transformations: off-by-one, incorrect parsing, wrong parameter types
-
-Use Read, Grep, and Glob for codebase context. Do NOT use Bash.
-BHA_EOF
-
-# Compute PROMPT_HASH and CONTEXT_KEY
 python <HELPERS> compute-hashes \
-  --shared-prompt <CR_DIR>/shared_prompt.txt" \
-  --bha-suffix <CR_DIR>/bha_suffix.txt" \
+  --shared-prompt <CR_DIR>/shared_prompt.txt \
+  --bha-suffix <CR_DIR>/bha_suffix.txt \
   --diff-tip <DIFF_TIP> \
   --base-ref "<BASE_REF>" \
   > <CR_DIR>/hashes.json
@@ -466,18 +417,7 @@ This produces three files:
 - `<CR_DIR>/agent_cached_bha.json` — cached BHA findings (glob-compatible with `agent_*`)
 - `<CR_DIR>/uncached_diff_data.json` — filtered diff_data with only uncached files
 
-Read `<CR_DIR>/cache_result.json` and report the cache status to the user:
-
-```
-If stats.cached > 0:
-  "BHA Cache: {cached}/{total_files} files cached ({hit_rate_pct}% hit rate) — {cached} files skip BHA review"
-Else if first run (empty cache):
-  "BHA Cache: first run — building cache for next review"
-Else:
-  "BHA Cache: 0/{total_files} files cached (all files changed since last review)"
-```
-
-On first run (empty cache), all files will be uncached — zero overhead vs today.
+Read `<CR_DIR>/cache_result.json` and print the `status_message` field to report cache status.
 
 ---
 
@@ -534,19 +474,20 @@ Mark todo as completed. EXIT — do not proceed to Step 3 or beyond.
 
 Mark todo "Assess scope and route models" as `in_progress`.
 
-Run the `route` subcommand to compute risk scores and model routing:
+Run the `route` subcommand to compute risk scores and model routing. Pass the `INTENT` value from `<CR_DIR>/intent.json` (classified in Task 5):
 
 ```bash
-python <HELPERS> route --diff-data <CR_DIR>/diff_data.json --critic-gates .claude/settings/critic-gates.json > <CR_DIR>/route.json
+python <HELPERS> route --diff-data <CR_DIR>/diff_data.json --critic-gates .claude/settings/critic-gates.json --intent <INTENT> > <CR_DIR>/route.json
 ```
 
 Read `<CR_DIR>/route.json` with the Read tool.
 
 The script outputs:
-- **size_category**: "Small" (≤500), "Medium" (501-2000), or "Large" (2001+)
-- **models**: Model assignments for each agent role (bug_hunter_a, bug_hunter_b, unified_auditor, premise_reviewer)
+- **size_category**: "Small" (<=500), "Medium" (501-2000), or "Large" (2001+)
+- **models**: Model assignments for each agent role. `bug_hunter_a` is `{"default": "opus", "test_only": "sonnet"}`. `premise_reviewer` is "opus" (fix/refactor/mixed) or "sonnet" (feature).
 - **high_risk_files**: Top 5 files by risk score
 - **domain_critics**: Selected domain critics from critic-gates.json (max 1)
+- **max_bha_agents**: Maximum BHA partitions (9 minus non-BHA agents). Pass this to `--max-bha-agents` on the partition call.
 
 Report to user: model routing decision, which agents will run (including Premise Reviewer), and domain critics (if any).
 
@@ -576,13 +517,13 @@ Mark todo "Spawn reviewer agents in parallel" as `in_progress`.
 
 | Agent | Instances | Model | Partitioned? | Focus |
 |-------|-----------|-------|-------------|-------|
-| **Bug Hunter A** | 1 per partition | Opus (all sizes) | Yes | Diff-only: correctness, security, logic bugs, error handling |
+| **Bug Hunter A** | 1 per partition | Opus (impl) / Sonnet (test-only) | Yes | Diff-only: correctness, security, logic bugs, error handling |
 | **Bug Hunter B** | 1 total | Sonnet | No (full file list) | Cross-file: DRY, API contracts, pattern consistency, imports |
 | **Unified Auditor** | 1 total | Sonnet | No (full file list) | CLAUDE.md rules + architectural conventions |
 | **Domain Critic** | 0-1 | Sonnet | No (full file list) | From critic-gates.json (capped at 1) |
-| **Premise Reviewer** | 1 total | Opus | No (full file list) | Questions whether changes were necessary at all |
+| **Premise Reviewer** | 1 total | Per route.json | No (full file list) | Questions whether changes were necessary at all |
 
-**Max agents = partitions + 4** (BHB + Auditor + Premise + 0-1 domain). Hard cap at 9.
+**Cap enforcement is handled by the `partition` subcommand via `--max-bha-agents`.** The orchestrator reads the partition count from `partitions.json` and spawns one BHA agent per partition -- no further merging needed.
 
 ### File Partitioning (Critical for Large Diffs)
 
@@ -594,10 +535,10 @@ When caching is active (`CACHE_DIR` is set), partition only uncached files. Othe
 
 ```bash
 # Caching active: use uncached_diff_data.json (from cache-check)
-python <HELPERS> partition --diff-data <CR_DIR>/uncached_diff_data.json --loc-budget 800 --max-files 25 > <CR_DIR>/partitions.json
+python <HELPERS> partition --diff-data <CR_DIR>/uncached_diff_data.json --loc-budget 500 --max-files 25 --max-bha-agents <MAX_BHA_AGENTS> > <CR_DIR>/partitions.json
 
 # No caching: use full diff_data.json
-python <HELPERS> partition --diff-data <CR_DIR>/diff_data.json --loc-budget 800 --max-files 25 > <CR_DIR>/partitions.json
+python <HELPERS> partition --diff-data <CR_DIR>/diff_data.json --loc-budget 500 --max-files 25 --max-bha-agents <MAX_BHA_AGENTS> > <CR_DIR>/partitions.json
 ```
 
 Read `<CR_DIR>/partitions.json` with the Read tool.
@@ -609,34 +550,17 @@ The script performs greedy bin-packing (sorted by LOC descending), splits oversi
 - Each `files[]` entry may include optional `line_range: [start, end]` when a large file is split by hunks
 - **test_file_paths**: Array of detected test file paths
 
-### Pre-Extract Patches to Disk (CRITICAL — eliminates sub-agent Bash dependency)
+### Pre-Extract Patches to Disk (CRITICAL -- eliminates sub-agent Bash dependency)
 
-After partitioning, extract patches to disk files so agents can Read them without needing Bash permissions. Run these BEFORE spawning any agents:
+After partitioning, extract patches to disk files so agents can Read them without needing Bash permissions. Run this BEFORE spawning any agents:
 
-**Per-partition patches** (for BHA instances):
 ```bash
-# For each partition, extract its files' patches to a dedicated file
-# Example for partition 0 with files file1.ts file2.ts:
-git diff <DIFF_SCOPE> -- file1.ts file2.ts > <CR_DIR>/patches_p0.txt
-
-# Repeat for each partition (use a loop or multiple commands)
+python <HELPERS> extract-patches --partitions-file <CR_DIR>/partitions.json --diff-scope "<DIFF_SCOPE>" --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>
 ```
 
-If a partition file entry has `line_range`, include that range in `<files_assigned>`
-for the agent and treat it as a hard scope fence. This prevents duplicate reporting when
-multiple BHA partitions reference different hunks of the same file.
+This creates `patches_p{N}.txt` (one per partition) and `patches_all.txt` (full diff from all files in `diff_data.json`). When caching is active, partitions contain only uncached files, but `patches_all.txt` includes ALL files since BHB/Auditor/Premise review the full diff.
 
-**Full diff patches** (for BHB, Unified Auditor, Domain Critic — they review all files):
-```bash
-git diff <DIFF_SCOPE> > <CR_DIR>/patches_all.txt
-```
-
-If the full diff is very large (>200 files), batch the extraction:
-```bash
-# Extract in batches of 50 files, append to the same file
-git diff <DIFF_SCOPE> -- file1 file2 ... file50 > <CR_DIR>/patches_all.txt
-git diff <DIFF_SCOPE> -- file51 file52 ... file100 >> <CR_DIR>/patches_all.txt
-```
+If a partition file entry has `line_range`, include that range in `<files_assigned>` for the agent and treat it as a hard scope fence.
 
 ### Partition-to-Agent Mapping
 
@@ -650,7 +574,11 @@ Partitions are computed ONCE. Agents are mapped as follows:
 
 For BHB, Unified Auditor, Premise Reviewer, and Domain Critic, the `<files_assigned>` in their prompt lists ALL `files_to_review` (not a partition subset). They read the full diff from `<CR_DIR>/patches_all.txt`.
 
-**Total agents** = BHA instances (one per partition) + BHB (1) + Unified Auditor (1) + Premise Reviewer (1) + Domain Critic (0-1). **Cap at 9 total.** If over budget, merge smallest BHA partitions (allow up to 1200 LOC).
+**Total agents** = BHA instances (one per partition) + BHB (1) + Unified Auditor (1) + Premise Reviewer (1) + Domain Critic (0-1). Cap enforcement is handled by the `partition` subcommand.
+
+**BHA model selection per partition:**
+- If `partition.is_test_only` is true: use `route.json -> models.bug_hunter_a.test_only` (sonnet)
+- Otherwise: use `route.json -> models.bug_hunter_a.default` (opus)
 
 ### Shared Prompt — Write to File (CRITICAL for context budget)
 
@@ -660,12 +588,7 @@ The shared prompt is ~130 lines of static instructions (constraints, severity gu
 
 **CRITICAL**: Do NOT embed patch content in the agent prompt. Agents read pre-extracted patch files from disk. The orchestrator only passes the file list, statuses, and patch file path.
 
-**Step 4a: Copy shared prompt to `<CR_DIR>`.** Run this ONCE before spawning any agents. Skip if already copied in Step 2.1 (caching was active):
-
-```bash
-# Copy shared prompt from plugin (canonical copy — do NOT recreate via heredoc)
-[ -f <CR_DIR>/shared_prompt.txt" ] || cp "${CLAUDE_PLUGIN_ROOT}/tools/prompts/shared_prompt.txt" <CR_DIR>/shared_prompt.txt"
-```
+**Step 4a:** Prompt assets (`shared_prompt.txt`, `bha_suffix.txt`) are already in `<CR_DIR>` from Task 2 (`prep-assets`). No copy needed.
 
 ### Per-Agent Prompt Template (what the orchestrator embeds in each Task call)
 
@@ -778,7 +701,7 @@ Return findings in the standard JSON format.
 **Guard:** If critic-gates.json references a critic name that doesn't map to a known
 subagent type, use `subagent_type: "code:code-review-worker"` (the default for all domain critics).
 
-**Premise Reviewer** (always runs, model per routing table — `opus`, AGENT_ID `premise`):
+**Premise Reviewer** (always runs, model per routing table `route.json -> models.premise_reviewer`, AGENT_ID `premise`):
 ```
 You are the Premise Reviewer — you question whether the changes in this diff were necessary at all.
 
@@ -861,7 +784,7 @@ Call all `TaskOutput` calls in a **single message** (parallel) so they resolve t
 
 Mark todo "Collect, normalize, and validate findings" as `in_progress`.
 
-**All agent findings are on disk** in `<CR_DIR>/agent_*.json` files (each agent wrote its own file). The orchestrator does NOT need to parse or extract findings — just merge the files with Bash.
+**All agent findings are on disk** in `<CR_DIR>/agent_*.json` files (each agent wrote its own file). Use the `collect-findings` helper to merge them.
 
 ### Agent Failure Recovery
 
@@ -879,31 +802,14 @@ If any agent failed (context overflow, subscription limits, timeout) or its outp
 1. **Agent findings** — on disk in `<CR_DIR>/agent_*.json` files (one per agent)
 2. **Hygiene findings** — extract the `"findings"` array from `<CR_DIR>/hygiene.json` (written in Step 2.5)
 
-Merge and validate in one step:
+Merge and validate:
 
 ```bash
-python3 -c "
-import json, sys, glob
-all_f = []
-for path in sorted(glob.glob('<CR_DIR>/agent_*.json')):
-    try:
-        with open(path) as f:
-            data = json.load(f)
-        all_f.extend(data.get('findings', []) if isinstance(data, dict) else data)
-    except (json.JSONDecodeError, KeyError) as e:
-        print(f'Warning: skipping {path}: {e}', file=sys.stderr)
-try:
-    with open('<CR_DIR>/hygiene.json') as hf:
-        all_f.extend(json.load(hf).get('findings', []))
-except (OSError, json.JSONDecodeError) as e:
-    print(f'Warning: failed to read hygiene.json: {e}', file=sys.stderr)
-json.dump(all_f, sys.stdout)
-" > <CR_DIR>/findings.json
-
+python <HELPERS> collect-findings --cr-dir <CR_DIR> --hygiene <CR_DIR>/hygiene.json
 python <HELPERS> validate --findings <CR_DIR>/findings.json --diff-data <CR_DIR>/diff_data.json > <CR_DIR>/validate_output.json
 ```
 
-**Important:** If hygiene findings are omitted from this merge, they will bypass the validate pipeline entirely (no dedup, no normalization). Always include them.
+The `collect-findings` helper merges all `agent_*.json` files + hygiene findings into `<CR_DIR>/findings.json`. Malformed agent files are skipped with a warning.
 
 The script performs all mechanical validation in one pass:
 1. **Severity normalization**: Critical→BLOCKING, High→HIGH, Low→discard, unknown→MEDIUM+warning
@@ -946,12 +852,13 @@ python <HELPERS> cache-update \
   --schema-version 1 \
   --global-cache <GLOBAL_CACHE> \
   --context-key <CONTEXT_KEY> \
-  --partitions-file <CR_DIR>/partitions.json"
+  --partitions-file <CR_DIR>/partitions.json" \
+  --exclude-test-partitions
 ```
 
-This writes the updated manifest to `<CACHE_DIR>/manifest.json`. In GitHub mode, the `actions/cache` post-action saves this directory for subsequent workflow runs. In local mode, the `.claude/cr-cache-*` directory persists on disk across CLI sessions.
+This writes the updated manifest to `<CACHE_DIR>/manifest.json`. The `--exclude-test-partitions` flag skips caching files from `is_test_only=True` partitions (which were reviewed by Sonnet, not Opus). In GitHub mode, the `actions/cache` post-action saves this directory for subsequent workflow runs. In local mode, the `.claude/cr-cache-*` directory persists on disk across CLI sessions.
 
-**Important:** Use `diff_data.json` (full diff), NOT `uncached_diff_data.json`, so the update has patch hashes for all files. The `--reviewed-files` flag ensures only files that were actually reviewed by BHA agents get cached.
+**Important:** Use `diff_data.json` (full diff), NOT `uncached_diff_data.json`, so the update has patch hashes for all files.
 
 ---
 
@@ -1124,26 +1031,13 @@ Print a markdown horizontal rule (`---`) followed by the `footer_line` value fro
 
 ## PR Verdict
 
-After the footer, emit a single `<pr_verdict>` tag as the absolute last line of output. The verdict is deterministic, computed from validated findings:
+Run the verdict helper to compute the deterministic verdict:
 
-1. If any finding has `BLOCKING: true` → verdict is `"decline"`, reason: `"N blocking issue(s): [first title, ≤80 chars]"`
-2. If any Premise finding has priority 0 → verdict is `"decline"`, reason: `"Premise: [first title, ≤80 chars]"`
-3. If any HIGH-priority findings exist → verdict is `"needs_attention"`, reason: `"N high-priority finding(s) require attention"`
-4. Otherwise → verdict is `"approve"`, reason: `"No blocking or high-priority issues found"`
-
-Output exactly one line:
-
-```
-<pr_verdict>{"verdict":"decline","reason":"2 blocking issue(s): Missing null check in auth handler"}</pr_verdict>
+```bash
+python <HELPERS> verdict --validate-output <CR_DIR>/validate_output.json > <CR_DIR>/verdict.json
 ```
 
-or:
-
-```
-<pr_verdict>{"verdict":"approve","reason":"No blocking or high-priority issues found"}</pr_verdict>
-```
-
-Keep the reason under 120 characters. This tag is parsed by the ClosedLoop UI to render a verdict banner.
+Read `<CR_DIR>/verdict.json` and print the `tag` value as the absolute last line of output. This tag is parsed by the ClosedLoop UI to render a verdict banner.
 
 ---
 

--- a/plugins/code-review/tools/prompts/bha_suffix.txt
+++ b/plugins/code-review/tools/prompts/bha_suffix.txt
@@ -1,0 +1,10 @@
+You are Bug Hunter A — a diff-only reviewer focused on correctness.
+
+Focus areas:
+- Syntax/type errors, null/undefined handling, logic bugs
+- Security: injection, auth bypass, path traversal, data exposure
+- State management: race conditions, stale closures, double-trigger patterns
+- Error handling: missing try-catch on async, unhandled promise rejections
+- Data transformations: off-by-one, incorrect parsing, wrong parameter types
+
+Use Read, Grep, and Glob for codebase context. Do NOT use Bash.

--- a/plugins/code-review/tools/prompts/shared_prompt.txt
+++ b/plugins/code-review/tools/prompts/shared_prompt.txt
@@ -122,6 +122,7 @@ Before outputting your findings, reason through each one in <thinking> tags:
 4. Does my evidence support the assigned severity?
 5. Did I check for error handling that prevents this issue?
 6. Would the original author fix this if they knew? Or would they say "that's intentional"?
+7. If your analysis concludes the issue is NOT actually a problem (e.g., "this is fine", "not an issue"), DISCARD it — do not include it in your output.
 
 Then output your JSON report.
 

--- a/plugins/code-review/tools/python/code_review_helpers.py
+++ b/plugins/code-review/tools/python/code_review_helpers.py
@@ -17,7 +17,9 @@ import contextlib
 import hashlib
 import json
 import os
+import random
 import re
+import shutil
 import subprocess
 import sys
 from collections.abc import Generator
@@ -85,6 +87,12 @@ DIFF_HEADER_PARTS = 2
 # Risk scoring
 HIGH_LOC_THRESHOLD = 50
 
+# Partition post-processing
+TRIVIAL_PARTITION_THRESHOLD = 20
+DEFAULT_MAX_BHA_AGENTS = 5
+REBALANCE_LOC_BUDGET = 1200
+MIXED_PARTITION_SPLIT_THRESHOLD = 50
+
 # Validation thresholds
 CONFIDENCE_DISCARD_THRESHOLD = 0.5
 LINE_TOLERANCE = 3
@@ -93,6 +101,12 @@ JACCARD_DEDUP_THRESHOLD = 0.6
 # Number formatting thresholds
 FORMAT_MILLION = 1_000_000
 FORMAT_THOUSAND = 1_000
+
+# Intent classification
+INTENT_FEATURE_WORDS = frozenset({"feat", "feature", "add", "implement", "new", "introduce", "create"})
+INTENT_FIX_WORDS = frozenset({"fix", "bug", "patch", "hotfix", "repair", "correct", "revert"})
+INTENT_REFACTOR_WORDS = frozenset({"refactor", "cleanup", "clean", "reorganize", "rename", "move", "restructure"})
+FEATURE_FILE_STATUS_THRESHOLD = 0.70
 
 
 # ---------------------------------------------------------------------------
@@ -701,6 +715,111 @@ def cmd_partition(args: argparse.Namespace) -> int:
 
     _flush_partition()
 
+    max_bha_agents: int = getattr(args, "max_bha_agents", DEFAULT_MAX_BHA_AGENTS) or DEFAULT_MAX_BHA_AGENTS
+
+    # Pass 1 -- Mixed-partition split
+    # For each partition with both test and non-test files where impl LOC >= threshold, split.
+    new_partitions: list[dict[str, Any]] = []
+    for part in partitions:
+        files = part["files"]
+        impl_files = [f for f in files if not f.get("is_test", False)]
+        test_files = [f for f in files if f.get("is_test", False)]
+        impl_loc = sum(f["loc"] for f in impl_files)
+        if impl_files and test_files and impl_loc >= MIXED_PARTITION_SPLIT_THRESHOLD:
+            # Split into impl-only and test-only sub-partitions
+            new_partitions.append({
+                "id": 0,  # renumbered later
+                "files": impl_files,
+                "total_loc": impl_loc,
+                "is_test_only": False,
+            })
+            test_loc = sum(f["loc"] for f in test_files)
+            new_partitions.append({
+                "id": 0,
+                "files": test_files,
+                "total_loc": test_loc,
+                "is_test_only": True,
+            })
+        else:
+            new_partitions.append(part)
+    partitions = new_partitions
+
+    # Pass 2 -- Agent cap enforcement
+    # If len(partitions) > max_bha_agents, merge the two smallest same-type partitions.
+    while len(partitions) > max_bha_agents:
+        # Try same-type merges first (test with test, impl with impl)
+        merged = False
+        for is_test in (True, False):
+            same_type = [
+                (i, p) for i, p in enumerate(partitions) if p["is_test_only"] == is_test
+            ]
+            if len(same_type) < 2:
+                continue
+            # Sort by total_loc ascending to find the two smallest
+            same_type.sort(key=lambda x: x[1]["total_loc"])
+            idx_a, part_a = same_type[0]
+            idx_b, part_b = same_type[1]
+            merged_loc = part_a["total_loc"] + part_b["total_loc"]
+            merged_file_count = len(part_a["files"]) + len(part_b["files"])
+            if merged_loc <= REBALANCE_LOC_BUDGET and merged_file_count <= max_files:
+                merged_files = part_a["files"] + part_b["files"]
+                new_part: dict[str, Any] = {
+                    "id": 0,
+                    "files": merged_files,
+                    "total_loc": merged_loc,
+                    "is_test_only": is_test,
+                }
+                # Remove the two originals (remove higher index first)
+                remove_indices = sorted([idx_a, idx_b], reverse=True)
+                for ri in remove_indices:
+                    partitions.pop(ri)
+                partitions.append(new_part)
+                merged = True
+                break
+        if not merged:
+            break  # No valid same-type merge possible, stop
+
+    # Pass 3 -- Trivial merge
+    # Merge partitions below TRIVIAL_PARTITION_THRESHOLD into same-type normal partitions.
+    trivial = [p for p in partitions if p["total_loc"] < TRIVIAL_PARTITION_THRESHOLD]
+    normal = [p for p in partitions if p["total_loc"] >= TRIVIAL_PARTITION_THRESHOLD]
+
+    for triv in trivial:
+        triv_is_test = triv["is_test_only"]
+        triv_files = triv["files"]
+        triv_loc = triv["total_loc"]
+
+        # Find best merge target: prefer same-type, fallback to any
+        same_type_targets = [
+            p for p in normal if p["is_test_only"] == triv_is_test and len(p["files"]) + len(triv_files) <= max_files
+        ]
+        any_type_targets = [
+            p for p in normal if len(p["files"]) + len(triv_files) <= max_files
+        ]
+
+        target = None
+        if same_type_targets:
+            # Merge into smallest same-type
+            target = min(same_type_targets, key=lambda p: p["total_loc"])
+        elif any_type_targets:
+            # Fallback: merge into smallest any-type
+            target = min(any_type_targets, key=lambda p: p["total_loc"])
+
+        if target is not None:
+            target["files"] = target["files"] + triv_files
+            target["total_loc"] += triv_loc
+            # Recompute is_test_only
+            target["is_test_only"] = all(f.get("is_test", False) for f in target["files"])
+        else:
+            # No valid merge target — keep trivial partition as-is
+            normal.append(triv)
+
+    partitions = normal
+
+    # Renumber IDs sequentially
+    for idx, part in enumerate(partitions):
+        part["id"] = idx
+
     json.dump(
         {"partitions": partitions, "test_file_paths": test_file_paths},
         sys.stdout,
@@ -757,12 +876,14 @@ def cmd_route(args: argparse.Namespace) -> int:
     else:
         size_category = "Large"
 
-    # Model routing — BHA is always Opus, other agents always Sonnet
-    models: dict[str, str] = {
-        "bug_hunter_a": "opus",
+    # Model routing — BHA impl uses Opus, test-only uses Sonnet; other agents always Sonnet
+    intent: str = getattr(args, "intent", "mixed") or "mixed"
+    premise_model = "opus" if intent in ("fix", "refactor", "mixed") else "sonnet"
+    models: dict[str, Any] = {
+        "bug_hunter_a": {"default": "opus", "test_only": "sonnet"},
         "bug_hunter_b": "sonnet",
         "unified_auditor": "sonnet",
-        "premise_reviewer": "opus",
+        "premise_reviewer": premise_model,
     }
 
     # Risk scoring for high-risk files (large diffs)
@@ -802,6 +923,8 @@ def cmd_route(args: argparse.Namespace) -> int:
 
     selected_domain_critics = sorted(set(selected_domain_critics))[:max_domain_critics]
 
+    max_bha_agents = 9 - 3 - len(selected_domain_critics)  # 3 = BHB + Auditor + Premise
+
     json.dump(
         {
             "size_category": size_category,
@@ -809,6 +932,7 @@ def cmd_route(args: argparse.Namespace) -> int:
             "models": models,
             "high_risk_files": high_risk_files,
             "domain_critics": selected_domain_critics,
+            "max_bha_agents": max_bha_agents,
         },
         sys.stdout,
         indent=2,
@@ -1434,6 +1558,62 @@ def cmd_cache_check(args: argparse.Namespace) -> int:
     )
 
 
+def _compute_cache_status(
+    stats: dict[str, Any],
+    manifest: dict[str, Any],
+    fallback_error: bool,
+    manifest_file_existed: bool = False,
+) -> tuple[str, str]:
+    """Compute status_kind and status_message for cache_result.json."""
+    if fallback_error:
+        status_kind = "fallback_error"
+        msg = "BHA Cache: unavailable (fallback to full review)"
+    elif stats["cached"] > 0:
+        status_kind = "hits"
+        msg = (
+            f"BHA Cache: {stats['cached']}/{stats['total_files']} files cached "
+            f"({stats['hit_rate_pct']}% hit rate) -- "
+            f"{stats['cached']} files skip BHA review"
+        )
+    elif not manifest and not manifest_file_existed:
+        # File genuinely absent (first run), not corrupt
+        status_kind = "first_run"
+        msg = "BHA Cache: first run -- building cache for next review"
+    elif not manifest and manifest_file_existed:
+        # File existed but was empty/corrupt -- treat as error, not first run
+        status_kind = "fallback_error"
+        msg = "BHA Cache: unavailable (corrupt manifest, fallback to full review)"
+    else:
+        status_kind = "all_changed"
+        msg = (
+            f"BHA Cache: 0/{stats['total_files']} files cached "
+            f"(all files changed since last review)"
+        )
+    return status_kind, msg
+
+
+def _append_cache_status(
+    output_dir: Path,
+    manifest: dict[str, Any],
+    fallback_error: bool,
+    manifest_file_existed: bool = False,
+) -> None:
+    """Add status_kind and status_message to the written cache_result.json."""
+    result_path = output_dir / "cache_result.json"
+    try:
+        with open(result_path) as f:
+            cache_result = json.load(f)
+        stats = cache_result.get("stats", {})
+        status_kind, msg = _compute_cache_status(stats, manifest, fallback_error, manifest_file_existed)
+        cache_result["status_kind"] = status_kind
+        cache_result["status_message"] = msg
+        with open(result_path, "w") as f:
+            json.dump(cache_result, f, indent=2)
+            f.write("\n")
+    except (OSError, json.JSONDecodeError):
+        pass
+
+
 def _cmd_cache_check_v1(  # noqa: PLR0913
     cache_dir: Path,
     output_dir: Path,
@@ -1445,6 +1625,7 @@ def _cmd_cache_check_v1(  # noqa: PLR0913
     prompt_hash: str,
 ) -> int:
     """Legacy V1 cache-check path."""
+    manifest_file_existed = (cache_dir / CACHE_MANIFEST_FILENAME).exists()
     manifest = _load_manifest(cache_dir)
 
     cached_files: list[str] = []
@@ -1469,6 +1650,7 @@ def _cmd_cache_check_v1(  # noqa: PLR0913
     _write_cache_output_files(
         output_dir, cached_files, uncached_files, cached_findings, diff_data, hit_rate,
     )
+    _append_cache_status(output_dir, manifest, fallback_error=False, manifest_file_existed=manifest_file_existed)
 
     summary = (
         f"Cache: {len(cached_files)}/{total} files hit ({hit_rate:.0f}%), "
@@ -1492,6 +1674,8 @@ def _cmd_cache_check_v2(  # noqa: PLR0913
     lock_path = cache_dir / CACHE_LOCK_FILENAME
     migration = False
     fallback: str | None = None
+    manifest: dict[str, Any] = {}
+    manifest_file_existed = (cache_dir / CACHE_MANIFEST_FILENAME).exists()
 
     try:
         with _manifest_lock(lock_path, exclusive=False):
@@ -1534,6 +1718,7 @@ def _cmd_cache_check_v2(  # noqa: PLR0913
     _write_cache_output_files(
         output_dir, cached_files, uncached_files, cached_findings, diff_data, hit_rate,
     )
+    _append_cache_status(output_dir, manifest, fallback_error=fallback is not None, manifest_file_existed=manifest_file_existed)
 
     # Observability: JSON line to stdout
     obs = {
@@ -1602,6 +1787,22 @@ def cmd_cache_update(args: argparse.Namespace) -> int:
             ]
         except (OSError, json.JSONDecodeError, KeyError) as exc:
             print(f"Warning: failed to read partitions file: {exc}", file=sys.stderr)
+
+    exclude_test = getattr(args, "exclude_test_partitions", False)
+    if exclude_test and partitions_file:
+        try:
+            with open(partitions_file) as pf:
+                pdata = json.load(pf)
+            test_files = {
+                entry["file"]
+                for part in pdata.get("partitions", [])
+                if part.get("is_test_only", False)
+                for entry in part.get("files", [])
+            }
+            reviewed_files = [f for f in reviewed_files if f not in test_files]
+        except (OSError, json.JSONDecodeError, KeyError):
+            pass  # Fall through to existing behavior
+
     if not reviewed_files:
         reviewed_files = list(findings_by_file.keys())
 
@@ -2144,6 +2345,166 @@ def cmd_session_tokens(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Subcommand: resolve-scope
+# ---------------------------------------------------------------------------
+
+
+def cmd_resolve_scope(args: argparse.Namespace) -> int:
+    """Resolve diff scope from mode, pr-number, and scope-args."""
+    mode: str = args.mode
+    pr_number: int | None = args.pr_number
+    scope_args: str = args.scope_args or ""
+    base_ref_override: str | None = args.base_ref_override
+    setup_json_path: str = args.setup_json
+
+    # Read current_branch from setup.json
+    try:
+        with open(setup_json_path) as f:
+            setup_data = json.load(f)
+        current_branch: str = setup_data.get("current_branch", "HEAD")
+    except (OSError, json.JSONDecodeError):
+        current_branch = "HEAD"
+
+    diff_scope = ""
+    base_ref = "main"
+    head_ref = current_branch
+    review_branch = current_branch
+    diff_tip = "HEAD"
+    path_filter = ""
+    scope_kind = "branch"
+
+    if pr_number is not None:
+        # Fetch PR base/head from gh
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "view", str(pr_number), "--json", "baseRefName,headRefName",
+                 "-q", ".baseRefName,.headRefName"],
+                capture_output=True, text=True, check=True,
+            )
+            lines = result.stdout.strip().splitlines()
+            base_ref = lines[0].strip() if len(lines) > 0 else "main"
+            head_ref = lines[1].strip() if len(lines) > 1 else current_branch
+        except subprocess.CalledProcessError:
+            base_ref = "main"
+            head_ref = current_branch
+
+        # Fetch origin head (allow failure)
+        subprocess.run(
+            ["git", "fetch", "origin", head_ref],
+            capture_output=True, text=True,
+        )
+
+        diff_scope = f"origin/{base_ref}...origin/{head_ref}"
+        diff_tip = f"origin/{head_ref}"
+        scope_kind = "pr"
+        review_branch = head_ref
+
+    elif mode == "local":
+        if not scope_args or scope_args.strip() in ("", "branch"):
+            diff_scope = "main...HEAD"
+            scope_kind = "branch"
+        elif scope_args.strip() == "staged":
+            diff_scope = "--cached"
+            scope_kind = "staged"
+        else:
+            # Treat scope_args as file paths
+            files = scope_args.strip()
+            diff_scope = f"main...HEAD -- {files}"
+            path_filter = f"-- {files}"
+            scope_kind = "file_paths"
+
+    elif mode == "github":
+        # GitHub mode, no PR number: leave unset
+        diff_scope = ""
+        scope_kind = "github_pending"
+
+    # Apply base-ref override if provided
+    if base_ref_override:
+        if scope_kind == "pr":
+            diff_scope = f"origin/{base_ref_override}...origin/{head_ref}"
+        elif path_filter:
+            diff_scope = f"origin/{base_ref_override}...HEAD {path_filter}"
+        else:
+            diff_scope = f"origin/{base_ref_override}...HEAD"
+        base_ref = base_ref_override
+
+    result_out = {
+        "diff_scope": diff_scope,
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "review_branch": review_branch,
+        "diff_tip": diff_tip,
+        "pr_number": pr_number,
+        "path_filter": path_filter,
+        "scope_kind": scope_kind,
+    }
+    json.dump(result_out, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: fetch-intent
+# ---------------------------------------------------------------------------
+
+
+def cmd_fetch_intent(args: argparse.Namespace) -> int:
+    """Fetch intent context (PR description or commit messages) for premise review."""
+    pr_number: int | None = args.pr_number
+    base_ref: str = args.base_ref
+    diff_tip: str = args.diff_tip
+    scope_kind: str = args.scope_kind
+    cr_dir = Path(args.cr_dir)
+
+    intent_data: dict[str, str] = {"title": "", "body": "", "commits": ""}
+    source = "empty"
+
+    if pr_number is not None:
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "view", str(pr_number), "--json", "title,body"],
+                capture_output=True, text=True, check=True,
+            )
+            pr_json = json.loads(result.stdout)
+            intent_data = {
+                "title": pr_json.get("title", ""),
+                "body": pr_json.get("body", ""),
+                "commits": "",
+            }
+            source = "pr"
+        except (subprocess.CalledProcessError, json.JSONDecodeError):
+            # Graceful fallback to empty context
+            intent_data = {"title": "", "body": "", "commits": ""}
+            source = "empty"
+
+    elif scope_kind == "branch":
+        try:
+            result = subprocess.run(
+                ["git", "log", f"{base_ref}..{diff_tip}",
+                 "--oneline", "--no-merges", "--format=%s"],
+                capture_output=True, text=True, check=True,
+            )
+            commits_text = result.stdout.strip()
+            intent_data = {"title": "", "body": "", "commits": commits_text}
+            source = "commits"
+        except subprocess.CalledProcessError:
+            intent_data = {"title": "", "body": "", "commits": ""}
+            source = "empty"
+
+    # Otherwise (staged, file_paths, github_pending, etc.): empty context
+
+    intent_path = cr_dir / "intent_context.json"
+    with open(intent_path, "w") as f:
+        json.dump(intent_data, f, indent=2)
+        f.write("\n")
+
+    result_out = {"path": str(intent_path), "source": source}
+    json.dump(result_out, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Subcommand: setup
 # ---------------------------------------------------------------------------
 
@@ -2175,16 +2536,21 @@ def cmd_setup(args: argparse.Namespace) -> int:
     else:
         global_cache = "1"
 
-    json.dump(
-        {
-            "start_time": start_time,
-            "repo_name": repo_name,
-            "current_branch": current_branch,
-            "global_cache": global_cache,
-        },
-        sys.stdout,
-        indent=2,
-    )
+    output: dict[str, Any] = {
+        "start_time": start_time,
+        "repo_name": repo_name,
+        "current_branch": current_branch,
+        "global_cache": global_cache,
+    }
+
+    cr_dir_prefix: str | None = getattr(args, "cr_dir_prefix", None)
+    if cr_dir_prefix is not None:
+        suffix = random.randint(10000, 99999)
+        cr_dir = f"{cr_dir_prefix}{suffix}"
+        os.makedirs(cr_dir, exist_ok=True)
+        output["cr_dir"] = cr_dir
+
+    json.dump(output, sys.stdout, indent=2)
     sys.stdout.write("\n")
     return 0
 
@@ -2595,6 +2961,301 @@ def cmd_finalize_cache(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Subcommand: classify-intent
+# ---------------------------------------------------------------------------
+
+
+def _classify_intent(
+    title: str,
+    body: str,
+    commits: str,
+    file_statuses: dict[str, str],
+) -> str:
+    """Classify the intent of a diff as feature, fix, refactor, or mixed.
+
+    Uses stem-prefix matching on tokenized text so inflected forms like
+    "fixes" (starts with "fix") and "adds" (starts with "add") are matched
+    without enumerating every variant.
+    """
+    # Use first line of body only -- full body is noisy
+    body_first_line = body.split("\n")[0] if body else ""
+    combined = " ".join(filter(None, [title, body_first_line, commits]))
+    tokens = re.split(r"[^a-z]+", combined.lower())
+
+    has_feature = any(
+        tok.startswith(w) for tok in tokens for w in INTENT_FEATURE_WORDS if tok
+    )
+    has_fix = any(
+        tok.startswith(w) for tok in tokens for w in INTENT_FIX_WORDS if tok
+    )
+    has_refactor = any(
+        tok.startswith(w) for tok in tokens for w in INTENT_REFACTOR_WORDS if tok
+    )
+
+    # Boost toward "feature" if majority of files are newly added
+    if file_statuses:
+        added_count = sum(1 for s in file_statuses.values() if s == "added")
+        if added_count / len(file_statuses) >= FEATURE_FILE_STATUS_THRESHOLD:
+            has_feature = True
+
+    matches = [c for c, flag in [("feature", has_feature), ("fix", has_fix), ("refactor", has_refactor)] if flag]
+    if len(matches) == 1:
+        return matches[0]
+    return "mixed"
+
+
+def cmd_classify_intent(args: argparse.Namespace) -> int:
+    """Classify diff intent for model routing."""
+    intent_context_path: str = args.intent_context
+    diff_data_path: str | None = getattr(args, "diff_data", None)
+
+    try:
+        with open(intent_context_path) as f:
+            ctx = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Error reading intent context: {exc}", file=sys.stderr)
+        return 1
+
+    title = str(ctx.get("title", ""))
+    body = str(ctx.get("body", ""))
+    commits = str(ctx.get("commits", ""))
+
+    file_statuses: dict[str, str] = {}
+    if diff_data_path:
+        try:
+            with open(diff_data_path) as f:
+                diff_data = json.load(f)
+            file_statuses = diff_data.get("file_statuses", {})
+        except (OSError, json.JSONDecodeError):
+            pass  # Proceed without file statuses
+
+    intent = _classify_intent(title, body, commits, file_statuses)
+    json.dump({"intent": intent}, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: collect-findings
+# ---------------------------------------------------------------------------
+
+
+def cmd_collect_findings(args: argparse.Namespace) -> int:
+    """Merge agent findings and hygiene findings into a single JSON file."""
+    cr_dir = Path(args.cr_dir)
+    output_filename: str = args.output
+    hygiene_path: str | None = getattr(args, "hygiene", None)
+
+    findings: list[Any] = []
+    agent_files: list[str] = []
+
+    # Glob agent_*.json files in cr_dir
+    for agent_file in sorted(cr_dir.glob("agent_*.json")):
+        try:
+            with open(agent_file) as f:
+                data = json.load(f)
+            file_findings = data.get("findings", [])
+            if not isinstance(file_findings, list):
+                raise ValueError(f"findings is not a list in {agent_file}")
+            findings.extend(file_findings)
+            agent_files.append(str(agent_file))
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            print(f"Warning: skipping malformed agent file {agent_file}: {exc}", file=sys.stderr)
+
+    # Read hygiene.json if provided
+    hygiene_included = False
+    if hygiene_path:
+        try:
+            with open(hygiene_path) as f:
+                hygiene_data = json.load(f)
+            hygiene_findings = hygiene_data.get("findings", [])
+            if isinstance(hygiene_findings, list):
+                findings.extend(hygiene_findings)
+                hygiene_included = True
+        except (OSError, json.JSONDecodeError):
+            pass  # hygiene file missing or malformed -- skip silently
+
+    # Write combined findings
+    output_path = cr_dir / output_filename
+    with open(output_path, "w") as f:
+        json.dump(findings, f, indent=2)
+
+    json.dump(
+        {
+            "total_findings": len(findings),
+            "agent_files": agent_files,
+            "hygiene_included": hygiene_included,
+        },
+        sys.stdout,
+        indent=2,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: verdict
+# ---------------------------------------------------------------------------
+
+_VERDICT_REASON_MAX = 80
+
+
+def cmd_verdict(args: argparse.Namespace) -> int:
+    """Compute PR verdict from validated findings."""
+    validate_output_path: str = args.validate_output
+
+    try:
+        with open(validate_output_path) as f:
+            validate_output = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Error reading validate output: {exc}", file=sys.stderr)
+        return 1
+
+    validated: list[dict[str, Any]] = validate_output.get("validated", [])
+
+    verdict = "approve"
+    reason = ""
+
+    # Priority 1: BLOCKING findings or Premise P0 -> decline
+    for finding in validated:
+        severity = str(finding.get("severity", ""))
+        category = str(finding.get("category", ""))
+        priority = finding.get("priority", 2)
+        if severity == "BLOCKING" or (category == "Premise" and priority == 0):
+            verdict = "decline"
+            issue = str(finding.get("issue", ""))
+            reason = issue[:_VERDICT_REASON_MAX]
+            break
+
+    # Priority 2: HIGH findings -> needs_attention (only if not already decline)
+    if verdict != "decline":
+        for finding in validated:
+            severity = str(finding.get("severity", ""))
+            if severity == "HIGH":
+                verdict = "needs_attention"
+                issue = str(finding.get("issue", ""))
+                reason = issue[:_VERDICT_REASON_MAX]
+                break
+
+    tag_payload = json.dumps({"verdict": verdict, "reason": reason})
+    tag = f"<pr_verdict>{tag_payload}</pr_verdict>"
+
+    json.dump(
+        {"verdict": verdict, "reason": reason, "tag": tag},
+        sys.stdout,
+        indent=2,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: prep-assets
+# ---------------------------------------------------------------------------
+
+
+def cmd_prep_assets(args: argparse.Namespace) -> int:
+    """Copy prompt assets from plugin to CR_DIR."""
+    plugin_root = Path(args.plugin_root)
+    cr_dir = Path(args.cr_dir)
+
+    shared_src = plugin_root / "tools" / "prompts" / "shared_prompt.txt"
+    bha_src = plugin_root / "tools" / "prompts" / "bha_suffix.txt"
+
+    shared_dst = cr_dir / "shared_prompt.txt"
+    bha_dst = cr_dir / "bha_suffix.txt"
+
+    shutil.copy2(shared_src, shared_dst)
+    shutil.copy2(bha_src, bha_dst)
+
+    json.dump(
+        {"shared_prompt": str(shared_dst), "bha_suffix": str(bha_dst)},
+        sys.stdout,
+        indent=2,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: extract-patches
+# ---------------------------------------------------------------------------
+
+_EXTRACT_PATCHES_BATCH_SIZE = 50
+_EXTRACT_PATCHES_BATCH_THRESHOLD = 200
+
+
+def cmd_extract_patches(args: argparse.Namespace) -> int:
+    """Extract git diff patches to disk files for each partition and full diff."""
+    partitions_file = args.partitions_file
+    diff_scope: str = args.diff_scope
+    cr_dir = Path(args.cr_dir)
+    diff_data_path: str = args.diff_data
+    workdir: str | None = getattr(args, "workdir", None)
+    batch_size: int = getattr(args, "batch_size", _EXTRACT_PATCHES_BATCH_SIZE)
+
+    # Read partitions for per-partition patches
+    with open(partitions_file) as f:
+        pdata = json.load(f)
+    partitions: list[dict[str, Any]] = pdata.get("partitions", [])
+
+    # Read full diff_data for patches_all.txt (includes cached files too)
+    with open(diff_data_path) as f:
+        diff_data = json.load(f)
+    all_files: list[str] = diff_data.get("files_to_review", [])
+
+    run_kwargs: dict[str, Any] = {"capture_output": False, "text": True, "check": False}
+    if workdir:
+        run_kwargs["cwd"] = workdir
+
+    # Strip any embedded pathspec (-- file1 file2) from diff_scope since we add explicit file lists
+    range_scope = diff_scope.split(" -- ")[0] if " -- " in diff_scope else diff_scope
+    range_parts = range_scope.split()
+
+    # Per-partition patches
+    partition_patches: list[str] = []
+    for part in partitions:
+        part_id = part["id"]
+        files_in_part = [entry["file"] for entry in part.get("files", [])]
+        patch_name = f"patches_p{part_id}.txt"
+        patch_path = cr_dir / patch_name
+
+        cmd = ["git", "diff"] + range_parts + ["--"] + files_in_part
+        with open(patch_path, "w") as out:
+            subprocess.run(cmd, stdout=out, stderr=subprocess.DEVNULL, **run_kwargs)
+        partition_patches.append(patch_name)
+
+    # Full diff (for BHB, Auditor, Premise, Domain Critic)
+    full_patch_name = "patches_all.txt"
+    full_patch_path = cr_dir / full_patch_name
+
+    if len(all_files) > _EXTRACT_PATCHES_BATCH_THRESHOLD:
+        # Batch extraction
+        first_batch = True
+        for i in range(0, len(all_files), batch_size):
+            batch_files = all_files[i : i + batch_size]
+            cmd = ["git", "diff"] + range_parts + ["--"] + batch_files
+            mode = "w" if first_batch else "a"
+            with open(full_patch_path, mode) as out:
+                subprocess.run(cmd, stdout=out, stderr=subprocess.DEVNULL, **run_kwargs)
+            first_batch = False
+    else:
+        cmd = ["git", "diff"] + range_parts
+        if all_files:
+            cmd += ["--"] + all_files
+        with open(full_patch_path, "w") as out:
+            subprocess.run(cmd, stdout=out, stderr=subprocess.DEVNULL, **run_kwargs)
+
+    json.dump(
+        {"partition_patches": partition_patches, "full_patch": full_patch_name},
+        sys.stdout,
+        indent=2,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -2618,12 +3279,15 @@ def _register_subparsers(subparsers: argparse._SubParsersAction) -> None:  # typ
     p_part.add_argument("--diff-data", default=None, help="Path to diff_data.json (reads stdin if omitted)")
     p_part.add_argument("--loc-budget", type=int, default=400, help="LOC budget per partition")
     p_part.add_argument("--max-files", type=int, default=20, help="Max files per partition")
+    p_part.add_argument("--max-bha-agents", type=int, default=DEFAULT_MAX_BHA_AGENTS, help="Max BHA agent partitions (cap enforcement)")
     p_part.set_defaults(func=cmd_partition)
 
     # route
     p_route = subparsers.add_parser("route", help="Compute risk scores and model routing")
     p_route.add_argument("--diff-data", default=None, help="Path to diff_data.json (reads stdin if omitted)")
     p_route.add_argument("--critic-gates", default=None, help="Path to critic-gates.json")
+    p_route.add_argument("--intent", default="mixed", choices=["feature", "fix", "refactor", "mixed"],
+                         help="PR intent classification (from classify-intent)")
     p_route.set_defaults(func=cmd_route)
 
     # validate
@@ -2658,6 +3322,8 @@ def _register_subparsers(subparsers: argparse._SubParsersAction) -> None:  # typ
     p_cu.add_argument("--context-key", default="", help="Context key (merge-base SHA)")
     p_cu.add_argument("--gc-ttl-days", type=int, default=CACHE_GC_TTL_DAYS_DEFAULT, help="GC TTL in days")
     p_cu.add_argument("--gc-max-per-file", type=int, default=CACHE_GC_MAX_PER_FILE_DEFAULT, help="Max cache entries per file")
+    p_cu.add_argument("--exclude-test-partitions", action="store_true",
+                      help="Skip caching files from is_test_only partitions")
     p_cu.set_defaults(func=cmd_cache_update)
 
     # post-comments
@@ -2696,7 +3362,27 @@ def _register_subparsers(subparsers: argparse._SubParsersAction) -> None:  # typ
     # setup
     p_setup = subparsers.add_parser("setup", help="Session setup: start_time, repo_name, current_branch, global_cache")
     p_setup.add_argument("--mode", required=True, choices=["local", "github"], help="Review mode")
+    p_setup.add_argument("--cr-dir-prefix", default=None,
+                         help="CR dir prefix (e.g. .closedloop-ai/code-review/cr-); random suffix appended")
     p_setup.set_defaults(func=cmd_setup)
+
+    # resolve-scope
+    p_rs = subparsers.add_parser("resolve-scope", help="Resolve diff scope from arguments")
+    p_rs.add_argument("--mode", required=True, choices=["local", "github"])
+    p_rs.add_argument("--pr-number", type=int, default=None)
+    p_rs.add_argument("--scope-args", default="", help="Remaining scope arguments")
+    p_rs.add_argument("--base-ref-override", default=None)
+    p_rs.add_argument("--setup-json", required=True, help="Path to setup.json")
+    p_rs.set_defaults(func=cmd_resolve_scope)
+
+    # fetch-intent
+    p_fi = subparsers.add_parser("fetch-intent", help="Fetch intent context for premise review")
+    p_fi.add_argument("--pr-number", type=int, default=None)
+    p_fi.add_argument("--base-ref", default="main")
+    p_fi.add_argument("--diff-tip", default="HEAD")
+    p_fi.add_argument("--scope-kind", required=True, choices=["pr", "branch", "staged", "file_paths", "github_pending"])
+    p_fi.add_argument("--cr-dir", required=True)
+    p_fi.set_defaults(func=cmd_fetch_intent)
 
     # compute-hashes
     p_ch = subparsers.add_parser("compute-hashes", help="Compute prompt hash and context key")
@@ -2732,6 +3418,40 @@ def _register_subparsers(subparsers: argparse._SubParsersAction) -> None:  # typ
     p_footer.add_argument("--review-mode-line", default=None, help="Review mode line (falls back to cr-dir/auto_incremental.json)")
     p_footer.add_argument("--cr-dir", default=None, help="CR session dir (fallback for --review-mode-line)")
     p_footer.set_defaults(func=cmd_footer, project_dir=None)
+
+    # classify-intent
+    p_ci = subparsers.add_parser("classify-intent", help="Classify diff intent for model routing")
+    p_ci.add_argument("--intent-context", required=True, help="Path to intent_context.json")
+    p_ci.add_argument("--diff-data", default=None, help="Path to diff_data.json for file statuses")
+    p_ci.set_defaults(func=cmd_classify_intent)
+
+    # collect-findings
+    p_cf = subparsers.add_parser("collect-findings", help="Merge agent + hygiene findings")
+    p_cf.add_argument("--cr-dir", required=True, help="Directory containing agent_*.json files")
+    p_cf.add_argument("--output", default="findings.json", help="Output filename (written to cr-dir)")
+    p_cf.add_argument("--hygiene", default=None, help="Path to hygiene.json")
+    p_cf.set_defaults(func=cmd_collect_findings)
+
+    # verdict
+    p_v = subparsers.add_parser("verdict", help="Compute PR verdict from validated findings")
+    p_v.add_argument("--validate-output", required=True, help="Path to validate_output.json")
+    p_v.set_defaults(func=cmd_verdict)
+
+    # prep-assets
+    p_pa = subparsers.add_parser("prep-assets", help="Copy prompt assets from plugin to CR_DIR")
+    p_pa.add_argument("--plugin-root", required=True, help="Resolved CLAUDE_PLUGIN_ROOT path")
+    p_pa.add_argument("--cr-dir", required=True, help="Session CR_DIR path")
+    p_pa.set_defaults(func=cmd_prep_assets)
+
+    # extract-patches
+    p_ep = subparsers.add_parser("extract-patches", help="Extract git diff patches to disk files")
+    p_ep.add_argument("--partitions-file", required=True, help="Path to partitions.json")
+    p_ep.add_argument("--diff-scope", required=True, help="Git diff scope string")
+    p_ep.add_argument("--diff-data", required=True, help="Path to full diff_data.json (for patches_all.txt)")
+    p_ep.add_argument("--cr-dir", required=True, help="Output directory for patch files")
+    p_ep.add_argument("--workdir", default=None, help="Git working directory")
+    p_ep.add_argument("--batch-size", type=int, default=_EXTRACT_PATCHES_BATCH_SIZE, help="Batch size for large diffs")
+    p_ep.set_defaults(func=cmd_extract_patches)
 
 
 def main() -> int:

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -14,6 +15,7 @@ from code_review_helpers import (
     _check_gitignore_drift,
     _check_path_leakage,
     _check_sensitive_files,
+    _classify_intent,
     _compute_composite_key,
     _compute_patch_hash,
     _entry_matches_v2,
@@ -44,10 +46,12 @@ from code_review_helpers import (
     CACHE_LOCK_FILENAME,
     CACHE_MANIFEST_FILENAME,
     CACHE_SCHEMA_VERSION_V2,
+    DEFAULT_MAX_BHA_AGENTS,
     REVIEW_STATE_FILENAME,
     cmd_auto_incremental,
     cmd_cache_check,
     cmd_cache_update,
+    cmd_collect_findings,
     cmd_compute_hashes,
     cmd_footer,
     cmd_hygiene,
@@ -60,6 +64,7 @@ from code_review_helpers import (
     cmd_session_tokens,
     cmd_setup,
     cmd_validate,
+    cmd_verdict,
 )
 
 
@@ -540,6 +545,7 @@ class TestRoute:
         self,
         diff_data: dict[str, Any],
         critic_gates_path: str | None = None,
+        intent: str = "mixed",
     ) -> dict[str, Any]:
         import io
         import sys as _sys
@@ -550,7 +556,7 @@ class TestRoute:
         _sys.stdout = io.StringIO()
         try:
             import argparse
-            ns = argparse.Namespace(critic_gates=critic_gates_path)
+            ns = argparse.Namespace(critic_gates=critic_gates_path, intent=intent)
             cmd_route(ns)
             _sys.stdout.seek(0)
             return json.load(_sys.stdout)
@@ -566,7 +572,7 @@ class TestRoute:
         data["total_loc"] = 150
         result = self._run_route(data)
         assert result["size_category"] == "Small"
-        assert result["models"]["bug_hunter_a"] == "opus"
+        assert result["models"]["bug_hunter_a"]["default"] == "opus"
         assert result["models"]["bug_hunter_b"] == "sonnet"
 
     def test_medium_diff_routing(self) -> None:
@@ -577,7 +583,7 @@ class TestRoute:
         data["total_loc"] = 1000
         result = self._run_route(data)
         assert result["size_category"] == "Medium"
-        assert result["models"]["bug_hunter_a"] == "opus"
+        assert result["models"]["bug_hunter_a"]["default"] == "opus"
         assert result["models"]["bug_hunter_b"] == "sonnet"
 
     def test_large_diff_routing(self) -> None:
@@ -588,7 +594,7 @@ class TestRoute:
         data["total_loc"] = 2500
         result = self._run_route(data)
         assert result["size_category"] == "Large"
-        assert result["models"]["bug_hunter_a"] == "opus"
+        assert result["models"]["bug_hunter_a"]["default"] == "opus"
 
     def test_high_risk_files(self, tmp_path: Path) -> None:
         gates = {
@@ -633,7 +639,7 @@ class TestRoute:
         result = self._run_route(data, str(gates_path))
         assert "python-script-reviewer" in result["domain_critics"]
 
-    def test_domain_critics_capped_at_2(self, tmp_path: Path) -> None:
+    def test_domain_critics_capped_at_1(self, tmp_path: Path) -> None:
         gates = {
             "defaults": {"reviewBudget": 10},
             "moduleCritics": [
@@ -654,7 +660,7 @@ class TestRoute:
         )
         data["total_loc"] = 20
         result = self._run_route(data, str(gates_path))
-        assert len(result["domain_critics"]) <= 2
+        assert len(result["domain_critics"]) <= 1
 
     def test_missing_critic_gates(self) -> None:
         data = _make_diff_data(files=["a.ts"])
@@ -662,6 +668,356 @@ class TestRoute:
         result = self._run_route(data, "/nonexistent/path.json")
         assert result["domain_critics"] == []
         assert result["size_category"] == "Small"
+
+    def test_bug_hunter_a_model_is_dict(self) -> None:
+        data = _make_diff_data(files=["a.ts"])
+        data["total_loc"] = 100
+        result = self._run_route(data)
+        bha = result["models"]["bug_hunter_a"]
+        assert isinstance(bha, dict)
+        assert "default" in bha
+        assert "test_only" in bha
+
+    def test_bug_hunter_a_test_only_is_sonnet(self) -> None:
+        data = _make_diff_data(files=["a.ts"])
+        data["total_loc"] = 100
+        result = self._run_route(data)
+        assert result["models"]["bug_hunter_a"]["test_only"] == "sonnet"
+
+    def test_max_bha_agents_no_domain_critic(self) -> None:
+        data = _make_diff_data(files=["a.ts"])
+        data["total_loc"] = 100
+        result = self._run_route(data)
+        assert result["max_bha_agents"] == 6  # 9 - BHB - Auditor - Premise
+
+    def test_max_bha_agents_with_domain_critic(self, tmp_path: Path) -> None:
+        gates = {
+            "defaults": {"reviewBudget": 2},
+            "moduleCritics": [
+                {"patterns": [".ts"], "critics": ["ts-reviewer"]},
+            ],
+        }
+        gates_path = tmp_path / "critic-gates.json"
+        gates_path.write_text(json.dumps(gates))
+        data = _make_diff_data(
+            files=["a.ts"],
+            loc={"a.ts": {"added": 10, "removed": 0}},
+        )
+        data["total_loc"] = 10
+        result = self._run_route(data, str(gates_path))
+        assert len(result["domain_critics"]) == 1
+        assert result["max_bha_agents"] == 5  # 9 - BHB - Auditor - Premise - 1 domain
+
+    def test_premise_opus_for_fix(self) -> None:
+        data = _make_diff_data(files=["a.ts"])
+        data["total_loc"] = 100
+        result = self._run_route(data, intent="fix")
+        assert result["models"]["premise_reviewer"] == "opus"
+
+    def test_premise_sonnet_for_feature(self) -> None:
+        data = _make_diff_data(files=["a.ts"])
+        data["total_loc"] = 100
+        result = self._run_route(data, intent="feature")
+        assert result["models"]["premise_reviewer"] == "sonnet"
+
+    def test_premise_opus_default(self) -> None:
+        data = _make_diff_data(files=["a.ts"])
+        data["total_loc"] = 100
+        result = self._run_route(data)
+        assert result["models"]["premise_reviewer"] == "opus"
+
+
+# ---------------------------------------------------------------------------
+# Partition post-processing
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionPostProcessing:
+    def _run_partition(
+        self,
+        diff_data: dict[str, Any],
+        loc_budget: int = 400,
+        max_files: int = 20,
+        max_bha_agents: int = DEFAULT_MAX_BHA_AGENTS,
+    ) -> dict[str, Any]:
+        import io
+        import sys as _sys
+
+        old_stdin = _sys.stdin
+        old_stdout = _sys.stdout
+        _sys.stdin = io.StringIO(json.dumps(diff_data))
+        _sys.stdout = io.StringIO()
+        try:
+            import argparse
+            ns = argparse.Namespace(
+                loc_budget=loc_budget, max_files=max_files,
+                max_bha_agents=max_bha_agents, diff_data=None,
+            )
+            cmd_partition(ns)
+            _sys.stdout.seek(0)
+            return json.load(_sys.stdout)
+        finally:
+            _sys.stdin = old_stdin
+            _sys.stdout = old_stdout
+
+    def test_trivial_partition_merged(self) -> None:
+        data = _make_diff_data(
+            files=["a.ts", "b.ts", "c.ts"],
+            loc={"a.ts": {"added": 300, "removed": 0}, "b.ts": {"added": 250, "removed": 0}, "c.ts": {"added": 5, "removed": 0}},
+        )
+        result = self._run_partition(data, loc_budget=400)
+        assert len(result["partitions"]) == 2
+        # c.ts (5 LOC) should be merged into b.ts partition (smaller)
+        all_files = [f["file"] for p in result["partitions"] for f in p["files"]]
+        assert "c.ts" in all_files
+
+    def test_all_trivial_unchanged(self) -> None:
+        data = _make_diff_data(
+            files=["a.ts", "b.ts", "c.ts"],
+            loc={"a.ts": {"added": 5, "removed": 0}, "b.ts": {"added": 5, "removed": 0}, "c.ts": {"added": 5, "removed": 0}},
+        )
+        result = self._run_partition(data, max_files=1)
+        assert len(result["partitions"]) == 3  # All trivial, no normal target to merge into
+
+    def test_trivial_merge_updates_total_loc(self) -> None:
+        data = _make_diff_data(
+            files=["a.ts", "b.ts"],
+            loc={"a.ts": {"added": 200, "removed": 0}, "b.ts": {"added": 5, "removed": 0}},
+        )
+        result = self._run_partition(data, loc_budget=400)
+        assert len(result["partitions"]) == 1
+        assert result["partitions"][0]["total_loc"] == 205
+
+    def test_trivial_merge_recomputes_is_test_only(self) -> None:
+        data = _make_diff_data(
+            files=["tests/test_a.ts", "src/impl.ts"],
+            loc={"tests/test_a.ts": {"added": 200, "removed": 0}, "src/impl.ts": {"added": 5, "removed": 0}},
+        )
+        result = self._run_partition(data, loc_budget=400)
+        assert len(result["partitions"]) == 1
+        # Impl file merged into test partition flips is_test_only
+        assert result["partitions"][0]["is_test_only"] is False
+
+    def test_trivial_merge_respects_max_files(self) -> None:
+        files = [f"f{i}.ts" for i in range(3)]
+        loc = {"f0.ts": {"added": 200, "removed": 0}, "f1.ts": {"added": 200, "removed": 0}, "f2.ts": {"added": 5, "removed": 0}}
+        data = _make_diff_data(files=files, loc=loc)
+        # max_files=1 means each is its own partition, no merge target can accept
+        result = self._run_partition(data, loc_budget=300, max_files=1)
+        assert len(result["partitions"]) == 3
+
+    def test_mixed_partition_splits(self) -> None:
+        data = _make_diff_data(
+            files=["src/app.ts", "tests/app.test.ts"],
+            loc={"src/app.ts": {"added": 200, "removed": 0}, "tests/app.test.ts": {"added": 400, "removed": 0}},
+        )
+        result = self._run_partition(data, loc_budget=800)
+        assert len(result["partitions"]) == 2
+        test_partitions = [p for p in result["partitions"] if p["is_test_only"]]
+        impl_partitions = [p for p in result["partitions"] if not p["is_test_only"]]
+        assert len(test_partitions) == 1
+        assert len(impl_partitions) == 1
+
+    def test_mixed_partition_no_split_below_threshold(self) -> None:
+        data = _make_diff_data(
+            files=["src/app.ts", "tests/app.test.ts"],
+            loc={"src/app.ts": {"added": 10, "removed": 0}, "tests/app.test.ts": {"added": 200, "removed": 0}},
+        )
+        result = self._run_partition(data, loc_budget=800)
+        assert len(result["partitions"]) == 1  # Not split, impl LOC < 50
+
+    def test_cap_enforcement_merges_smallest_same_type(self) -> None:
+        # Create 7 files that each get their own partition (loc_budget forces 1 per partition)
+        files = [f"f{i}.ts" for i in range(7)]
+        loc = {f: {"added": 100, "removed": 0} for f in files}
+        data = _make_diff_data(files=files, loc=loc)
+        result = self._run_partition(data, loc_budget=150, max_files=20, max_bha_agents=5)
+        assert len(result["partitions"]) <= 5
+
+
+# ---------------------------------------------------------------------------
+# Classify intent
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyIntent:
+    def test_feature_from_title(self) -> None:
+        result = _classify_intent("feat: add dashboard", "", "", {})
+        assert result == "feature"
+
+    def test_fix_from_title(self) -> None:
+        result = _classify_intent("fix: null pointer", "", "", {})
+        assert result == "fix"
+
+    def test_fix_from_inflected_title(self) -> None:
+        result = _classify_intent("fixes null pointer in auth", "", "", {})
+        assert result == "fix"
+
+    def test_refactor_from_title(self) -> None:
+        result = _classify_intent("refactor: rename service", "", "", {})
+        assert result == "refactor"
+
+    def test_mixed_on_ambiguity(self) -> None:
+        result = _classify_intent("fix and refactor auth", "", "", {})
+        assert result == "mixed"
+
+    def test_feature_boosted_by_file_statuses(self) -> None:
+        statuses = {"a.ts": "added", "b.ts": "added", "c.ts": "added", "d.ts": "modified"}
+        result = _classify_intent("", "", "", statuses)
+        assert result == "feature"  # 75% added >= 70% threshold
+
+    def test_empty_context_returns_mixed(self) -> None:
+        result = _classify_intent("", "", "", {})
+        assert result == "mixed"
+
+    def test_feature_from_body_first_line(self) -> None:
+        result = _classify_intent("", "feat: add new dashboard\n\n- [ ] checkbox", "", {})
+        assert result == "feature"
+
+    def test_body_only_first_line_used(self) -> None:
+        result = _classify_intent("", "This adds a feature\nfix: something else", "", {})
+        assert result == "feature"
+
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+
+
+class TestVerdict:
+    def _run_verdict(self, validated: list[dict[str, Any]]) -> dict[str, Any]:
+        import io
+        import sys as _sys
+        import tempfile
+
+        validate_output = {"validated": validated, "discarded": [], "stats": {}}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tf:
+            json.dump(validate_output, tf)
+            tf_path = tf.name
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            import argparse
+            ns = argparse.Namespace(validate_output=tf_path)
+            cmd_verdict(ns)
+            _sys.stdout.seek(0)
+            return json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+            os.unlink(tf_path)
+
+    def test_verdict_approve_no_findings(self) -> None:
+        result = self._run_verdict([])
+        assert result["verdict"] == "approve"
+
+    def test_verdict_decline_blocking(self) -> None:
+        result = self._run_verdict([
+            {"severity": "BLOCKING", "issue": "[P0] Missing null check", "priority": 0, "category": "Correctness"},
+        ])
+        assert result["verdict"] == "decline"
+        assert "Missing null check" in result["reason"]
+
+    def test_verdict_decline_premise_p0(self) -> None:
+        result = self._run_verdict([
+            {"severity": "HIGH", "issue": "[P0] Unnecessary change", "priority": 0, "category": "Premise"},
+        ])
+        assert result["verdict"] == "decline"
+
+    def test_verdict_needs_attention_high(self) -> None:
+        result = self._run_verdict([
+            {"severity": "HIGH", "issue": "[P1] Race condition", "priority": 1, "category": "Correctness"},
+        ])
+        assert result["verdict"] == "needs_attention"
+
+    def test_verdict_priority_order(self) -> None:
+        result = self._run_verdict([
+            {"severity": "HIGH", "issue": "[P1] Race condition", "priority": 1, "category": "Correctness"},
+            {"severity": "BLOCKING", "issue": "[P0] Data loss", "priority": 0, "category": "Security"},
+        ])
+        assert result["verdict"] == "decline"
+
+    def test_verdict_reason_truncated(self) -> None:
+        long_issue = "A" * 200
+        result = self._run_verdict([
+            {"severity": "BLOCKING", "issue": long_issue, "priority": 0, "category": "Correctness"},
+        ])
+        assert len(result["reason"]) <= 80
+
+
+# ---------------------------------------------------------------------------
+# Collect findings
+# ---------------------------------------------------------------------------
+
+
+class TestCollectFindings:
+    def test_merges_agents_and_hygiene(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+
+        # Write agent files
+        (tmp_path / "agent_bha_p0.json").write_text(json.dumps({"findings": [{"file": "a.ts", "severity": "HIGH"}]}))
+        (tmp_path / "agent_bhb.json").write_text(json.dumps({"findings": [{"file": "b.ts", "severity": "MEDIUM"}]}))
+        # Write hygiene file
+        hygiene_path = tmp_path / "hygiene.json"
+        hygiene_path.write_text(json.dumps({"findings": [{"file": "c.ts", "severity": "MEDIUM"}]}))
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            ns = argparse.Namespace(cr_dir=str(tmp_path), output="findings.json", hygiene=str(hygiene_path))
+            cmd_collect_findings(ns)
+            _sys.stdout.seek(0)
+            result = json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+
+        assert result["total_findings"] == 3
+        assert result["hygiene_included"] is True
+        # Verify merged file on disk
+        merged = json.loads((tmp_path / "findings.json").read_text())
+        assert len(merged) == 3
+
+    def test_skips_malformed(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+
+        (tmp_path / "agent_good.json").write_text(json.dumps({"findings": [{"file": "a.ts"}]}))
+        (tmp_path / "agent_bad.json").write_text("not json{{{")
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            ns = argparse.Namespace(cr_dir=str(tmp_path), output="findings.json", hygiene=None)
+            cmd_collect_findings(ns)
+            _sys.stdout.seek(0)
+            result = json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+
+        assert result["total_findings"] == 1
+
+    def test_no_hygiene(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+
+        (tmp_path / "agent_bha_p0.json").write_text(json.dumps({"findings": [{"file": "a.ts"}]}))
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            ns = argparse.Namespace(cr_dir=str(tmp_path), output="findings.json", hygiene=str(tmp_path / "nonexistent.json"))
+            cmd_collect_findings(ns)
+            _sys.stdout.seek(0)
+            result = json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+
+        assert result["total_findings"] == 1
+        assert result["hygiene_included"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -3549,3 +3905,560 @@ class TestCacheUpdatePartitionsFile:
         manifest = _load_manifest(cache_dir)
         assert "a.ts" in manifest
         assert "b.ts" in manifest
+
+    def test_exclude_test_partitions_skips_test_only(self, tmp_path: Path) -> None:
+        import argparse
+
+        cache_dir = tmp_path / "cache"
+        bha_dir = tmp_path / "bha"
+        bha_dir.mkdir()
+
+        partitions_data = {
+            "partitions": [
+                {"files": [{"file": "src/app.ts"}], "is_test_only": False},
+                {"files": [{"file": "tests/app.test.ts"}], "is_test_only": True},
+            ]
+        }
+        partitions_file = tmp_path / "partitions.json"
+        partitions_file.write_text(json.dumps(partitions_data))
+
+        diff_data = _make_cache_diff_data(files=["src/app.ts", "tests/app.test.ts"])
+        diff_path = bha_dir / "diff_data.json"
+        diff_path.write_text(json.dumps(diff_data))
+
+        ns = argparse.Namespace(
+            cache_dir=str(cache_dir),
+            diff_data=str(diff_path),
+            bha_dir=str(bha_dir),
+            prompt_hash="abc123",
+            model_id="opus",
+            schema_version=1,
+            reviewed_files=[],
+            partitions_file=str(partitions_file),
+            exclude_test_partitions=True,
+        )
+        cmd_cache_update(ns)
+        manifest = _load_manifest(cache_dir)
+        assert "src/app.ts" in manifest
+        assert "tests/app.test.ts" not in manifest
+
+    def test_exclude_test_partitions_false_by_default(self, tmp_path: Path) -> None:
+        import argparse
+
+        cache_dir = tmp_path / "cache"
+        bha_dir = tmp_path / "bha"
+        bha_dir.mkdir()
+
+        partitions_data = {
+            "partitions": [
+                {"files": [{"file": "src/app.ts"}], "is_test_only": False},
+                {"files": [{"file": "tests/app.test.ts"}], "is_test_only": True},
+            ]
+        }
+        partitions_file = tmp_path / "partitions.json"
+        partitions_file.write_text(json.dumps(partitions_data))
+
+        diff_data = _make_cache_diff_data(files=["src/app.ts", "tests/app.test.ts"])
+        diff_path = bha_dir / "diff_data.json"
+        diff_path.write_text(json.dumps(diff_data))
+
+        ns = argparse.Namespace(
+            cache_dir=str(cache_dir),
+            diff_data=str(diff_path),
+            bha_dir=str(bha_dir),
+            prompt_hash="abc123",
+            model_id="opus",
+            schema_version=1,
+            reviewed_files=[],
+            partitions_file=str(partitions_file),
+            exclude_test_partitions=False,
+        )
+        cmd_cache_update(ns)
+        manifest = _load_manifest(cache_dir)
+        assert "src/app.ts" in manifest
+        assert "tests/app.test.ts" in manifest
+
+    def test_exclude_test_partitions_caches_mixed(self, tmp_path: Path) -> None:
+        import argparse
+
+        cache_dir = tmp_path / "cache"
+        bha_dir = tmp_path / "bha"
+        bha_dir.mkdir()
+
+        # Mixed partition (is_test_only=False) should still be cached
+        partitions_data = {
+            "partitions": [
+                {"files": [{"file": "src/app.ts"}, {"file": "src/app.test.ts"}], "is_test_only": False},
+            ]
+        }
+        partitions_file = tmp_path / "partitions.json"
+        partitions_file.write_text(json.dumps(partitions_data))
+
+        diff_data = _make_cache_diff_data(files=["src/app.ts", "src/app.test.ts"])
+        diff_path = bha_dir / "diff_data.json"
+        diff_path.write_text(json.dumps(diff_data))
+
+        ns = argparse.Namespace(
+            cache_dir=str(cache_dir),
+            diff_data=str(diff_path),
+            bha_dir=str(bha_dir),
+            prompt_hash="abc123",
+            model_id="opus",
+            schema_version=1,
+            reviewed_files=[],
+            partitions_file=str(partitions_file),
+            exclude_test_partitions=True,
+        )
+        cmd_cache_update(ns)
+        manifest = _load_manifest(cache_dir)
+        # Both files cached because the partition is NOT test_only
+        assert "src/app.ts" in manifest
+        assert "src/app.test.ts" in manifest
+
+
+# ---------------------------------------------------------------------------
+# Cache status message
+# ---------------------------------------------------------------------------
+
+
+class TestCacheStatusMessage:
+    def test_hits(self) -> None:
+        from code_review_helpers import _compute_cache_status
+        stats = {"cached": 5, "total_files": 10, "hit_rate_pct": 50.0}
+        kind, msg = _compute_cache_status(stats, {"some": "data"}, fallback_error=False)
+        assert kind == "hits"
+        assert "5/10" in msg
+
+    def test_first_run(self) -> None:
+        from code_review_helpers import _compute_cache_status
+        stats = {"cached": 0, "total_files": 5, "hit_rate_pct": 0.0}
+        kind, msg = _compute_cache_status(stats, {}, fallback_error=False, manifest_file_existed=False)
+        assert kind == "first_run"
+
+    def test_all_changed(self) -> None:
+        from code_review_helpers import _compute_cache_status
+        stats = {"cached": 0, "total_files": 5, "hit_rate_pct": 0.0}
+        kind, msg = _compute_cache_status(stats, {"file": {}}, fallback_error=False)
+        assert kind == "all_changed"
+
+    def test_fallback_error(self) -> None:
+        from code_review_helpers import _compute_cache_status
+        stats = {"cached": 0, "total_files": 5, "hit_rate_pct": 0.0}
+        kind, msg = _compute_cache_status(stats, {}, fallback_error=True)
+        assert kind == "fallback_error"
+
+    def test_corrupt_manifest_not_first_run(self) -> None:
+        from code_review_helpers import _compute_cache_status
+        stats = {"cached": 0, "total_files": 5, "hit_rate_pct": 0.0}
+        # File existed but was corrupt (loaded as {})
+        kind, msg = _compute_cache_status(stats, {}, fallback_error=False, manifest_file_existed=True)
+        assert kind == "fallback_error"
+        assert "corrupt" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Resolve scope
+# ---------------------------------------------------------------------------
+
+
+class TestResolveScope:
+    def _run(self, mode: str, scope_args: str = "", pr_number: int | None = None,
+             base_ref_override: str | None = None, setup_json: str | None = None,
+             tmp_path: Path | None = None) -> dict[str, Any]:
+        import argparse
+        import io
+        import sys as _sys
+
+        if setup_json is None and tmp_path is not None:
+            setup_path = tmp_path / "setup.json"
+            setup_path.write_text(json.dumps({"current_branch": "feat-x"}))
+            setup_json = str(setup_path)
+
+        from code_review_helpers import cmd_resolve_scope
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            ns = argparse.Namespace(
+                mode=mode, pr_number=pr_number, scope_args=scope_args,
+                base_ref_override=base_ref_override, setup_json=setup_json or "",
+            )
+            cmd_resolve_scope(ns)
+            _sys.stdout.seek(0)
+            return json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+
+    def test_local_branch(self, tmp_path: Path) -> None:
+        result = self._run("local", tmp_path=tmp_path)
+        assert result["diff_scope"] == "main...HEAD"
+        assert result["scope_kind"] == "branch"
+
+    def test_staged(self, tmp_path: Path) -> None:
+        result = self._run("local", scope_args="staged", tmp_path=tmp_path)
+        assert result["diff_scope"] == "--cached"
+        assert result["scope_kind"] == "staged"
+
+    def test_file_paths(self, tmp_path: Path) -> None:
+        result = self._run("local", scope_args="file1.ts file2.ts", tmp_path=tmp_path)
+        assert "-- file1.ts file2.ts" in result["diff_scope"]
+        assert result["scope_kind"] == "file_paths"
+        assert result["path_filter"] == "-- file1.ts file2.ts"
+
+    def test_base_override(self, tmp_path: Path) -> None:
+        result = self._run("local", base_ref_override="develop", tmp_path=tmp_path)
+        assert "origin/develop" in result["diff_scope"]
+        assert result["base_ref"] == "develop"
+
+    def test_base_override_preserves_path_filter(self, tmp_path: Path) -> None:
+        result = self._run("local", scope_args="file1.ts", base_ref_override="develop", tmp_path=tmp_path)
+        assert "origin/develop" in result["diff_scope"]
+        assert "-- file1.ts" in result["path_filter"]
+
+
+# ---------------------------------------------------------------------------
+# Prep assets
+# ---------------------------------------------------------------------------
+
+
+class TestPrepAssets:
+    def test_copies_files(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+
+        from code_review_helpers import cmd_prep_assets
+
+        # Create mock plugin structure
+        plugin_root = tmp_path / "plugin"
+        prompts_dir = plugin_root / "tools" / "prompts"
+        prompts_dir.mkdir(parents=True)
+        (prompts_dir / "shared_prompt.txt").write_text("shared prompt content")
+        (prompts_dir / "bha_suffix.txt").write_text("bha suffix content")
+
+        cr_dir = tmp_path / "cr"
+        cr_dir.mkdir()
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            ns = argparse.Namespace(plugin_root=str(plugin_root), cr_dir=str(cr_dir))
+            cmd_prep_assets(ns)
+            _sys.stdout.seek(0)
+            result = json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+
+        assert (cr_dir / "shared_prompt.txt").exists()
+        assert (cr_dir / "bha_suffix.txt").exists()
+        assert "shared_prompt" in result
+        assert "bha_suffix" in result
+        # Output paths should point to actual files in cr_dir
+        assert result["shared_prompt"] == str(cr_dir / "shared_prompt.txt")
+        assert result["bha_suffix"] == str(cr_dir / "bha_suffix.txt")
+
+
+# ---------------------------------------------------------------------------
+# Fetch intent
+# ---------------------------------------------------------------------------
+
+
+class TestFetchIntent:
+    def _run(self, scope_kind: str, cr_dir: Path, pr_number: int | None = None,
+             base_ref: str = "main", diff_tip: str = "HEAD") -> dict[str, Any]:
+        import argparse
+        import io
+        import sys as _sys
+
+        from code_review_helpers import cmd_fetch_intent
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            ns = argparse.Namespace(
+                pr_number=pr_number, base_ref=base_ref, diff_tip=diff_tip,
+                scope_kind=scope_kind, cr_dir=str(cr_dir),
+            )
+            cmd_fetch_intent(ns)
+            _sys.stdout.seek(0)
+            return json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+
+    def test_staged_empty(self, tmp_path: Path) -> None:
+        result = self._run("staged", tmp_path)
+        assert result["source"] == "empty"
+        intent = json.loads((tmp_path / "intent_context.json").read_text())
+        assert intent["title"] == ""
+        assert intent["commits"] == ""
+
+    def test_file_scope_empty(self, tmp_path: Path) -> None:
+        result = self._run("file_paths", tmp_path)
+        assert result["source"] == "empty"
+
+    def test_branch_uses_git_log(self, tmp_path: Path) -> None:
+        from unittest.mock import patch as mock_patch
+        mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="feat: add dashboard\nfix: typo\n")
+        with mock_patch("code_review_helpers.subprocess.run", return_value=mock_result):
+            result = self._run("branch", tmp_path, base_ref="main", diff_tip="HEAD")
+        assert result["source"] == "commits"
+        intent = json.loads((tmp_path / "intent_context.json").read_text())
+        assert "add dashboard" in intent["commits"]
+
+    def test_pr_uses_gh(self, tmp_path: Path) -> None:
+        from unittest.mock import patch as mock_patch
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps({"title": "feat: PR title", "body": "PR body"}),
+        )
+        with mock_patch("code_review_helpers.subprocess.run", return_value=mock_result):
+            result = self._run("pr", tmp_path, pr_number=42)
+        assert result["source"] == "pr"
+        intent = json.loads((tmp_path / "intent_context.json").read_text())
+        assert intent["title"] == "feat: PR title"
+
+    def test_pr_fallback_on_error(self, tmp_path: Path) -> None:
+        from unittest.mock import patch as mock_patch
+        with mock_patch("code_review_helpers.subprocess.run", side_effect=subprocess.CalledProcessError(1, "gh")):
+            result = self._run("pr", tmp_path, pr_number=42)
+        assert result["source"] == "empty"
+
+
+# ---------------------------------------------------------------------------
+# Setup --cr-dir-prefix
+# ---------------------------------------------------------------------------
+
+
+class TestSetupCrDir:
+    def test_creates_cr_dir(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+
+        prefix = str(tmp_path / "cr-")
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            ns = argparse.Namespace(mode="local", cr_dir_prefix=prefix)
+            cmd_setup(ns)
+            _sys.stdout.seek(0)
+            result = json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+
+        assert "cr_dir" in result
+        assert Path(result["cr_dir"]).exists()
+        assert result["cr_dir"].startswith(prefix)
+
+    def test_unique_paths(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+
+        prefix = str(tmp_path / "cr-")
+        paths = []
+        for _ in range(5):
+            old_stdout = _sys.stdout
+            _sys.stdout = io.StringIO()
+            try:
+                ns = argparse.Namespace(mode="local", cr_dir_prefix=prefix)
+                cmd_setup(ns)
+                _sys.stdout.seek(0)
+                result = json.load(_sys.stdout)
+            finally:
+                _sys.stdout = old_stdout
+            paths.append(result["cr_dir"])
+
+        # With 5-digit random suffix, collisions across 5 runs are extremely unlikely
+        assert len(set(paths)) >= 2
+
+
+# ---------------------------------------------------------------------------
+# Extract patches
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPatches:
+    def test_creates_partition_and_full_files(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+        from unittest.mock import patch as mock_patch
+
+        from code_review_helpers import cmd_extract_patches
+
+        cr_dir = tmp_path / "cr"
+        cr_dir.mkdir()
+
+        partitions_data = {"partitions": [
+            {"id": 0, "files": [{"file": "a.ts"}]},
+            {"id": 1, "files": [{"file": "b.ts"}]},
+        ]}
+        partitions_file = tmp_path / "partitions.json"
+        partitions_file.write_text(json.dumps(partitions_data))
+
+        diff_data = {"files_to_review": ["a.ts", "b.ts", "c.ts"]}
+        diff_data_file = tmp_path / "diff_data.json"
+        diff_data_file.write_text(json.dumps(diff_data))
+
+        def mock_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+            # Write something to stdout if it was redirected
+            stdout = kwargs.get("stdout")
+            if stdout and hasattr(stdout, "write"):
+                stdout.write(f"diff output for {' '.join(cmd)}\n")
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
+                ns = argparse.Namespace(
+                    partitions_file=str(partitions_file), diff_scope="main...HEAD",
+                    diff_data=str(diff_data_file), cr_dir=str(cr_dir),
+                    workdir=None, batch_size=50,
+                )
+                cmd_extract_patches(ns)
+                _sys.stdout.seek(0)
+                result = json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+
+        assert "patches_p0.txt" in result["partition_patches"]
+        assert "patches_p1.txt" in result["partition_patches"]
+        assert result["full_patch"] == "patches_all.txt"
+        assert (cr_dir / "patches_p0.txt").exists()
+        assert (cr_dir / "patches_all.txt").exists()
+
+    def test_strips_pathspec_from_scope(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+        from unittest.mock import patch as mock_patch
+
+        from code_review_helpers import cmd_extract_patches
+
+        cr_dir = tmp_path / "cr"
+        cr_dir.mkdir()
+
+        partitions_data = {"partitions": [{"id": 0, "files": [{"file": "a.ts"}]}]}
+        partitions_file = tmp_path / "partitions.json"
+        partitions_file.write_text(json.dumps(partitions_data))
+
+        diff_data = {"files_to_review": ["a.ts"]}
+        diff_data_file = tmp_path / "diff_data.json"
+        diff_data_file.write_text(json.dumps(diff_data))
+
+        captured_cmds: list[list[str]] = []
+
+        def mock_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+            captured_cmds.append(cmd)
+            stdout = kwargs.get("stdout")
+            if stdout and hasattr(stdout, "write"):
+                stdout.write("")
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
+                ns = argparse.Namespace(
+                    partitions_file=str(partitions_file),
+                    diff_scope="main...HEAD -- a.ts b.ts",  # pathspec embedded
+                    diff_data=str(diff_data_file), cr_dir=str(cr_dir),
+                    workdir=None, batch_size=50,
+                )
+                cmd_extract_patches(ns)
+        finally:
+            _sys.stdout = old_stdout
+
+        # Verify no double -- in any command
+        for cmd in captured_cmds:
+            separator_count = cmd.count("--")
+            assert separator_count <= 1, f"Double pathspec separator in: {cmd}"
+
+    def test_full_diff_uses_diff_data_not_partitions(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+        from unittest.mock import patch as mock_patch
+
+        from code_review_helpers import cmd_extract_patches
+
+        cr_dir = tmp_path / "cr"
+        cr_dir.mkdir()
+
+        # Partitions only have 1 file (uncached), but diff_data has 3 (full set)
+        partitions_data = {"partitions": [{"id": 0, "files": [{"file": "a.ts"}]}]}
+        (tmp_path / "partitions.json").write_text(json.dumps(partitions_data))
+        (tmp_path / "diff_data.json").write_text(json.dumps({"files_to_review": ["a.ts", "b.ts", "c.ts"]}))
+
+        captured_cmds: list[list[str]] = []
+
+        def mock_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+            captured_cmds.append(cmd)
+            stdout = kwargs.get("stdout")
+            if stdout and hasattr(stdout, "write"):
+                stdout.write("")
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
+                ns = argparse.Namespace(
+                    partitions_file=str(tmp_path / "partitions.json"), diff_scope="main...HEAD",
+                    diff_data=str(tmp_path / "diff_data.json"), cr_dir=str(cr_dir),
+                    workdir=None, batch_size=50,
+                )
+                cmd_extract_patches(ns)
+        finally:
+            _sys.stdout = old_stdout
+
+        # The full-diff command (last one) should include all 3 files from diff_data
+        full_diff_cmd = captured_cmds[-1]
+        assert "a.ts" in full_diff_cmd
+        assert "b.ts" in full_diff_cmd
+        assert "c.ts" in full_diff_cmd
+
+    def test_batches_large_diffs(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+        from unittest.mock import patch as mock_patch
+
+        from code_review_helpers import cmd_extract_patches
+
+        cr_dir = tmp_path / "cr"
+        cr_dir.mkdir()
+
+        # 250 files -- above the 200 threshold
+        all_files = [f"f{i}.ts" for i in range(250)]
+        partitions_data = {"partitions": [{"id": 0, "files": [{"file": all_files[0]}]}]}
+        (tmp_path / "partitions.json").write_text(json.dumps(partitions_data))
+        (tmp_path / "diff_data.json").write_text(json.dumps({"files_to_review": all_files}))
+
+        captured_cmds: list[list[str]] = []
+
+        def mock_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+            captured_cmds.append(cmd)
+            stdout = kwargs.get("stdout")
+            if stdout and hasattr(stdout, "write"):
+                stdout.write("")
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
+                ns = argparse.Namespace(
+                    partitions_file=str(tmp_path / "partitions.json"), diff_scope="main...HEAD",
+                    diff_data=str(tmp_path / "diff_data.json"), cr_dir=str(cr_dir),
+                    workdir=None, batch_size=50,
+                )
+                cmd_extract_patches(ns)
+        finally:
+            _sys.stdout = old_stdout
+
+        # 1 partition cmd + 5 batched full-diff cmds (250 / 50 = 5)
+        full_diff_cmds = [c for c in captured_cmds if "patches_p" not in " ".join(str(x) for x in c)]
+        # Should be multiple batches (>1 command for the full diff)
+        assert len(full_diff_cmds) >= 5


### PR DESCRIPTION
Reduce /code-review:start wall time by tightening BHA partitioning, routing test-only BHA work to Sonnet, and routing Premise Reviewer by intent.

Move the following into deterministic Python helpers so the slash command no longer depends on fragile inline shell/prose logic:
- scope resolution
- intent fetch/classification
- prompt asset prep
- patch extraction
- findings collection
- verdict generation
- session setup

Also harden cache behavior by excluding Sonnet-reviewed test-only partitions from Opus cache writes, adding cache status reporting, and keeping route output aligned with agent-cap enforcement.

Update tests, plugin version, changelog, and checked-in prompt assets to match the new pipeline behavior.

Result: 1.47x faster code reviews or 32% reduction in total runtime