### PR TITLE
PLAN-75: disable self-learning by default with --self-learning opt-in flag

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,8 +1,9 @@
 #!/bin/bash
-# Pre-push hook: Require CHANGELOG.md updates when modifying plugins in plugins/
+# Pre-push hook: Require changelog updates when modifying plugins in plugins/
 #
 # This script checks if any files in plugins/ are being pushed and ensures
-# that at least one CHANGELOG.md within plugins/ is also being modified.
+# that the repository changelog (or a plugin-local changelog, if present) is
+# also being modified.
 
 set -e
 
@@ -37,11 +38,11 @@ while read -r -t 5 local_ref local_sha remote_ref remote_sha; do
         continue
     fi
 
-    # Check for changes in plugins/ (excluding CHANGELOG.md files)
+    # Check for changes in plugins/ (excluding plugin-local CHANGELOG.md files)
     plugin_changes=$(echo "$changed_files" | grep -E '^plugins/' | grep -v 'CHANGELOG.md' || true)
 
-    # Check for CHANGELOG.md changes in plugins/
-    changelog_changes=$(echo "$changed_files" | grep -E '^plugins/.*CHANGELOG\.md$' || true)
+    # Accept either the root CHANGELOG.md or a plugin-local CHANGELOG.md
+    changelog_changes=$(echo "$changed_files" | grep -E '^(CHANGELOG\.md|plugins/.*CHANGELOG\.md)$' || true)
 
     if [ -n "$plugin_changes" ] && [ -z "$changelog_changes" ]; then
         echo -e "${RED}ERROR: Plugin changes detected without CHANGELOG.md update${NC}"
@@ -52,7 +53,8 @@ while read -r -t 5 local_ref local_sha remote_ref remote_sha; do
             echo "... and more"
         fi
         echo ""
-        echo -e "${YELLOW}Please update the appropriate CHANGELOG.md file:${NC}"
+        echo -e "${YELLOW}Please update CHANGELOG.md before pushing.${NC}"
+        echo "  - Preferred: CHANGELOG.md"
         # List available changelogs based on which plugins were modified
         modified_plugins=$(echo "$plugin_changes" | cut -d'/' -f2 | sort -u)
         for plugin in $modified_plugins; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [Releases]
+
+### code v1.5.0
+
+### Added
+- `--self-learning` opt-in flag for `run-loop.sh` -- self-learning is now disabled by default
+- `CLOSEDLOOP_SELF_LEARNING` config propagation via `config.env` and state frontmatter
+- Self-learning guard in `subagent-start-hook.sh` to skip learning injection when disabled
+- Self-learning guard in `subagent-stop-hook.sh` to skip entire learning region when disabled
+- Self-learning guard in `pretooluse-hook.sh` to skip tool-specific pattern injection when disabled
+
+### Changed
+- `post_iteration_processing()` skips steps 2-10 when self-learning is off; step 1 (changed-files.json) and step 11 (judges) always run
+- `bootstrap_learnings()` skips `.learnings/` directory creation when self-learning is off
+- `run_background_pruning()` skips pruning when self-learning is off
+- Resume restores `SELF_LEARNING` from state frontmatter and re-exports to hooks
 
 ### code v1.4.1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,15 +68,15 @@ All commits MUST follow the conventions in `CONTRIBUTING.md`. Specifically:
 - Valid types: `feat`, `fix`, `docs`, `refactor`
 - Valid scopes: `bootstrap`, `code`, `code-review`, `judges`, `platform`, `self-learning`
 - Examples: `feat(code): add visual-qa-subagent`, `fix(platform): correct tool list`
-- When modifying files under `plugins/`, also update the plugin version in `plugin.json` (semver) and `CHANGELOG.md`
+- When modifying files under `plugins/`, also update the plugin version in `plugin.json` (semver) and the root `CHANGELOG.md`
 
 ### Versioning
 
 Semver in each plugin's `plugin.json`. PATCH for bug fixes/prompt wording, MINOR for new agents/skills/commands, MAJOR for breaking changes to orchestration/hook API/skill interfaces.
 
-### Pre-push Hook
+### Pre-push Hook and CHANGELOG
 
-The `.githooks/pre-push` hook blocks pushes that modify files under `plugins/` without updating a `CHANGELOG.md` in the affected plugin directory.
+The `.githooks/pre-push` hook blocks pushes that modify files under `plugins/` without a `CHANGELOG.md` update. The CHANGELOG lives at the **repo root** (`CHANGELOG.md`), NOT inside individual plugin directories. Never create `plugins/<name>/CHANGELOG.md`.
 
 ### Branching
 

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/hooks/pretooluse-hook.sh
+++ b/plugins/code/hooks/pretooluse-hook.sh
@@ -134,6 +134,15 @@ mkdir -p "$CLOSEDLOOP_WORKDIR/.learnings"
 DEBUG_LOG="$CLOSEDLOOP_WORKDIR/.learnings/pretooluse-hook-debug.log"
 echo "$(date): PreToolUse hook started, tool=$TOOL_NAME" >> "$DEBUG_LOG"
 
+# Source closedloop config and skip learning injection if disabled
+CLOSEDLOOP_CONFIG="$CLOSEDLOOP_WORKDIR/.closedloop/config.env"
+if [[ -f "$CLOSEDLOOP_CONFIG" ]]; then
+    source "$CLOSEDLOOP_CONFIG"
+fi
+if [[ "${CLOSEDLOOP_SELF_LEARNING:-false}" != "true" ]]; then
+    exit 0
+fi
+
 # Path to org-patterns.toon (fall back to legacy location during migration)
 PATTERNS_FILE="$HOME/.closedloop-ai/learnings/org-patterns.toon"
 if [[ ! -f "$PATTERNS_FILE" ]]; then

--- a/plugins/code/hooks/subagent-start-hook.sh
+++ b/plugins/code/hooks/subagent-start-hook.sh
@@ -169,6 +169,14 @@ export CLAUDE_PLUGIN_ROOT=\"$PLUGIN_ROOT\"
 </closedloop-environment>"
 SUFFIX_PARTS="$ENV_INFO"
 
+# Skip learning injection if self-learning is disabled (agent-type tracking above is unconditional)
+if [[ "${CLOSEDLOOP_SELF_LEARNING:-false}" != "true" ]]; then
+    SUFFIX_ESCAPED=$(echo "$SUFFIX_PARTS" | jq -Rs '.')
+    echo "$(date): Self-learning disabled, skipping learning injection" >> "$DEBUG_LOG"
+    echo "{\"hookSpecificOutput\": {\"additionalContext\": $SUFFIX_ESCAPED}}"
+    exit 0
+fi
+
 # Derive agent name for learnings filtering
 # SubagentStart input provides agent_type (e.g., "code:plan-writer")
 # but not agentName. Use the short name already derived above.

--- a/plugins/code/hooks/subagent-stop-hook.sh
+++ b/plugins/code/hooks/subagent-stop-hook.sh
@@ -119,305 +119,307 @@ BUILDEOF
     fi
 fi
 
-# Check for pending learning file from this agent
-PENDING_FILE=$(find "$PENDING_DIR" -maxdepth 1 -name "*-${AGENT_NAME}.json" -type f 2>/dev/null | head -1)
+if [[ "${CLOSEDLOOP_SELF_LEARNING:-false}" == "true" ]]; then
+    # Check for pending learning file from this agent
+    PENDING_FILE=$(find "$PENDING_DIR" -maxdepth 1 -name "*-${AGENT_NAME}.json" -type f 2>/dev/null | head -1)
 
-# Check for LEARNINGS_ACKNOWLEDGED in agent output
-ACKNOWLEDGED=false
-EVIDENCE=""
+    # Check for LEARNINGS_ACKNOWLEDGED in agent output
+    ACKNOWLEDGED=false
+    EVIDENCE=""
 
-if echo "$AGENT_OUTPUT" | grep -q "LEARNINGS_ACKNOWLEDGED"; then
-    ACKNOWLEDGED=true
-    # Extract evidence (everything after LEARNINGS_ACKNOWLEDGED)
-    EVIDENCE=$(echo "$AGENT_OUTPUT" | grep -A 20 "LEARNINGS_ACKNOWLEDGED" | head -20)
-fi
-
-# Log acknowledgment for audit trail
-TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-APPLIED_PATTERNS=""
-
-if [[ "$ACKNOWLEDGED" == "true" ]]; then
-    # Parse applied patterns from evidence
-    while IFS= read -r line; do
-        if echo "$line" | grep -q 'Applied:'; then
-            # Extract pattern trigger from Applied: "pattern" -> [evidence]
-            PATTERN=$(echo "$line" | sed -n 's/.*Applied: "\([^"]*\)".*/\1/p')
-            if [[ -n "$PATTERN" ]]; then
-                APPLIED_PATTERNS="${APPLIED_PATTERNS}${PATTERN},"
-            fi
-        fi
-    done <<< "$EVIDENCE"
-
-    # Remove trailing comma
-    APPLIED_PATTERNS="${APPLIED_PATTERNS%,}"
-
-    # Log to acknowledgments.log
-    # Format: timestamp|run_id|iteration|agent|acknowledged|patterns_applied|evidence_summary
-    EVIDENCE_SUMMARY=$(echo "$EVIDENCE" | tr '\n' ' ' | cut -c1-200)
-    echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_NAME|true|$APPLIED_PATTERNS|$EVIDENCE_SUMMARY" >> "$LOGS_DIR/acknowledgments.log"
-
-    # Log explicitly-applied patterns to outcomes.log
-    # Format: timestamp|run_id|iteration|agent|pattern|status|file_citations
-    if [[ -n "$APPLIED_PATTERNS" ]]; then
-        IFS=',' read -ra PATTERNS <<< "$APPLIED_PATTERNS"
-        for pattern in "${PATTERNS[@]}"; do
-            # Extract file:line citations from evidence
-            CITATIONS=$(echo "$EVIDENCE" | grep -oE '[a-zA-Z0-9_/.-]+:[0-9]+' | tr '\n' ',' | sed 's/,$//')
-            # Sanitize pipe chars to prevent corrupting pipe-delimited outcomes.log
-            SAFE_PATTERN=$(echo "$pattern" | tr '|' '/')
-            echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_NAME|$SAFE_PATTERN|applied|$CITATIONS" >> "$LOGS_DIR/outcomes.log"
-        done
+    if echo "$AGENT_OUTPUT" | grep -q "LEARNINGS_ACKNOWLEDGED"; then
+        ACKNOWLEDGED=true
+        # Extract evidence (everything after LEARNINGS_ACKNOWLEDGED)
+        EVIDENCE=$(echo "$AGENT_OUTPUT" | grep -A 20 "LEARNINGS_ACKNOWLEDGED" | head -20)
     fi
-else
-    # Log missing acknowledgment
-    echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_NAME|false||missing acknowledgment" >> "$LOGS_DIR/acknowledgments.log"
-fi
 
-# ============================================================================
-# ALWAYS write injected patterns to outcomes.log (regardless of acknowledgment)
-# The start hook writes injected learnings to .closedloop-ai/learnings-{agent}
-# Read that file and log each injected pattern with its actual outcome status:
-#   - "applied" if agent explicitly cited it (already written above)
-#   - "injected" if patterns were sent but agent didn't cite them
-# This ensures compute_success_rates.py always has data to work with.
-# ============================================================================
-AGENT_NAME_LOWER=$(echo "$AGENT_NAME" | tr '[:upper:]' '[:lower:]')
-LEARNINGS_FILE="$CWD/.closedloop-ai/learnings-$AGENT_NAME_LOWER"
-# Fallback: check legacy path for mid-upgrade sessions
-if [[ ! -f "$LEARNINGS_FILE" ]] && [[ -f "$CWD/.claude/.closedloop/learnings-$AGENT_NAME_LOWER" ]]; then
-    LEARNINGS_FILE="$CWD/.claude/.closedloop/learnings-$AGENT_NAME_LOWER"
-fi
+    # Log acknowledgment for audit trail
+    TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    APPLIED_PATTERNS=""
 
-if [[ -f "$LEARNINGS_FILE" ]]; then
-    echo "$(date): Reading injected patterns from $LEARNINGS_FILE" >> "$DEBUG_LOG"
-
-    # Extract pattern summaries from the learnings file
-    # Format: [confidence] summary text (optional flags)
-    while IFS= read -r line; do
-        # Match lines like: [high] Some pattern summary [UNTESTED]
-        INJECTED_PATTERN=$(echo "$line" | sed -n 's/^\[.*\] \(.*\)$/\1/p' | sed 's/ \[UNTESTED\]$//; s/ \[REVIEW\]$//; s/ \[STALE\]$//; s/ \[PRUNE\]$//')
-        if [[ -z "$INJECTED_PATTERN" ]]; then
-            continue
-        fi
-
-        # Skip if this pattern was already written as "applied" above
-        ALREADY_APPLIED=false
-        if [[ -n "$APPLIED_PATTERNS" ]]; then
-            IFS=',' read -ra APPLIED_LIST <<< "$APPLIED_PATTERNS"
-            for applied in "${APPLIED_LIST[@]}"; do
-                if [[ "$applied" == "$INJECTED_PATTERN" ]]; then
-                    ALREADY_APPLIED=true
-                    break
+    if [[ "$ACKNOWLEDGED" == "true" ]]; then
+        # Parse applied patterns from evidence
+        while IFS= read -r line; do
+            if echo "$line" | grep -q 'Applied:'; then
+                # Extract pattern trigger from Applied: "pattern" -> [evidence]
+                PATTERN=$(echo "$line" | sed -n 's/.*Applied: "\([^"]*\)".*/\1/p')
+                if [[ -n "$PATTERN" ]]; then
+                    APPLIED_PATTERNS="${APPLIED_PATTERNS}${PATTERN},"
                 fi
+            fi
+        done <<< "$EVIDENCE"
+
+        # Remove trailing comma
+        APPLIED_PATTERNS="${APPLIED_PATTERNS%,}"
+
+        # Log to acknowledgments.log
+        # Format: timestamp|run_id|iteration|agent|acknowledged|patterns_applied|evidence_summary
+        EVIDENCE_SUMMARY=$(echo "$EVIDENCE" | tr '\n' ' ' | cut -c1-200)
+        echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_NAME|true|$APPLIED_PATTERNS|$EVIDENCE_SUMMARY" >> "$LOGS_DIR/acknowledgments.log"
+
+        # Log explicitly-applied patterns to outcomes.log
+        # Format: timestamp|run_id|iteration|agent|pattern|status|file_citations
+        if [[ -n "$APPLIED_PATTERNS" ]]; then
+            IFS=',' read -ra PATTERNS <<< "$APPLIED_PATTERNS"
+            for pattern in "${PATTERNS[@]}"; do
+                # Extract file:line citations from evidence
+                CITATIONS=$(echo "$EVIDENCE" | grep -oE '[a-zA-Z0-9_/.-]+:[0-9]+' | tr '\n' ',' | sed 's/,$//')
+                # Sanitize pipe chars to prevent corrupting pipe-delimited outcomes.log
+                SAFE_PATTERN=$(echo "$pattern" | tr '|' '/')
+                echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_NAME|$SAFE_PATTERN|applied|$CITATIONS" >> "$LOGS_DIR/outcomes.log"
             done
         fi
-
-        if [[ "$ALREADY_APPLIED" == "false" ]]; then
-            # Sanitize pipe chars to prevent corrupting pipe-delimited outcomes.log
-            SAFE_INJECTED=$(echo "$INJECTED_PATTERN" | tr '|' '/')
-            echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_NAME|$SAFE_INJECTED|injected|" >> "$LOGS_DIR/outcomes.log"
-        fi
-    done < "$LEARNINGS_FILE"
-
-    echo "$(date): Wrote injected pattern outcomes to outcomes.log" >> "$DEBUG_LOG"
-fi
-
-# Verify pending file exists (if agent should have captured learnings)
-# This is informational - we don't block the agent
-if [[ -z "$PENDING_FILE" ]]; then
-    # Check if agent output indicates no learnings needed
-    if echo "$AGENT_OUTPUT" | grep -q "no_learnings"; then
-        # Valid case - agent explicitly stated no learnings
-        :
     else
-        # Log warning about missing pending file
-        TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-        echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_NAME|warning|missing pending file" >> "$LOGS_DIR/failures.log" 2>/dev/null || true
+        # Log missing acknowledgment
+        echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_NAME|false||missing acknowledgment" >> "$LOGS_DIR/acknowledgments.log"
     fi
-fi
 
-# ============================================================================
-# LEARNING ACKNOWLEDGMENT ENFORCEMENT
-# Block agents that don't acknowledge learnings (if configured as learning_agent)
-# ============================================================================
+    # ============================================================================
+    # ALWAYS write injected patterns to outcomes.log (regardless of acknowledgment)
+    # The start hook writes injected learnings to .closedloop-ai/learnings-{agent}
+    # Read that file and log each injected pattern with its actual outcome status:
+    #   - "applied" if agent explicitly cited it (already written above)
+    #   - "injected" if patterns were sent but agent didn't cite them
+    # This ensures compute_success_rates.py always has data to work with.
+    # ============================================================================
+    AGENT_NAME_LOWER=$(echo "$AGENT_NAME" | tr '[:upper:]' '[:lower:]')
+    LEARNINGS_FILE="$CWD/.closedloop-ai/learnings-$AGENT_NAME_LOWER"
+    # Fallback: check legacy path for mid-upgrade sessions
+    if [[ ! -f "$LEARNINGS_FILE" ]] && [[ -f "$CWD/.claude/.closedloop/learnings-$AGENT_NAME_LOWER" ]]; then
+        LEARNINGS_FILE="$CWD/.claude/.closedloop/learnings-$AGENT_NAME_LOWER"
+    fi
 
-# Check if this agent is a learning agent
-IS_LEARNING_AGENT=false
-MAX_LEARNING_RETRIES=2
+    if [[ -f "$LEARNINGS_FILE" ]]; then
+        echo "$(date): Reading injected patterns from $LEARNINGS_FILE" >> "$DEBUG_LOG"
 
-if [[ -f "$LOOP_CONFIG" ]] && [[ -n "$AGENT_TYPE" ]]; then
-    # Check if agent is in learning_agents list
-    LEARNING_AGENTS=$(jq -r '.learning_agents.agents // [] | .[]' "$LOOP_CONFIG" 2>/dev/null)
-    MAX_LEARNING_RETRIES=$(jq -r '.learning_agents.max_retries // 2' "$LOOP_CONFIG" 2>/dev/null)
+        # Extract pattern summaries from the learnings file
+        # Format: [confidence] summary text (optional flags)
+        while IFS= read -r line; do
+            # Match lines like: [high] Some pattern summary [UNTESTED]
+            INJECTED_PATTERN=$(echo "$line" | sed -n 's/^\[.*\] \(.*\)$/\1/p' | sed 's/ \[UNTESTED\]$//; s/ \[REVIEW\]$//; s/ \[STALE\]$//; s/ \[PRUNE\]$//')
+            if [[ -z "$INJECTED_PATTERN" ]]; then
+                continue
+            fi
 
-    for agent in $LEARNING_AGENTS; do
-        if [[ "$agent" == "$AGENT_TYPE" ]]; then
-            IS_LEARNING_AGENT=true
-            echo "$(date): Agent $AGENT_TYPE is a learning agent" >> "$DEBUG_LOG"
-            break
-        fi
-    done
-fi
+            # Skip if this pattern was already written as "applied" above
+            ALREADY_APPLIED=false
+            if [[ -n "$APPLIED_PATTERNS" ]]; then
+                IFS=',' read -ra APPLIED_LIST <<< "$APPLIED_PATTERNS"
+                for applied in "${APPLIED_LIST[@]}"; do
+                    if [[ "$applied" == "$INJECTED_PATTERN" ]]; then
+                        ALREADY_APPLIED=true
+                        break
+                    fi
+                done
+            fi
 
-# If this is a learning agent, check for acknowledgment
-if [[ "$IS_LEARNING_AGENT" == "true" ]]; then
-    # Check if learnings were actually injected (org-patterns.toon exists)
-    PATTERNS_FILE="$CLOSEDLOOP_WORKDIR/.learnings/org-patterns.toon"
+            if [[ "$ALREADY_APPLIED" == "false" ]]; then
+                # Sanitize pipe chars to prevent corrupting pipe-delimited outcomes.log
+                SAFE_INJECTED=$(echo "$INJECTED_PATTERN" | tr '|' '/')
+                echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_NAME|$SAFE_INJECTED|injected|" >> "$LOGS_DIR/outcomes.log"
+            fi
+        done < "$LEARNINGS_FILE"
 
-    if [[ -f "$PATTERNS_FILE" ]]; then
-        echo "$(date): Learnings file exists, checking acknowledgment" >> "$DEBUG_LOG"
+        echo "$(date): Wrote injected pattern outcomes to outcomes.log" >> "$DEBUG_LOG"
+    fi
 
-        # Track retry count in state file
-        LEARNING_STATE_DIR="$CLOSEDLOOP_WORKDIR/.agent-types"
-        RETRY_FILE="$LEARNING_STATE_DIR/${AGENT_ID}-learning-retries"
-        mkdir -p "$LEARNING_STATE_DIR"
-
-        CURRENT_RETRY=0
-        if [[ -f "$RETRY_FILE" ]]; then
-            CURRENT_RETRY=$(cat "$RETRY_FILE")
-        fi
-
-        if [[ "$ACKNOWLEDGED" != "true" ]] && [[ $CURRENT_RETRY -lt $MAX_LEARNING_RETRIES ]]; then
-            # Increment retry count
-            NEXT_RETRY=$((CURRENT_RETRY + 1))
-            echo "$NEXT_RETRY" > "$RETRY_FILE"
-
-            echo "$(date): Blocking agent - no acknowledgment (retry $NEXT_RETRY/$MAX_LEARNING_RETRIES)" >> "$DEBUG_LOG"
-            echo "$(date): ACKNOWLEDGED=$ACKNOWLEDGED, PATTERNS_FILE=$PATTERNS_FILE" >> "$DEBUG_LOG"
-
-            # Block the agent and request acknowledgment
-            BLOCK_MSG="LEARNING ACKNOWLEDGMENT REQUIRED (attempt $NEXT_RETRY/$MAX_LEARNING_RETRIES)
-
-Organization learnings were injected into your context. You MUST acknowledge them before stopping.
-
-Output ONE of:
-1. LEARNINGS_ACKNOWLEDGED with evidence:
-   Applied: \"pattern trigger\" -> [evidence at file:line]
-   Applied: \"other pattern\" -> [evidence at file:line]
-
-2. LEARNINGS_ACKNOWLEDGED: no_learnings (reason why none applied)
-
-Without this acknowledgment, we cannot track learning effectiveness."
-
-            # Output block JSON
-            ACK_BLOCK_JSON=$(jq -n \
-                --arg reason "Please acknowledge the organization learnings that were provided to you." \
-                --arg msg "$BLOCK_MSG" \
-                '{
-                    "decision": "block",
-                    "reason": $reason,
-                    "systemMessage": $msg
-                }')
-            echo "$(date): Outputting acknowledgment block JSON: $ACK_BLOCK_JSON" >> "$DEBUG_LOG"
-            echo "$ACK_BLOCK_JSON"
-            exit 0
-        elif [[ "$ACKNOWLEDGED" == "true" ]]; then
-            # Clean up retry file on success
-            rm -f "$RETRY_FILE"
-            echo "$(date): Learning acknowledged successfully" >> "$DEBUG_LOG"
+    # Verify pending file exists (if agent should have captured learnings)
+    # This is informational - we don't block the agent
+    if [[ -z "$PENDING_FILE" ]]; then
+        # Check if agent output indicates no learnings needed
+        if echo "$AGENT_OUTPUT" | grep -q "no_learnings"; then
+            # Valid case - agent explicitly stated no learnings
+            :
         else
-            # Max retries reached, allow exit but log warning
-            rm -f "$RETRY_FILE"
-            echo "$(date): Max retries reached, allowing exit without acknowledgment" >> "$DEBUG_LOG"
+            # Log warning about missing pending file
             TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-            echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_TYPE|warning|max_retries_exceeded|no_acknowledgment" >> "$LOGS_DIR/failures.log" 2>/dev/null || true
+            echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_NAME|warning|missing pending file" >> "$LOGS_DIR/failures.log" 2>/dev/null || true
         fi
-    else
-        echo "$(date): No learnings file exists, skipping acknowledgment check" >> "$DEBUG_LOG"
-    fi
-fi
-
-# ============================================================================
-# NEW LEARNING CAPTURE ENFORCEMENT
-# Block learning agents that don't produce new learnings or explicitly state no_learnings
-# ============================================================================
-
-if [[ "$IS_LEARNING_AGENT" == "true" ]] && [[ -n "$CLOSEDLOOP_WORKDIR" ]]; then
-    echo "$(date): Checking for new learning capture" >> "$DEBUG_LOG"
-
-    # Create learnings directory if needed
-    LEARNINGS_PENDING_DIR="$CLOSEDLOOP_WORKDIR/.learnings/pending"
-    mkdir -p "$LEARNINGS_PENDING_DIR"
-
-    # Extract agent short name from agent type (e.g., "code:plan-writer" -> "plan-writer")
-    AGENT_SHORT_NAME="${AGENT_TYPE##*:}"
-    echo "$(date): Agent short name: $AGENT_SHORT_NAME, searching in: $LEARNINGS_PENDING_DIR" >> "$DEBUG_LOG"
-
-    # Check if agent produced a learning file (exact match by agent_id, or pattern match)
-    LEARNING_FILE=""
-    if [[ -n "$AGENT_ID" ]] && [[ -f "$LEARNINGS_PENDING_DIR/${AGENT_SHORT_NAME}-${AGENT_ID}.json" ]]; then
-        LEARNING_FILE="$LEARNINGS_PENDING_DIR/${AGENT_SHORT_NAME}-${AGENT_ID}.json"
-    else
-        # Fallback: search for any recent file from this agent type
-        LEARNING_FILE=$(find "$LEARNINGS_PENDING_DIR" -maxdepth 1 -name "${AGENT_SHORT_NAME}-*.json" -type f -mmin -5 2>/dev/null | head -1)
-    fi
-    echo "$(date): Learning file search result: '${LEARNING_FILE:-none found}'" >> "$DEBUG_LOG"
-
-    # Check if agent output contains no_learnings
-    HAS_NO_LEARNINGS=false
-    if echo "$AGENT_OUTPUT" | grep -q "no_learnings"; then
-        HAS_NO_LEARNINGS=true
-        echo "$(date): Agent explicitly stated no_learnings" >> "$DEBUG_LOG"
     fi
 
-    if [[ -z "$LEARNING_FILE" ]] && [[ "$HAS_NO_LEARNINGS" != "true" ]]; then
-        # Track retry count for learning capture
-        LEARNING_CAPTURE_RETRY_FILE="$CLOSEDLOOP_WORKDIR/.agent-types/${AGENT_ID}-capture-retries"
-        CAPTURE_RETRY=0
-        if [[ -f "$LEARNING_CAPTURE_RETRY_FILE" ]]; then
-            CAPTURE_RETRY=$(cat "$LEARNING_CAPTURE_RETRY_FILE")
-        fi
+    # ============================================================================
+    # LEARNING ACKNOWLEDGMENT ENFORCEMENT
+    # Block agents that don't acknowledge learnings (if configured as learning_agent)
+    # ============================================================================
 
-        if [[ $CAPTURE_RETRY -lt $MAX_LEARNING_RETRIES ]]; then
-            # Increment retry count
-            NEXT_CAPTURE_RETRY=$((CAPTURE_RETRY + 1))
-            echo "$NEXT_CAPTURE_RETRY" > "$LEARNING_CAPTURE_RETRY_FILE"
+    # Check if this agent is a learning agent
+    IS_LEARNING_AGENT=false
+    MAX_LEARNING_RETRIES=2
 
-            echo "$(date): Blocking agent - no learning captured (retry $NEXT_CAPTURE_RETRY/$MAX_LEARNING_RETRIES)" >> "$DEBUG_LOG"
-            echo "$(date): HAS_NO_LEARNINGS=$HAS_NO_LEARNINGS, LEARNING_FILE='$LEARNING_FILE'" >> "$DEBUG_LOG"
+    if [[ -f "$LOOP_CONFIG" ]] && [[ -n "$AGENT_TYPE" ]]; then
+        # Check if agent is in learning_agents list
+        LEARNING_AGENTS=$(jq -r '.learning_agents.agents // [] | .[]' "$LOOP_CONFIG" 2>/dev/null)
+        MAX_LEARNING_RETRIES=$(jq -r '.learning_agents.max_retries // 2' "$LOOP_CONFIG" 2>/dev/null)
 
-            CAPTURE_BLOCK_MSG="LEARNING CAPTURE REQUIRED (attempt $NEXT_CAPTURE_RETRY/$MAX_LEARNING_RETRIES)
+        for agent in $LEARNING_AGENTS; do
+            if [[ "$agent" == "$AGENT_TYPE" ]]; then
+                IS_LEARNING_AGENT=true
+                echo "$(date): Agent $AGENT_TYPE is a learning agent" >> "$DEBUG_LOG"
+                break
+            fi
+        done
+    fi
 
-You MUST capture learnings before stopping. Write to: $LEARNINGS_PENDING_DIR/${AGENT_SHORT_NAME}-${AGENT_ID}.json
+    # If this is a learning agent, check for acknowledgment
+    if [[ "$IS_LEARNING_AGENT" == "true" ]]; then
+        # Check if learnings were actually injected (org-patterns.toon exists)
+        PATTERNS_FILE="$CLOSEDLOOP_WORKDIR/.learnings/org-patterns.toon"
 
-Format:
-{
-  \"what_happened\": \"Brief description\",
-  \"why\": \"Root cause or why this matters\",
-  \"fix_applied\": \"What you did (if applicable)\",
-  \"pattern_to_remember\": \"Actionable takeaway (20+ chars, specific not generic)\",
-  \"applies_to\": [\"${AGENT_TYPE}\"],
-  \"context\": { \"file\": \"path/to/file\", \"line\": 42 }
-}
+        if [[ -f "$PATTERNS_FILE" ]]; then
+            echo "$(date): Learnings file exists, checking acknowledgment" >> "$DEBUG_LOG"
 
-OR if no learnings, output: { \"no_learnings\": true, \"reason\": \"explanation\" }
+            # Track retry count in state file
+            LEARNING_STATE_DIR="$CLOSEDLOOP_WORKDIR/.agent-types"
+            RETRY_FILE="$LEARNING_STATE_DIR/${AGENT_ID}-learning-retries"
+            mkdir -p "$LEARNING_STATE_DIR"
 
-Good patterns: \"Always check for None before accessing .items() on optional dicts\"
-Bad patterns: \"Be careful with None\" (too vague)"
+            CURRENT_RETRY=0
+            if [[ -f "$RETRY_FILE" ]]; then
+                CURRENT_RETRY=$(cat "$RETRY_FILE")
+            fi
 
-            BLOCK_JSON=$(jq -n \
-                --arg reason "Please capture learnings from your work before stopping." \
-                --arg msg "$CAPTURE_BLOCK_MSG" \
-                '{
-                    "decision": "block",
-                    "reason": $reason,
-                    "systemMessage": $msg
-                }')
-            echo "$(date): Outputting learning capture block JSON: $BLOCK_JSON" >> "$DEBUG_LOG"
-            echo "$BLOCK_JSON"
-            exit 0
+            if [[ "$ACKNOWLEDGED" != "true" ]] && [[ $CURRENT_RETRY -lt $MAX_LEARNING_RETRIES ]]; then
+                # Increment retry count
+                NEXT_RETRY=$((CURRENT_RETRY + 1))
+                echo "$NEXT_RETRY" > "$RETRY_FILE"
+
+                echo "$(date): Blocking agent - no acknowledgment (retry $NEXT_RETRY/$MAX_LEARNING_RETRIES)" >> "$DEBUG_LOG"
+                echo "$(date): ACKNOWLEDGED=$ACKNOWLEDGED, PATTERNS_FILE=$PATTERNS_FILE" >> "$DEBUG_LOG"
+
+                # Block the agent and request acknowledgment
+                BLOCK_MSG="LEARNING ACKNOWLEDGMENT REQUIRED (attempt $NEXT_RETRY/$MAX_LEARNING_RETRIES)
+
+    Organization learnings were injected into your context. You MUST acknowledge them before stopping.
+
+    Output ONE of:
+    1. LEARNINGS_ACKNOWLEDGED with evidence:
+       Applied: \"pattern trigger\" -> [evidence at file:line]
+       Applied: \"other pattern\" -> [evidence at file:line]
+
+    2. LEARNINGS_ACKNOWLEDGED: no_learnings (reason why none applied)
+
+    Without this acknowledgment, we cannot track learning effectiveness."
+
+                # Output block JSON
+                ACK_BLOCK_JSON=$(jq -n \
+                    --arg reason "Please acknowledge the organization learnings that were provided to you." \
+                    --arg msg "$BLOCK_MSG" \
+                    '{
+                        "decision": "block",
+                        "reason": $reason,
+                        "systemMessage": $msg
+                    }')
+                echo "$(date): Outputting acknowledgment block JSON: $ACK_BLOCK_JSON" >> "$DEBUG_LOG"
+                echo "$ACK_BLOCK_JSON"
+                exit 0
+            elif [[ "$ACKNOWLEDGED" == "true" ]]; then
+                # Clean up retry file on success
+                rm -f "$RETRY_FILE"
+                echo "$(date): Learning acknowledged successfully" >> "$DEBUG_LOG"
+            else
+                # Max retries reached, allow exit but log warning
+                rm -f "$RETRY_FILE"
+                echo "$(date): Max retries reached, allowing exit without acknowledgment" >> "$DEBUG_LOG"
+                TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+                echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_TYPE|warning|max_retries_exceeded|no_acknowledgment" >> "$LOGS_DIR/failures.log" 2>/dev/null || true
+            fi
         else
-            # Max retries reached
-            rm -f "$LEARNING_CAPTURE_RETRY_FILE"
-            echo "$(date): Max capture retries reached, allowing exit" >> "$DEBUG_LOG"
-            TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-            echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_TYPE|warning|max_retries_exceeded|no_learning_captured" >> "$LOGS_DIR/failures.log" 2>/dev/null || true
+            echo "$(date): No learnings file exists, skipping acknowledgment check" >> "$DEBUG_LOG"
         fi
-    else
-        # Learning captured or no_learnings stated - clean up
-        rm -f "$CLOSEDLOOP_WORKDIR/.agent-types/${AGENT_ID}-capture-retries"
-        if [[ -n "$LEARNING_FILE" ]]; then
-            echo "$(date): Learning file found: $LEARNING_FILE" >> "$DEBUG_LOG"
+    fi
+
+    # ============================================================================
+    # NEW LEARNING CAPTURE ENFORCEMENT
+    # Block learning agents that don't produce new learnings or explicitly state no_learnings
+    # ============================================================================
+
+    if [[ "$IS_LEARNING_AGENT" == "true" ]] && [[ -n "$CLOSEDLOOP_WORKDIR" ]]; then
+        echo "$(date): Checking for new learning capture" >> "$DEBUG_LOG"
+
+        # Create learnings directory if needed
+        LEARNINGS_PENDING_DIR="$CLOSEDLOOP_WORKDIR/.learnings/pending"
+        mkdir -p "$LEARNINGS_PENDING_DIR"
+
+        # Extract agent short name from agent type (e.g., "code:plan-writer" -> "plan-writer")
+        AGENT_SHORT_NAME="${AGENT_TYPE##*:}"
+        echo "$(date): Agent short name: $AGENT_SHORT_NAME, searching in: $LEARNINGS_PENDING_DIR" >> "$DEBUG_LOG"
+
+        # Check if agent produced a learning file (exact match by agent_id, or pattern match)
+        LEARNING_FILE=""
+        if [[ -n "$AGENT_ID" ]] && [[ -f "$LEARNINGS_PENDING_DIR/${AGENT_SHORT_NAME}-${AGENT_ID}.json" ]]; then
+            LEARNING_FILE="$LEARNINGS_PENDING_DIR/${AGENT_SHORT_NAME}-${AGENT_ID}.json"
+        else
+            # Fallback: search for any recent file from this agent type
+            LEARNING_FILE=$(find "$LEARNINGS_PENDING_DIR" -maxdepth 1 -name "${AGENT_SHORT_NAME}-*.json" -type f -mmin -5 2>/dev/null | head -1)
+        fi
+        echo "$(date): Learning file search result: '${LEARNING_FILE:-none found}'" >> "$DEBUG_LOG"
+
+        # Check if agent output contains no_learnings
+        HAS_NO_LEARNINGS=false
+        if echo "$AGENT_OUTPUT" | grep -q "no_learnings"; then
+            HAS_NO_LEARNINGS=true
+            echo "$(date): Agent explicitly stated no_learnings" >> "$DEBUG_LOG"
+        fi
+
+        if [[ -z "$LEARNING_FILE" ]] && [[ "$HAS_NO_LEARNINGS" != "true" ]]; then
+            # Track retry count for learning capture
+            LEARNING_CAPTURE_RETRY_FILE="$CLOSEDLOOP_WORKDIR/.agent-types/${AGENT_ID}-capture-retries"
+            CAPTURE_RETRY=0
+            if [[ -f "$LEARNING_CAPTURE_RETRY_FILE" ]]; then
+                CAPTURE_RETRY=$(cat "$LEARNING_CAPTURE_RETRY_FILE")
+            fi
+
+            if [[ $CAPTURE_RETRY -lt $MAX_LEARNING_RETRIES ]]; then
+                # Increment retry count
+                NEXT_CAPTURE_RETRY=$((CAPTURE_RETRY + 1))
+                echo "$NEXT_CAPTURE_RETRY" > "$LEARNING_CAPTURE_RETRY_FILE"
+
+                echo "$(date): Blocking agent - no learning captured (retry $NEXT_CAPTURE_RETRY/$MAX_LEARNING_RETRIES)" >> "$DEBUG_LOG"
+                echo "$(date): HAS_NO_LEARNINGS=$HAS_NO_LEARNINGS, LEARNING_FILE='$LEARNING_FILE'" >> "$DEBUG_LOG"
+
+                CAPTURE_BLOCK_MSG="LEARNING CAPTURE REQUIRED (attempt $NEXT_CAPTURE_RETRY/$MAX_LEARNING_RETRIES)
+
+    You MUST capture learnings before stopping. Write to: $LEARNINGS_PENDING_DIR/${AGENT_SHORT_NAME}-${AGENT_ID}.json
+
+    Format:
+    {
+      \"what_happened\": \"Brief description\",
+      \"why\": \"Root cause or why this matters\",
+      \"fix_applied\": \"What you did (if applicable)\",
+      \"pattern_to_remember\": \"Actionable takeaway (20+ chars, specific not generic)\",
+      \"applies_to\": [\"${AGENT_TYPE}\"],
+      \"context\": { \"file\": \"path/to/file\", \"line\": 42 }
+    }
+
+    OR if no learnings, output: { \"no_learnings\": true, \"reason\": \"explanation\" }
+
+    Good patterns: \"Always check for None before accessing .items() on optional dicts\"
+    Bad patterns: \"Be careful with None\" (too vague)"
+
+                BLOCK_JSON=$(jq -n \
+                    --arg reason "Please capture learnings from your work before stopping." \
+                    --arg msg "$CAPTURE_BLOCK_MSG" \
+                    '{
+                        "decision": "block",
+                        "reason": $reason,
+                        "systemMessage": $msg
+                    }')
+                echo "$(date): Outputting learning capture block JSON: $BLOCK_JSON" >> "$DEBUG_LOG"
+                echo "$BLOCK_JSON"
+                exit 0
+            else
+                # Max retries reached
+                rm -f "$LEARNING_CAPTURE_RETRY_FILE"
+                echo "$(date): Max capture retries reached, allowing exit" >> "$DEBUG_LOG"
+                TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+                echo "$TIMESTAMP|$RUN_ID|$ITERATION|$AGENT_TYPE|warning|max_retries_exceeded|no_learning_captured" >> "$LOGS_DIR/failures.log" 2>/dev/null || true
+            fi
+        else
+            # Learning captured or no_learnings stated - clean up
+            rm -f "$CLOSEDLOOP_WORKDIR/.agent-types/${AGENT_ID}-capture-retries"
+            if [[ -n "$LEARNING_FILE" ]]; then
+                echo "$(date): Learning file found: $LEARNING_FILE" >> "$DEBUG_LOG"
+            fi
         fi
     fi
 fi

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -27,6 +27,7 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Run identification
 RUN_ID=""
 START_SHA=""
+SELF_LEARNING=false
 
 # Check for jq dependency (required for learning system)
 check_jq_dependency() {
@@ -99,6 +100,11 @@ release_lock() {
 # Bootstrap run-specific learnings directories
 bootstrap_learnings() {
   local workdir="$1"
+
+  if [[ "${SELF_LEARNING:-false}" != "true" ]]; then
+    return
+  fi
+
   local bootstrap_script="$SCRIPTS_DIR/bootstrap-learnings.sh"
 
   if [[ ! -d "$workdir/.learnings" ]]; then
@@ -491,181 +497,195 @@ post_iteration_processing() {
     emit_skipped_step 1 "changed_files"
   fi
 
-  # Step 2: pattern_relevance.py (score patterns -> relevance-scores.json)
-  local relevance_script="$sl_tools_dir/pattern_relevance.py"
-  if [[ -f "$relevance_script" ]] && [[ -f "$workdir/.learnings/changed-files.json" ]]; then
-    echo -e "${BLUE}[2/10] Computing pattern relevance...${NC}"
-    log_progress "Step 2: Running pattern_relevance.py"
-    if run_timed_step 2 "pattern_relevance" bash -c "
-      python3 '$relevance_script' \
-          --workdir '$workdir' \
-          --changed-files '$workdir/.learnings/changed-files.json' \
-          --output '$workdir/.learnings/relevance-scores.json' 2>&1 | tee -a '$PROGRESS_LOG'
-    "; then
-      log_progress "Step 2: Pattern relevance completed"
-    else
-      log_progress "Step 2: pattern_relevance.py encountered errors (continuing)"
-    fi
-  else
-    emit_skipped_step 2 "pattern_relevance"
-  fi
-
-  # Step 3: merge_relevance.py (append relevance to outcomes.log)
-  local merge_rel_script="$sl_tools_dir/merge_relevance.py"
-  if [[ -f "$merge_rel_script" ]] && [[ -f "$workdir/.learnings/relevance-scores.json" ]]; then
-    echo -e "${BLUE}[3/10] Merging relevance scores...${NC}"
-    log_progress "Step 3: Running merge_relevance.py"
-    if run_timed_step 3 "merge_relevance" bash -c "
-      python3 '$merge_rel_script' \
-          --workdir '$workdir' \
-          --relevance-file '$workdir/.learnings/relevance-scores.json' 2>&1 | tee -a '$PROGRESS_LOG'
-    "; then
-      log_progress "Step 3: Relevance merge completed"
-    else
-      log_progress "Step 3: merge_relevance.py encountered errors (continuing)"
-    fi
-  else
-    emit_skipped_step 3 "merge_relevance"
-  fi
-
-  # Step 4: evaluate_goal.py (evaluate goal -> goal-outcome.json)
-  local eval_script="$sl_tools_dir/evaluate_goal.py"
-  if [[ -f "$eval_script" ]]; then
-    echo -e "${BLUE}[4/10] Evaluating goal...${NC}"
-    log_progress "Step 4: Running evaluate_goal.py"
-    if run_timed_step 4 "evaluate_goal" bash -c "
-      python3 '$eval_script' \
-          --workdir '$workdir' \
-          --run-id '$RUN_ID' 2>&1 | tee -a '$PROGRESS_LOG'
-    "; then
-      log_progress "Step 4: Goal evaluation completed"
-    else
-      log_progress "Step 4: evaluate_goal.py encountered errors (continuing)"
-    fi
-  else
-    emit_skipped_step 4 "evaluate_goal"
-  fi
-
-  # Step 5: merge_goal_outcome.py (append goal data to outcomes.log)
-  local merge_goal_script="$sl_tools_dir/merge_goal_outcome.py"
-  if [[ -f "$merge_goal_script" ]] && [[ -f "$workdir/.learnings/goal-outcome.json" ]]; then
-    echo -e "${BLUE}[5/10] Merging goal outcome...${NC}"
-    log_progress "Step 5: Running merge_goal_outcome.py"
-    if run_timed_step 5 "merge_goal_outcome" bash -c "
-      python3 '$merge_goal_script' \
-          --workdir '$workdir' 2>&1 | tee -a '$PROGRESS_LOG'
-    "; then
-      log_progress "Step 5: Goal outcome merge completed"
-    else
-      log_progress "Step 5: merge_goal_outcome.py encountered errors (continuing)"
-    fi
-  else
-    emit_skipped_step 5 "merge_goal_outcome"
-  fi
-
-  # Step 6: verify_citations.py (mark |unverified in outcomes.log)
-  if [[ -n "$START_SHA" ]]; then
-    local verify_script="$sl_tools_dir/verify_citations.py"
-    if [[ -f "$verify_script" ]]; then
-      echo -e "${BLUE}[6/10] Verifying citations...${NC}"
-      log_progress "Step 6: Running verify_citations.py"
-      if run_timed_step 6 "verify_citations" bash -c "
-        python3 '$verify_script' --start-sha '$START_SHA' --workdir '$workdir' 2>&1 | tee -a '$PROGRESS_LOG'
+  if [[ "${SELF_LEARNING:-false}" == "true" ]]; then
+    # Step 2: pattern_relevance.py (score patterns -> relevance-scores.json)
+    local relevance_script="$sl_tools_dir/pattern_relevance.py"
+    if [[ -f "$relevance_script" ]] && [[ -f "$workdir/.learnings/changed-files.json" ]]; then
+      echo -e "${BLUE}[2/10] Computing pattern relevance...${NC}"
+      log_progress "Step 2: Running pattern_relevance.py"
+      if run_timed_step 2 "pattern_relevance" bash -c "
+        python3 '$relevance_script' \
+            --workdir '$workdir' \
+            --changed-files '$workdir/.learnings/changed-files.json' \
+            --output '$workdir/.learnings/relevance-scores.json' 2>&1 | tee -a '$PROGRESS_LOG'
       "; then
-        log_progress "Step 6: Citation verification passed"
+        log_progress "Step 2: Pattern relevance completed"
       else
-        log_progress "Step 6: Citation verification found issues (see failures.md)"
+        log_progress "Step 2: pattern_relevance.py encountered errors (continuing)"
+      fi
+    else
+      emit_skipped_step 2 "pattern_relevance"
+    fi
+
+    # Step 3: merge_relevance.py (append relevance to outcomes.log)
+    local merge_rel_script="$sl_tools_dir/merge_relevance.py"
+    if [[ -f "$merge_rel_script" ]] && [[ -f "$workdir/.learnings/relevance-scores.json" ]]; then
+      echo -e "${BLUE}[3/10] Merging relevance scores...${NC}"
+      log_progress "Step 3: Running merge_relevance.py"
+      if run_timed_step 3 "merge_relevance" bash -c "
+        python3 '$merge_rel_script' \
+            --workdir '$workdir' \
+            --relevance-file '$workdir/.learnings/relevance-scores.json' 2>&1 | tee -a '$PROGRESS_LOG'
+      "; then
+        log_progress "Step 3: Relevance merge completed"
+      else
+        log_progress "Step 3: merge_relevance.py encountered errors (continuing)"
+      fi
+    else
+      emit_skipped_step 3 "merge_relevance"
+    fi
+
+    # Step 4: evaluate_goal.py (evaluate goal -> goal-outcome.json)
+    local eval_script="$sl_tools_dir/evaluate_goal.py"
+    if [[ -f "$eval_script" ]]; then
+      echo -e "${BLUE}[4/10] Evaluating goal...${NC}"
+      log_progress "Step 4: Running evaluate_goal.py"
+      if run_timed_step 4 "evaluate_goal" bash -c "
+        python3 '$eval_script' \
+            --workdir '$workdir' \
+            --run-id '$RUN_ID' 2>&1 | tee -a '$PROGRESS_LOG'
+      "; then
+        log_progress "Step 4: Goal evaluation completed"
+      else
+        log_progress "Step 4: evaluate_goal.py encountered errors (continuing)"
+      fi
+    else
+      emit_skipped_step 4 "evaluate_goal"
+    fi
+
+    # Step 5: merge_goal_outcome.py (append goal data to outcomes.log)
+    local merge_goal_script="$sl_tools_dir/merge_goal_outcome.py"
+    if [[ -f "$merge_goal_script" ]] && [[ -f "$workdir/.learnings/goal-outcome.json" ]]; then
+      echo -e "${BLUE}[5/10] Merging goal outcome...${NC}"
+      log_progress "Step 5: Running merge_goal_outcome.py"
+      if run_timed_step 5 "merge_goal_outcome" bash -c "
+        python3 '$merge_goal_script' \
+            --workdir '$workdir' 2>&1 | tee -a '$PROGRESS_LOG'
+      "; then
+        log_progress "Step 5: Goal outcome merge completed"
+      else
+        log_progress "Step 5: merge_goal_outcome.py encountered errors (continuing)"
+      fi
+    else
+      emit_skipped_step 5 "merge_goal_outcome"
+    fi
+
+    # Step 6: verify_citations.py (mark |unverified in outcomes.log)
+    if [[ -n "$START_SHA" ]]; then
+      local verify_script="$sl_tools_dir/verify_citations.py"
+      if [[ -f "$verify_script" ]]; then
+        echo -e "${BLUE}[6/10] Verifying citations...${NC}"
+        log_progress "Step 6: Running verify_citations.py"
+        if run_timed_step 6 "verify_citations" bash -c "
+          python3 '$verify_script' --start-sha '$START_SHA' --workdir '$workdir' 2>&1 | tee -a '$PROGRESS_LOG'
+        "; then
+          log_progress "Step 6: Citation verification passed"
+        else
+          log_progress "Step 6: Citation verification found issues (see failures.md)"
+        fi
+      else
+        emit_skipped_step 6 "verify_citations"
       fi
     else
       emit_skipped_step 6 "verify_citations"
     fi
+
+    # Step 7: Merge build-validator results into outcomes.log
+    local merge_build_script="$sl_tools_dir/merge_build_result.py"
+    if [[ -f "$merge_build_script" ]] && [[ -f "$workdir/.learnings/build-result.json" ]]; then
+      echo -e "${BLUE}[7/10] Merging build-validator results...${NC}"
+      log_progress "Step 7: Running merge_build_result.py"
+      if run_timed_step 7 "merge_build_result" bash -c "
+        python3 '$merge_build_script' --workdir '$workdir' 2>&1 | tee -a '$PROGRESS_LOG'
+      "; then
+        log_progress "Step 7: Build result merge completed"
+      else
+        log_progress "Step 7: merge_build_result.py encountered errors (continuing)"
+      fi
+    else
+      emit_skipped_step 7 "merge_build_result"
+    fi
+
+    # Step 8: Process pending learnings (LLM classifies and aggregates into org-patterns.toon)
+    local pending_dir="$workdir/.learnings/pending"
+    if [[ -d "$pending_dir" ]] && [[ -n "$(ls -A "$pending_dir"/*.json 2>/dev/null)" ]]; then
+      echo -e "${BLUE}[8/10] Processing pending learnings...${NC}"
+      log_progress "Step 8: Running process-learnings"
+      if run_timed_step 8 "process_learnings" bash -c "
+        claude -p 'Run /self-learning:process-learnings $workdir' \
+            --allowed-tools=Bash,Grep,Glob,Read,Write \
+            --max-turns 100 2>&1 | tee -a '$PROGRESS_LOG'
+      "; then
+        log_progress "Step 8: Learning processing completed"
+      else
+        log_progress "Step 8: Learning processing encountered errors (continuing)"
+      fi
+    else
+      emit_skipped_step 8 "process_learnings"
+    fi
+
+    # Step 8.5: Write merge-result.json → org-patterns.toon (deterministic)
+    local merge_script="$sl_tools_dir/write_merged_patterns.py"
+    local merge_result="$workdir/.learnings/merge-result.json"
+    if [[ -f "$merge_result" ]] && [[ -f "$merge_script" ]]; then
+      echo -e "${BLUE}[8.5/10] Writing merged patterns to TOON...${NC}"
+      log_progress "Step 8.5: Running write_merged_patterns.py"
+      if run_timed_step 8.5 "write_merged_patterns" bash -c "
+        python3 '$merge_script' --merge-result '$merge_result' 2>&1 | tee -a '$PROGRESS_LOG'
+      "; then
+        log_progress "Step 8.5: TOON write completed"
+        # Cleanup session files only after successful TOON write
+        rm -rf "$workdir/.learnings/sessions/run-"* 2>/dev/null || true
+      else
+        log_progress "Step 8.5: TOON write failed — session files preserved for retry"
+      fi
+    else
+      emit_skipped_step 8.5 "write_merged_patterns"
+    fi
+
+    # Step 9: compute_success_rates.py (deterministic rates -> update org-patterns.toon)
+    local rates_script="$sl_tools_dir/compute_success_rates.py"
+    if [[ -f "$rates_script" ]]; then
+      echo -e "${BLUE}[9/10] Computing success rates...${NC}"
+      log_progress "Step 9: Running compute_success_rates.py"
+      if run_timed_step 9 "compute_success_rates" bash -c "
+        python3 '$rates_script' --workdir '$workdir' 2>&1 | tee -a '$PROGRESS_LOG'
+      "; then
+        log_progress "Step 9: Success rate computation completed"
+      else
+        log_progress "Step 9: compute_success_rates.py encountered errors (continuing)"
+      fi
+    else
+      emit_skipped_step 9 "compute_success_rates"
+    fi
+
+    # Step 10: Export closedloop learnings to global location
+    if [[ -f "$workdir/.learnings/pending-closedloop.json" ]]; then
+      echo -e "${BLUE}[10/10] Exporting closedloop learnings...${NC}"
+      log_progress "Step 10: Running export-closedloop-learnings"
+      if run_timed_step 10 "export_closedloop_learnings" bash -c "
+        claude -p '/self-learning:export-closedloop-learnings $workdir' \
+            --allowed-tools=Bash,Grep,Glob,Read,Write \
+            --max-turns 20 2>&1 | tee -a '$PROGRESS_LOG'
+      "; then
+        log_progress "Step 10: ClosedLoop learning export completed"
+      else
+        log_progress "Step 10: ClosedLoop learning export encountered errors (continuing)"
+      fi
+    else
+      emit_skipped_step 10 "export_closedloop_learnings"
+    fi
   else
+    log_progress "Self-learning disabled, skipping post-iteration pipeline (steps 2-10)"
+    emit_skipped_step 2 "pattern_relevance"
+    emit_skipped_step 3 "merge_relevance"
+    emit_skipped_step 4 "evaluate_goal"
+    emit_skipped_step 5 "merge_goal_outcome"
     emit_skipped_step 6 "verify_citations"
-  fi
-
-  # Step 7: Merge build-validator results into outcomes.log
-  local merge_build_script="$sl_tools_dir/merge_build_result.py"
-  if [[ -f "$merge_build_script" ]] && [[ -f "$workdir/.learnings/build-result.json" ]]; then
-    echo -e "${BLUE}[7/10] Merging build-validator results...${NC}"
-    log_progress "Step 7: Running merge_build_result.py"
-    if run_timed_step 7 "merge_build_result" bash -c "
-      python3 '$merge_build_script' --workdir '$workdir' 2>&1 | tee -a '$PROGRESS_LOG'
-    "; then
-      log_progress "Step 7: Build result merge completed"
-    else
-      log_progress "Step 7: merge_build_result.py encountered errors (continuing)"
-    fi
-  else
     emit_skipped_step 7 "merge_build_result"
-  fi
-
-  # Step 8: Process pending learnings (LLM classifies and aggregates into org-patterns.toon)
-  local pending_dir="$workdir/.learnings/pending"
-  if [[ -d "$pending_dir" ]] && [[ -n "$(ls -A "$pending_dir"/*.json 2>/dev/null)" ]]; then
-    echo -e "${BLUE}[8/10] Processing pending learnings...${NC}"
-    log_progress "Step 8: Running process-learnings"
-    if run_timed_step 8 "process_learnings" bash -c "
-      claude -p 'Run /self-learning:process-learnings $workdir' \
-          --allowed-tools=Bash,Grep,Glob,Read,Write \
-          --max-turns 100 2>&1 | tee -a '$PROGRESS_LOG'
-    "; then
-      log_progress "Step 8: Learning processing completed"
-    else
-      log_progress "Step 8: Learning processing encountered errors (continuing)"
-    fi
-  else
     emit_skipped_step 8 "process_learnings"
-  fi
-
-  # Step 8.5: Write merge-result.json → org-patterns.toon (deterministic)
-  local merge_script="$sl_tools_dir/write_merged_patterns.py"
-  local merge_result="$workdir/.learnings/merge-result.json"
-  if [[ -f "$merge_result" ]] && [[ -f "$merge_script" ]]; then
-    echo -e "${BLUE}[8.5/10] Writing merged patterns to TOON...${NC}"
-    log_progress "Step 8.5: Running write_merged_patterns.py"
-    if run_timed_step 8.5 "write_merged_patterns" bash -c "
-      python3 '$merge_script' --merge-result '$merge_result' 2>&1 | tee -a '$PROGRESS_LOG'
-    "; then
-      log_progress "Step 8.5: TOON write completed"
-      # Cleanup session files only after successful TOON write
-      rm -rf "$workdir/.learnings/sessions/run-"* 2>/dev/null || true
-    else
-      log_progress "Step 8.5: TOON write failed — session files preserved for retry"
-    fi
-  else
     emit_skipped_step 8.5 "write_merged_patterns"
-  fi
-
-  # Step 9: compute_success_rates.py (deterministic rates -> update org-patterns.toon)
-  local rates_script="$sl_tools_dir/compute_success_rates.py"
-  if [[ -f "$rates_script" ]]; then
-    echo -e "${BLUE}[9/10] Computing success rates...${NC}"
-    log_progress "Step 9: Running compute_success_rates.py"
-    if run_timed_step 9 "compute_success_rates" bash -c "
-      python3 '$rates_script' --workdir '$workdir' 2>&1 | tee -a '$PROGRESS_LOG'
-    "; then
-      log_progress "Step 9: Success rate computation completed"
-    else
-      log_progress "Step 9: compute_success_rates.py encountered errors (continuing)"
-    fi
-  else
     emit_skipped_step 9 "compute_success_rates"
-  fi
-
-  # Step 10: Export closedloop learnings to global location
-  if [[ -f "$workdir/.learnings/pending-closedloop.json" ]]; then
-    echo -e "${BLUE}[10/10] Exporting closedloop learnings...${NC}"
-    log_progress "Step 10: Running export-closedloop-learnings"
-    if run_timed_step 10 "export_closedloop_learnings" bash -c "
-      claude -p '/self-learning:export-closedloop-learnings $workdir' \
-          --allowed-tools=Bash,Grep,Glob,Read,Write \
-          --max-turns 20 2>&1 | tee -a '$PROGRESS_LOG'
-    "; then
-      log_progress "Step 10: ClosedLoop learning export completed"
-    else
-      log_progress "Step 10: ClosedLoop learning export encountered errors (continuing)"
-    fi
-  else
     emit_skipped_step 10 "export_closedloop_learnings"
   fi
 
@@ -676,6 +696,11 @@ post_iteration_processing() {
 # Run pruning in background after loop completes
 run_background_pruning() {
   local workdir="$1"
+
+  if [[ "${SELF_LEARNING:-false}" != "true" ]]; then
+    return
+  fi
+
   local prune_script="$SCRIPTS_DIR/prune-learnings.sh"
 
   if [[ -x "$prune_script" ]]; then
@@ -702,6 +727,7 @@ OPTIONS:
   --prompt <name>                Orchestrator prompt name from prompts/ folder (default: prompt)
   --max-iterations <n>           Maximum iterations (default: 50)
   --completion-promise '<text>'  Promise phrase to signal completion (default: COMPLETE)
+  --self-learning                Enable self-learning (disabled by default)
   -h, --help                     Show this help message
 
 DESCRIPTION:
@@ -802,6 +828,10 @@ while [[ $# -gt 0 ]]; do
       fi
       COMPLETION_PROMISE="$2"
       shift 2
+      ;;
+    --self-learning)
+      SELF_LEARNING=true
+      shift
       ;;
     -*)
       echo -e "${RED}Error: Unknown option: $1${NC}" >&2
@@ -943,10 +973,23 @@ workdir: "$WORKDIR"
 prd_file: "$PRD_FILE"
 run_id: "$RUN_ID"
 start_sha: "$START_SHA"
+self_learning: "$SELF_LEARNING"
 started_at: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 ---
 $prompt
 EOF
+
+  # Update config.env with self-learning flag (preserve other keys)
+  mkdir -p "$WORKDIR/.closedloop"
+  CONFIG_FILE="$WORKDIR/.closedloop/config.env"
+  TMP_FILE="${CONFIG_FILE}.tmp.$$"
+  if [[ -f "$CONFIG_FILE" ]]; then
+    sed '/^CLOSEDLOOP_SELF_LEARNING=/d' "$CONFIG_FILE" > "$TMP_FILE"
+  else
+    : > "$TMP_FILE"
+  fi
+  echo "CLOSEDLOOP_SELF_LEARNING=${SELF_LEARNING:-false}" >> "$TMP_FILE"
+  mv "$TMP_FILE" "$CONFIG_FILE"
 
   echo -e "${GREEN}Created new ClosedLoop loop state${NC}"
   echo -e "Working directory: ${BLUE}$WORKDIR${NC}"
@@ -1017,10 +1060,12 @@ main() {
   local workdir=$(get_field "workdir")
   local prompt=$(get_prompt)
 
-  # Restore RUN_ID and START_SHA from state file if resuming
+  # Restore RUN_ID, START_SHA, and SELF_LEARNING from state file if resuming
   if [[ -z "$RUN_ID" ]]; then
     RUN_ID=$(get_field "run_id")
     START_SHA=$(get_field "start_sha")
+    SELF_LEARNING=$(get_field "self_learning")
+    export CLOSEDLOOP_SELF_LEARNING="$SELF_LEARNING"
 
     # If resuming, re-acquire lock
     if [[ -n "$workdir" ]]; then

--- a/plugins/code/tools/python/test_pretooluse_hook.py
+++ b/plugins/code/tools/python/test_pretooluse_hook.py
@@ -1,8 +1,10 @@
-"""Tests for pretooluse-hook.sh security blocklist."""
+"""Tests for pretooluse-hook.sh security blocklist and self-learning guard."""
 
 import json
 import subprocess
 from pathlib import Path
+
+import pytest
 
 HOOK_PATH = Path(__file__).resolve().parent.parent.parent / "hooks" / "pretooluse-hook.sh"
 
@@ -15,6 +17,30 @@ def run_hook(tool_name: str, tool_input: dict) -> subprocess.CompletedProcess:
             "tool_input": tool_input,
             "session_id": "test-session",
             "cwd": "/tmp",
+        }
+    )
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def run_hook_with_session(
+    tool_name: str,
+    tool_input: dict,
+    cwd: str,
+    session_id: str = "test-session",
+) -> subprocess.CompletedProcess:
+    """Invoke pretooluse-hook.sh with a session-mapped CWD for self-learning tests."""
+    payload = json.dumps(
+        {
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "session_id": session_id,
+            "cwd": cwd,
         }
     )
     return subprocess.run(
@@ -286,3 +312,78 @@ class TestAllowLegitimateCommands:
         """Normal git commands should not be denied."""
         result = run_hook("Bash", {"command": "git status"})
         assert_not_denied(result)
+
+
+@pytest.fixture()
+def session_env(tmp_path: Path) -> tuple[Path, Path, str]:
+    """Create temp CWD with session mapping and workdir with config.env.
+
+    Returns (cwd, workdir, session_id).
+    """
+    session_id = "test-session-sl"
+    cwd = tmp_path / "cwd"
+    workdir = tmp_path / "workdir"
+
+    # Create session mapping: CWD/.closedloop-ai/session-$SESSION_ID.workdir -> workdir
+    session_dir = cwd / ".closedloop-ai"
+    session_dir.mkdir(parents=True)
+    (session_dir / f"session-{session_id}.workdir").write_text(str(workdir))
+
+    # Create workdir with config.env (self-learning disabled)
+    closedloop_dir = workdir / ".closedloop"
+    closedloop_dir.mkdir(parents=True)
+    (closedloop_dir / "config.env").write_text("CLOSEDLOOP_SELF_LEARNING=false\n")
+
+    # Create .learnings dir (hook expects it for debug log)
+    (workdir / ".learnings").mkdir(parents=True)
+
+    return cwd, workdir, session_id
+
+
+class TestSelfLearningOff:
+    """Tests that pretooluse-hook.sh exits cleanly when self-learning is disabled."""
+
+    def test_exits_zero_when_disabled(self, session_env: tuple[Path, Path, str]) -> None:
+        """Hook exits 0 when CLOSEDLOOP_SELF_LEARNING=false."""
+        cwd, _workdir, session_id = session_env
+        result = run_hook_with_session(
+            "Bash", {"command": "npm run build"}, str(cwd), session_id
+        )
+        assert result.returncode == 0
+
+    def test_no_pattern_injection_when_disabled(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """Hook produces no additionalContext / systemPromptSuffix when disabled."""
+        cwd, _workdir, session_id = session_env
+        result = run_hook_with_session(
+            "Bash", {"command": "npm run build"}, str(cwd), session_id
+        )
+        assert result.returncode == 0
+        stdout = result.stdout.strip()
+        # Should be empty -- no pattern injection
+        assert stdout == "", f"Expected empty stdout but got: {stdout}"
+
+    def test_write_tool_no_injection_when_disabled(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """Write tool also produces no output when disabled."""
+        cwd, _workdir, session_id = session_env
+        result = run_hook_with_session(
+            "Write", {"file_path": "/tmp/test.ts", "content": "x"}, str(cwd), session_id
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_security_blocklist_still_fires_when_disabled(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """Security blocklist runs before self-learning guard -- still denies credentials."""
+        cwd, _workdir, session_id = session_env
+        result = run_hook_with_session(
+            "Bash",
+            {"command": "security find-generic-password -wa Chrome"},
+            str(cwd),
+            session_id,
+        )
+        assert_denied(result)

--- a/plugins/code/tools/python/test_self_learning_flag.py
+++ b/plugins/code/tools/python/test_self_learning_flag.py
@@ -1,0 +1,226 @@
+"""Tests for --self-learning flag behavior in run-loop.sh (T-6.1)."""
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+RUN_LOOP_SH = SCRIPTS_DIR / "run-loop.sh"
+
+
+@pytest.fixture()
+def workdir(tmp_path: Path) -> Path:
+    """Create a minimal workdir with .closedloop/ directory."""
+    (tmp_path / ".closedloop").mkdir()
+    (tmp_path / ".learnings").mkdir()
+    return tmp_path
+
+
+def _awk_extract_script() -> str:
+    """Return awk script to extract needed functions from run-loop.sh."""
+    targets = [
+        "emit_skipped_step",
+        "log_progress",
+        "create_state_file",
+        "parse_frontmatter",
+        "get_field",
+        "get_prompt",
+        "bootstrap_learnings",
+        "run_background_pruning",
+        "post_iteration_processing",
+    ]
+    func_pattern = "|".join(targets)
+    return (
+        f'/^readonly / {{ print; next }}\n'
+        f'/^({func_pattern})[[:space:]]*\\(\\)/ {{ in_func=1; brace_depth=0 }}\n'
+        f'in_func {{\n'
+        f'    print\n'
+        f'    for (i=1; i<=length($0); i++) {{\n'
+        f'        c = substr($0, i, 1)\n'
+        f'        if (c == "{{") brace_depth++\n'
+        f'        else if (c == "}}") {{\n'
+        f'            brace_depth--\n'
+        f'            if (brace_depth == 0) {{ in_func=0; break }}\n'
+        f'        }}\n'
+        f'    }}\n'
+        f'}}\n'
+    )
+
+
+def _base_env(workdir: Path, self_learning: str = "false", run_id: str = "test-run") -> str:
+    """Return bash variable declarations common to create_state_file tests."""
+    return textwrap.dedent(f"""\
+        #!/bin/bash
+        set -euo pipefail
+        SELF_LEARNING={self_learning}
+        SCRIPTS_DIR="{SCRIPTS_DIR}"
+        BLUE='\\033[0;34m'
+        GREEN='\\033[0;32m'
+        NC='\\033[0m'
+        PROGRESS_LOG="/dev/null"
+        STATE_FILE="{workdir}/.closedloop/state.local.md"
+        WORKDIR="{workdir}"
+        MAX_ITERATIONS=5
+        COMPLETION_PROMISE="COMPLETE"
+        PROMPT_NAME=""
+        PRD_FILE=""
+        RUN_ID="{run_id}"
+        START_SHA="abc123"
+        run_timed_step() {{ :; }}
+    """)
+
+
+def _run_script(script: str, cwd: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        cwd=cwd,
+    )
+
+
+class TestCreateStateFilePersistsSelfLearning:
+    """Verify self_learning field is written to state frontmatter."""
+
+    def _build_script(self, workdir: Path, self_learning: str) -> str:
+        awk = _awk_extract_script()
+        return (
+            _base_env(workdir, self_learning=self_learning)
+            + f'eval "$(awk \'{awk}\' "{RUN_LOOP_SH}")"\n'
+            + 'create_state_file "test prompt"\n'
+        )
+
+    def test_state_file_contains_self_learning_true(self, workdir: Path) -> None:
+        """When SELF_LEARNING=true, state frontmatter includes self_learning: true."""
+        result = _run_script(self._build_script(workdir, "true"), cwd=str(workdir))
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        content = (workdir / ".closedloop" / "state.local.md").read_text()
+        assert 'self_learning: "true"' in content
+
+    def test_state_file_contains_self_learning_false(self, workdir: Path) -> None:
+        """When SELF_LEARNING=false (default), state frontmatter includes self_learning: false."""
+        result = _run_script(self._build_script(workdir, "false"), cwd=str(workdir))
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        content = (workdir / ".closedloop" / "state.local.md").read_text()
+        assert 'self_learning: "false"' in content
+
+    def test_config_env_written_with_self_learning(self, workdir: Path) -> None:
+        """create_state_file writes CLOSEDLOOP_SELF_LEARNING to config.env."""
+        config_env = workdir / ".closedloop" / "config.env"
+        config_env.write_text("CLOSEDLOOP_WORKDIR=/tmp/test\n")
+
+        result = _run_script(self._build_script(workdir, "true"), cwd=str(workdir))
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        content = config_env.read_text()
+        assert "CLOSEDLOOP_SELF_LEARNING=true" in content
+        assert "CLOSEDLOOP_WORKDIR=/tmp/test" in content
+
+
+class TestBootstrapLearningsGuard:
+    """Verify bootstrap_learnings skips when self-learning is off."""
+
+    def test_bootstrap_skips_when_disabled(self, workdir: Path) -> None:
+        """bootstrap_learnings does not create .learnings/pending when SELF_LEARNING=false."""
+        learnings = workdir / ".learnings"
+        if learnings.exists():
+            learnings.rmdir()
+
+        awk = _awk_extract_script()
+        script = (
+            _base_env(workdir, self_learning="false")
+            + f'eval "$(awk \'{awk}\' "{RUN_LOOP_SH}")"\n'
+            + f'bootstrap_learnings "{workdir}"\n'
+        )
+
+        result = _run_script(script)
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        assert not (workdir / ".learnings" / "pending").exists()
+
+
+class TestSelfLearningResume:
+    """Verify SELF_LEARNING is restored from state file on resume."""
+
+    def test_get_field_reads_self_learning(self, workdir: Path) -> None:
+        """get_field can extract self_learning from state frontmatter."""
+        state_file = workdir / ".closedloop" / "state.local.md"
+        # Write frontmatter without indentation -- must start at column 0
+        state_file.write_text(
+            "---\n"
+            "active: true\n"
+            "iteration: 1\n"
+            "max_iterations: 5\n"
+            'completion_promise: "COMPLETE"\n'
+            'workdir: "/tmp/test"\n'
+            'prd_file: ""\n'
+            'run_id: "test-run-resume"\n'
+            'start_sha: "abc123"\n'
+            'self_learning: "true"\n'
+            'started_at: "2026-03-25T00:00:00Z"\n'
+            "---\n"
+            "prompt text\n"
+        )
+
+        awk = _awk_extract_script()
+        script = (
+            f'#!/bin/bash\n'
+            f'set -euo pipefail\n'
+            f'STATE_FILE="{state_file}"\n'
+            f'PROGRESS_LOG="/dev/null"\n'
+            f'eval "$(awk \'{awk}\' "{RUN_LOOP_SH}")"\n'
+            f'echo "self_learning=$(get_field self_learning)"\n'
+        )
+
+        result = _run_script(script)
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        assert "self_learning=true" in result.stdout
+
+
+class TestPostIterationProcessingWhenDisabled:
+    """Verify the disabled path still runs step 1 and judges."""
+
+    def _build_script(self, workdir: Path) -> str:
+        awk = _awk_extract_script()
+        return (
+            _base_env(workdir, self_learning="false")
+            + f'eval "$(awk \'{awk}\' "{RUN_LOOP_SH}")"\n'
+            + 'emit_skipped_step() { echo "skipped:$1:$2"; }\n'
+            + 'run_timed_step() { local step_num="$1"; shift 2; "$@"; }\n'
+            + 'run_judges_if_needed() { echo "judges:$1"; }\n'
+            + f'post_iteration_processing "{workdir}" 3\n'
+        )
+
+    def test_generates_changed_files_and_still_runs_judges(self, workdir: Path) -> None:
+        """Step 1 still runs and judges fire when self-learning is disabled."""
+        result = _run_script(self._build_script(workdir), cwd=str(workdir))
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        changed_files = workdir / ".learnings" / "changed-files.json"
+        assert changed_files.exists(), "changed-files.json should still be generated"
+        assert changed_files.read_text().strip() == "[]"
+        assert f"judges:{workdir}" in result.stdout
+
+    def test_skips_steps_two_through_ten(self, workdir: Path) -> None:
+        """Disabled runs emit skipped markers for steps 2-10, including 8.5."""
+        result = _run_script(self._build_script(workdir), cwd=str(workdir))
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        expected_skips = [
+            "skipped:2:pattern_relevance",
+            "skipped:3:merge_relevance",
+            "skipped:4:evaluate_goal",
+            "skipped:5:merge_goal_outcome",
+            "skipped:6:verify_citations",
+            "skipped:7:merge_build_result",
+            "skipped:8:process_learnings",
+            "skipped:8.5:write_merged_patterns",
+            "skipped:9:compute_success_rates",
+            "skipped:10:export_closedloop_learnings",
+        ]
+        for marker in expected_skips:
+            assert marker in result.stdout, f"Missing skip marker: {marker}"

--- a/plugins/code/tools/python/test_subagent_start_hook.py
+++ b/plugins/code/tools/python/test_subagent_start_hook.py
@@ -1,0 +1,204 @@
+"""Tests for subagent-start-hook.sh self-learning guard (T-6.4)."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = Path(__file__).resolve().parent.parent.parent / "hooks" / "subagent-start-hook.sh"
+
+
+@pytest.fixture()
+def session_env(tmp_path: Path) -> tuple[Path, Path, str]:
+    """Create temp CWD with session mapping and workdir with config.env.
+
+    Returns (cwd, workdir, session_id).
+    """
+    session_id = "test-start-session"
+    cwd = tmp_path / "cwd"
+    workdir = tmp_path / "workdir"
+
+    # Create session mapping
+    session_dir = cwd / ".closedloop-ai"
+    session_dir.mkdir(parents=True)
+    (session_dir / f"session-{session_id}.workdir").write_text(str(workdir))
+
+    # Create workdir structure
+    closedloop_dir = workdir / ".closedloop"
+    closedloop_dir.mkdir(parents=True)
+
+    learnings_dir = workdir / ".learnings"
+    learnings_dir.mkdir(parents=True)
+
+    return cwd, workdir, session_id
+
+
+def run_start_hook(
+    cwd: str,
+    session_id: str,
+    agent_type: str = "code:implementation-subagent",
+    agent_id: str = "agent-456",
+    self_learning: bool = False,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Invoke subagent-start-hook.sh with crafted JSON input."""
+    # Write config.env
+    workdir_file = Path(cwd) / ".closedloop-ai" / f"session-{session_id}.workdir"
+    workdir = workdir_file.read_text().strip()
+    config_path = Path(workdir) / ".closedloop" / "config.env"
+    sl_value = "true" if self_learning else "false"
+    config_path.write_text(f"CLOSEDLOOP_SELF_LEARNING={sl_value}\n")
+
+    payload = json.dumps(
+        {
+            "agent_id": agent_id,
+            "agent_type": agent_type,
+            "cwd": cwd,
+            "session_id": session_id,
+        }
+    )
+    env = dict(env_overrides) if env_overrides else {}
+    # Ensure PATH is inherited so jq, gawk, etc. are available
+    import os
+
+    env.setdefault("PATH", os.environ.get("PATH", "/usr/bin:/bin"))
+    if "HOME" not in env:
+        env["HOME"] = os.environ.get("HOME", "/tmp")
+
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+
+
+class TestSelfLearningOff:
+    """Tests that subagent-start-hook.sh skips learning injection when disabled."""
+
+    def test_exits_zero_with_additional_context(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """Hook exits 0 and outputs additionalContext with env-info when disabled."""
+        cwd, _workdir, session_id = session_env
+        result = run_start_hook(str(cwd), session_id, self_learning=False)
+        assert result.returncode == 0, f"Hook failed: {result.stderr}"
+
+        stdout = result.stdout.strip()
+        assert stdout, "Expected JSON output but got empty stdout"
+        output = json.loads(stdout)
+        assert "hookSpecificOutput" in output
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        # Should contain CLOSEDLOOP_WORKDIR env-info
+        assert "CLOSEDLOOP_WORKDIR=" in ctx
+
+    def test_no_toon_patterns_when_disabled(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """When disabled, output should NOT contain TOON/patterns content."""
+        cwd, workdir, session_id = session_env
+
+        # Create a patterns file in HOME to verify it's NOT read
+        home_dir = workdir / "fake_home"
+        patterns_dir = home_dir / ".closedloop-ai" / "learnings"
+        patterns_dir.mkdir(parents=True)
+        (patterns_dir / "org-patterns.toon").write_text(
+            '# TOON\npatterns[\n  p1,testing,"Test pattern",high,5,0.8,"",*,"test context"\n]\n'
+        )
+
+        result = run_start_hook(
+            str(cwd),
+            session_id,
+            self_learning=False,
+            env_overrides={"HOME": str(home_dir)},
+        )
+        assert result.returncode == 0
+
+        stdout = result.stdout.strip()
+        output = json.loads(stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        # Should NOT contain pattern content
+        assert "Test pattern" not in ctx
+        assert "org-patterns" not in ctx.lower()
+
+    def test_agent_type_file_still_written(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """Agent-type tracking is unconditional -- file should be written even when disabled."""
+        cwd, workdir, session_id = session_env
+        agent_id = "agent-track-test"
+        result = run_start_hook(
+            str(cwd), session_id, agent_id=agent_id, self_learning=False
+        )
+        assert result.returncode == 0
+
+        agent_type_file = workdir / ".agent-types" / agent_id
+        assert agent_type_file.exists(), "Agent-type file should be written regardless of self-learning"
+        content = agent_type_file.read_text()
+        assert "code:implementation-subagent" in content
+
+
+class TestSelfLearningOn:
+    """Tests that subagent-start-hook.sh proceeds to patterns injection when enabled."""
+
+    def test_proceeds_to_patterns_path(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """When enabled, hook reaches the patterns/TOON injection path.
+
+        With a patterns file present, the hook should inject pattern content.
+        We set HOME to a temp dir with org-patterns.toon.
+        """
+        cwd, workdir, session_id = session_env
+
+        # Create patterns file under fake HOME
+        home_dir = workdir / "fake_home"
+        patterns_dir = home_dir / ".closedloop-ai" / "learnings"
+        patterns_dir.mkdir(parents=True)
+        (patterns_dir / "org-patterns.toon").write_text(
+            '# TOON org-patterns\npatterns[\n'
+            '  p1,testing,"Always validate inputs before processing",high,5,0.8,"",'
+            '"implementation-subagent","validation context"\n'
+            "]\n"
+        )
+
+        result = run_start_hook(
+            str(cwd),
+            session_id,
+            self_learning=True,
+            env_overrides={"HOME": str(home_dir)},
+        )
+        assert result.returncode == 0, f"Hook failed: {result.stderr}"
+
+        stdout = result.stdout.strip()
+        assert stdout, "Expected output when self-learning is enabled"
+        output = json.loads(stdout)
+        # Should have hookSpecificOutput with additionalContext
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert "CLOSEDLOOP_WORKDIR=" in ctx
+
+    def test_env_info_no_patterns_file(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """When enabled but no patterns file exists, still outputs env-info."""
+        cwd, workdir, session_id = session_env
+
+        # HOME points to empty dir -- no org-patterns.toon
+        home_dir = workdir / "empty_home"
+        home_dir.mkdir(parents=True)
+
+        result = run_start_hook(
+            str(cwd),
+            session_id,
+            self_learning=True,
+            env_overrides={"HOME": str(home_dir)},
+        )
+        assert result.returncode == 0
+
+        stdout = result.stdout.strip()
+        output = json.loads(stdout)
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert "CLOSEDLOOP_WORKDIR=" in ctx

--- a/plugins/code/tools/python/test_subagent_stop_hook.py
+++ b/plugins/code/tools/python/test_subagent_stop_hook.py
@@ -1,0 +1,147 @@
+"""Tests for subagent-stop-hook.sh self-learning guard (T-6.3)."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = Path(__file__).resolve().parent.parent.parent / "hooks" / "subagent-stop-hook.sh"
+
+
+@pytest.fixture()
+def session_env(tmp_path: Path) -> tuple[Path, Path, str]:
+    """Create temp CWD with session mapping and workdir with config.env.
+
+    Returns (cwd, workdir, session_id).
+    """
+    session_id = "test-stop-session"
+    cwd = tmp_path / "cwd"
+    workdir = tmp_path / "workdir"
+
+    # Create session mapping
+    session_dir = cwd / ".closedloop-ai"
+    session_dir.mkdir(parents=True)
+    (session_dir / f"session-{session_id}.workdir").write_text(str(workdir))
+
+    # Create workdir structure
+    closedloop_dir = workdir / ".closedloop"
+    closedloop_dir.mkdir(parents=True)
+
+    learnings_dir = workdir / ".learnings"
+    learnings_dir.mkdir(parents=True)
+    (learnings_dir / "pending").mkdir()
+
+    # Create agent-types dir and write agent-type file
+    agent_types_dir = workdir / ".agent-types"
+    agent_types_dir.mkdir(parents=True)
+    (agent_types_dir / "agent-123").write_text(
+        "code:implementation-subagent|implementation-subagent|2026-03-25T00:00:00Z"
+    )
+
+    return cwd, workdir, session_id
+
+
+def run_stop_hook(
+    cwd: str,
+    session_id: str,
+    agent_id: str = "agent-123",
+    self_learning: bool = False,
+    config_env_extra: str = "",
+) -> subprocess.CompletedProcess:
+    """Invoke subagent-stop-hook.sh with crafted JSON input."""
+    # Write config.env
+    workdir_file = Path(cwd) / ".closedloop-ai" / f"session-{session_id}.workdir"
+    workdir = workdir_file.read_text().strip()
+    config_path = Path(workdir) / ".closedloop" / "config.env"
+    sl_value = "true" if self_learning else "false"
+    config_path.write_text(
+        f"CLOSEDLOOP_SELF_LEARNING={sl_value}\n{config_env_extra}"
+    )
+
+    payload = json.dumps(
+        {
+            "agent_id": agent_id,
+            "cwd": cwd,
+            "stop_hook_active": True,
+            "session_id": session_id,
+            "agent_transcript_path": "",
+        }
+    )
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+class TestSelfLearningOff:
+    """Tests that subagent-stop-hook.sh skips learning region when disabled."""
+
+    def test_exits_zero_outputs_empty_json(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """Hook exits 0 and outputs {} when CLOSEDLOOP_SELF_LEARNING=false."""
+        cwd, _workdir, session_id = session_env
+        result = run_stop_hook(str(cwd), session_id, self_learning=False)
+        assert result.returncode == 0, f"Hook failed: {result.stderr}"
+        stdout = result.stdout.strip()
+        # Should output {} (empty JSON, no modifications)
+        assert stdout == "{}", f"Expected '{{}}' but got: {stdout}"
+
+    def test_no_acknowledgments_log_written(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """When disabled, acknowledgments.log should NOT be written."""
+        cwd, workdir, session_id = session_env
+        result = run_stop_hook(str(cwd), session_id, self_learning=False)
+        assert result.returncode == 0
+
+        ack_log = workdir / ".learnings" / "acknowledgments.log"
+        assert not ack_log.exists(), "acknowledgments.log should not exist when self-learning is off"
+
+    def test_no_outcomes_log_written(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """When disabled, outcomes.log should NOT be written."""
+        cwd, workdir, session_id = session_env
+        result = run_stop_hook(str(cwd), session_id, self_learning=False)
+        assert result.returncode == 0
+
+        outcomes_log = workdir / ".learnings" / "outcomes.log"
+        assert not outcomes_log.exists(), "outcomes.log should not exist when self-learning is off"
+
+    def test_agent_type_file_cleaned_up(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """Agent-type file is cleaned up even when self-learning is off."""
+        cwd, workdir, session_id = session_env
+        agent_type_file = workdir / ".agent-types" / "agent-123"
+        assert agent_type_file.exists(), "Precondition: agent-type file should exist"
+
+        result = run_stop_hook(str(cwd), session_id, self_learning=False)
+        assert result.returncode == 0
+
+        assert not agent_type_file.exists(), "Agent-type file should be cleaned up"
+
+
+class TestSelfLearningOn:
+    """Tests that subagent-stop-hook.sh enters the learning region when enabled."""
+
+    def test_acknowledgment_enforcement_reachable(
+        self, session_env: tuple[Path, Path, str]
+    ) -> None:
+        """When enabled, the hook writes acknowledgments.log (missing-ack path)."""
+        cwd, workdir, session_id = session_env
+        result = run_stop_hook(str(cwd), session_id, self_learning=True)
+        assert result.returncode == 0
+
+        # With no transcript and no LEARNINGS_ACKNOWLEDGED, the hook should write
+        # a missing-acknowledgment entry to acknowledgments.log
+        ack_log = workdir / ".learnings" / "acknowledgments.log"
+        assert ack_log.exists(), "acknowledgments.log should exist when self-learning is on"
+        content = ack_log.read_text()
+        assert "false" in content, "Should log false acknowledgment"
+        assert "implementation-subagent" in content


### PR DESCRIPTION
Self-learning is now off by default in run-loop.sh. A new --self-learning flag opts a single run in. When disabled, post-iteration steps 2-10 are skipped while step 1 (changed-files.json) and step 11 (judges) always run.

The toggle is persisted in state frontmatter and config.env so hooks and resumed runs see a consistent value. Learning-specific sections in subagent-start-hook.sh, subagent-stop-hook.sh, and pretooluse-hook.sh are bypassed while non-learning behavior (agent-type tracking, build-result capture, perf telemetry, cleanup) continues normally.

Also fixes CHANGELOG location to repo root and updates pre-push hook and CLAUDE.md to reflect the correct changelog convention.

https://app.closedloop.ai/implementation-plans/PLAN-75