### PR TITLE
fix(code): block pkill/killall in PreToolUse security hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### code v1.5.2
+
+#### Added
+- Rule 8 in `build-validator` agent: never use `pkill`, `killall`, or broad kill patterns — use `timeout` to bound hung commands and report stuck processes as failures instead of killing them
+
+#### Security
+- Added `pkill` and `killall` to credential-theft blocklist in `pretooluse-hook.sh` — broad process killing is now globally denied to prevent worktree agents from killing processes outside their context
+
 ## [Releases]
 
 ### code v1.5.1

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/agents/build-validator.md
+++ b/plugins/code/agents/build-validator.md
@@ -316,6 +316,7 @@ End your response with exactly ONE of these promises:
 5. **Always run from WORKDIR** - Use `cd "$CLOSEDLOOP_WORKDIR"` before commands
 6. **Capture learnings if possible** - But don't fail if learning infrastructure doesn't exist
 7. **Clear output** - Make it obvious what passed, failed, and needs attention
+8. **NEVER use pkill, killall, or broad kill patterns** - These kill processes outside the worktree (e.g. a running desktop-dev in the main tree). If a command hangs, use `timeout` to bound it. If a test process is stuck, report it as a failure — do not attempt to kill processes you didn't spawn
 
 ## Mixed Projects
 

--- a/plugins/code/hooks/pretooluse-hook.sh
+++ b/plugins/code/hooks/pretooluse-hook.sh
@@ -31,6 +31,14 @@ case "$TOOL_NAME" in
     Bash)
         _sec_cmd=$(echo "$TOOL_INPUT" | jq -r '.command // empty' 2>/dev/null || echo "")
         case "$_sec_cmd" in
+            # Broad process killing — globally denied.
+            # pkill/killall match by name and kill processes outside the current context
+            # (e.g. a running desktop-dev in the main tree killed by a worktree agent).
+            # Claude should never need these; use process.kill(pid) for specific PIDs instead.
+            *pkill*|*killall*)
+                echo "$_SEC_DENY"
+                exit 0
+                ;;
             # macOS Keychain
             *security\ find-generic-password*|*security\ find-internet-password*|*security\ dump-keychain*|\
             *security\ delete-generic-password*|*security\ delete-internet-password*|\


### PR DESCRIPTION
## Summary
- Adds `pkill` and `killall` to the global security blocklist in `pretooluse-hook.sh` — prevents worktree agents from killing processes outside their context (e.g. a running desktop-dev in the main tree)
- Adds Rule 8 to `build-validator` agent: never use broad kill patterns; use `timeout` for hung commands instead
- Bumps code plugin to v1.5.2

## Test plan
- [ ] Verify `pkill` and `killall` commands are denied by the PreToolUse hook
- [ ] Verify build-validator agent includes the new Rule 8 guidance
- [ ] Confirm no regression in existing security blocklist entries