### PR TITLE
Migrate work directory paths from .claude/ to .closedloop-ai/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code v1.5.3
+
+#### Changed
+- Migrated work directory paths from `.claude/` to `.closedloop-ai/` across `run-loop.sh` (state file, progress log, directory creation), `amend-plan` command (default workdir), and `cancel-code` command (loop state file path)
+- Enhanced `codex-review` prompt with 6 new analysis criteria: canonical state preservation, task specificity, behavioral precision, order-of-operations, lifecycle symmetry, and test fidelity -- plus implementability-focused preamble instructions
+
 ### code v1.5.2
 
 #### Added
@@ -37,14 +43,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### code v1.5.0
 
-### Added
+#### Added
 - `--self-learning` opt-in flag for `run-loop.sh` -- self-learning is now disabled by default
 - `CLOSEDLOOP_SELF_LEARNING` config propagation via `config.env` and state frontmatter
 - Self-learning guard in `subagent-start-hook.sh` to skip learning injection when disabled
 - Self-learning guard in `subagent-stop-hook.sh` to skip entire learning region when disabled
 - Self-learning guard in `pretooluse-hook.sh` to skip tool-specific pattern injection when disabled
 
-### Changed
+#### Changed
 - `post_iteration_processing()` skips steps 2-10 when self-learning is off; step 1 (changed-files.json) and step 11 (judges) always run
 - `bootstrap_learnings()` skips `.learnings/` directory creation when self-learning is off
 - `run_background_pruning()` skips pruning when self-learning is off

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/README.md
+++ b/plugins/code/README.md
@@ -82,7 +82,7 @@ The command runs inside a ClosedLoop loop — the external loop runner (`run-loo
 /code:amend-plan --workdir [path] --message "<text>" [--state-file [path]]
 ```
 
-- `--workdir <path>`: Work directory containing `plan.json` (defaults to `$CLOSEDLOOP_WORKDIR` or `.claude/work`)
+- `--workdir <path>`: Work directory containing `plan.json` (defaults to `$CLOSEDLOOP_WORKDIR` or `.closedloop-ai/work`)
 - `--message <text>`: The user's message (required)
 - `--state-file <path>`: Path to the amend session state file (defaults to `{workdir}/amend-session.json`)
 
@@ -100,7 +100,7 @@ Conversation state is persisted across GitHub workflow runs via `amend_state.py`
 
 **Description:** Cancel an active ClosedLoop loop.
 
-Checks for `.claude/closedloop-loop.local.md`, reads the current iteration, removes the file, and reports the cancellation. Hidden from the slash command picker.
+Checks for `.closedloop-ai/closedloop-loop.local.md`, reads the current iteration, removes the file, and reports the cancellation. Hidden from the slash command picker.
 
 ### `/code:plan-with-codex`
 
@@ -353,7 +353,7 @@ Initializes a ClosedLoop session. Parses arguments (`--prd`, `--max-iterations`,
 
 ### `run-loop.sh`
 
-External loop runner. Launches `claude -p` in a loop, maintaining state in `.claude/closedloop-loop.local.md`. Integrates with the self-learning system. Tracks run ID, start SHA, iteration count, and progress log. Continues until the orchestrator outputs `<promise>COMPLETE</promise>` or max iterations are reached.
+External loop runner. Launches `claude -p` in a loop, maintaining state in `.closedloop-ai/closedloop-loop.local.md`. Integrates with the self-learning system. Tracks run ID, start SHA, iteration count, and progress log. Continues until the orchestrator outputs `<promise>COMPLETE</promise>` or max iterations are reached.
 
 ### `setup-loop.sh`
 
@@ -412,23 +412,23 @@ Python dependencies: `pyyaml>=6.0`, `tree-sitter>=0.20.0` (optional, for AST par
 
 1. Create a work directory and place your PRD inside it:
    ```
-   mkdir .claude/work
-   cp requirements.md .claude/work/prd.md
+   mkdir .closedloop-ai/work
+   cp requirements.md .closedloop-ai/work/prd.md
    ```
 
 2. Start the session:
    ```
-   /code:code .claude/work
+   /code:code .closedloop-ai/work
    ```
 
 3. ClosedLoop will run the pre-explorer, then create a plan. It pauses after plan creation with:
    ```
-   Plan created. Review it at .claude/work/plan.md. Run /code:code .claude/work when ready to continue.
+   Plan created. Review it at .closedloop-ai/work/plan.md. Run /code:code .closedloop-ai/work when ready to continue.
    ```
 
 4. Review `plan.md`, add answers to open questions if needed, then continue:
    ```
-   /code:code .claude/work
+   /code:code .closedloop-ai/work
    ```
 
 5. The orchestrator proceeds through critic review, implementation, testing, and validation.

--- a/plugins/code/commands/amend-plan.md
+++ b/plugins/code/commands/amend-plan.md
@@ -16,18 +16,18 @@ When you invoke this command, **you are the orchestrator**. You handle the conve
 
 ```bash
 # With workdir (GitHub workflow passes this via $CLOSEDLOOP_WORKDIR)
-/code:amend-plan --workdir .claude/work --message "for task T-1.1, don't remove the SplashScreen.setLoadingInfo call"
+/code:amend-plan --workdir .closedloop-ai/work --message "for task T-1.1, don't remove the SplashScreen.setLoadingInfo call"
 
-# Auto-detect from $CLOSEDLOOP_WORKDIR or .claude/work
+# Auto-detect from $CLOSEDLOOP_WORKDIR or .closedloop-ai/work
 /code:amend-plan --message "change the caching approach in T-2.1"
 
 # With explicit state file
-/code:amend-plan --workdir .claude/work --state-file .claude/work/amend-session.json --message "yes go ahead"
+/code:amend-plan --workdir .closedloop-ai/work --state-file .closedloop-ai/work/amend-session.json --message "yes go ahead"
 ```
 
 ## Options
 
-- `--workdir <path>` - Path to the work directory. If not provided, uses `$CLOSEDLOOP_WORKDIR` env var or defaults to `.claude/work`
+- `--workdir <path>` - Path to the work directory. If not provided, uses `$CLOSEDLOOP_WORKDIR` env var or defaults to `.closedloop-ai/work`
 - `--message <text>` - The user's message (required)
 - `--state-file <path>` - Path to amend session state file. Defaults to `{workdir}/amend-session.json`
 
@@ -61,7 +61,7 @@ TodoWrite([
 2. **Determine workdir**:
    - If `--workdir` provided, use it
    - Else if `$CLOSEDLOOP_WORKDIR` env var is set, use it
-   - Otherwise, default to `.claude/work`
+   - Otherwise, default to `.closedloop-ai/work`
 
 3. **Set state file path**:
    - If `--state-file` provided, use it
@@ -393,7 +393,7 @@ The `amend-session.json` file tracks:
 ```json
 {
   "version": "1.0",
-  "run_dir": ".claude/work",
+  "run_dir": ".closedloop-ai/work",
   "status": "discussing",
   "conversation": [
     {"role": "user", "content": "...", "timestamp": "..."},

--- a/plugins/code/commands/cancel-code.md
+++ b/plugins/code/commands/cancel-code.md
@@ -1,6 +1,6 @@
 ---
 description: "Cancel active ClosedLoop Loop"
-allowed-tools: ["Bash(test -f .claude/closedloop-loop.local.md:*)", "Bash(rm .claude/closedloop-loop.local.md)", "Read(.claude/closedloop-loop.local.md)"]
+allowed-tools: ["Bash(test -f .closedloop-ai/closedloop-loop.local.md:*)", "Bash(rm .closedloop-ai/closedloop-loop.local.md)", "Read(.closedloop-ai/closedloop-loop.local.md)"]
 hide-from-slash-command-tool: "true"
 ---
 
@@ -8,11 +8,11 @@ hide-from-slash-command-tool: "true"
 
 To cancel the ClosedLoop loop:
 
-1. Check if `.claude/closedloop-loop.local.md` exists using Bash: `test -f .claude/closedloop-loop.local.md && echo "EXISTS" || echo "NOT_FOUND"`
+1. Check if `.closedloop-ai/closedloop-loop.local.md` exists using Bash: `test -f .closedloop-ai/closedloop-loop.local.md && echo "EXISTS" || echo "NOT_FOUND"`
 
 2. **If NOT_FOUND**: Say "No active ClosedLoop loop found."
 
 3. **If EXISTS**:
-   - Read `.claude/closedloop-loop.local.md` to get the current iteration number from the `iteration:` field
-   - Remove the file using Bash: `rm .claude/closedloop-loop.local.md`
+   - Read `.closedloop-ai/closedloop-loop.local.md` to get the current iteration number from the `iteration:` field
+   - Remove the file using Bash: `rm .closedloop-ai/closedloop-loop.local.md`
    - Report: "Cancelled ClosedLoop loop (was at iteration N)" where N is the iteration value

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -2,7 +2,7 @@
 
 # ClosedLoop External Loop Runner
 # Runs Claude iterations with fresh context by launching claude -p in a loop
-# State maintained in .claude/closedloop-loop.local.md
+# State maintained in .closedloop-ai/closedloop-loop.local.md
 # Integrates with the ClosedLoop Self-Learning System
 
 set -euo pipefail
@@ -15,8 +15,8 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # State file location
-STATE_FILE=".claude/closedloop-loop.local.md"
-PROGRESS_LOG=".claude/closedloop-progress.log"
+STATE_FILE=".closedloop-ai/closedloop-loop.local.md"
+PROGRESS_LOG=".closedloop-ai/closedloop-progress.log"
 
 # Learning system paths
 LOCK_FILE=".learnings/.lock"
@@ -459,7 +459,7 @@ DESCRIPTION:
   Runs Claude in a loop with fresh context on each iteration. Each iteration
   invokes `claude -p "/code:code <workdir>"`.
 
-  State is persisted to .claude/closedloop-loop.local.md so loops can be resumed.
+  State is persisted to .closedloop-ai/closedloop-loop.local.md so loops can be resumed.
 
   To signal completion, Claude must output: <promise>COMPLETE</promise>
 
@@ -491,10 +491,10 @@ STOPPING:
 
 MONITORING:
   # View current iteration:
-  grep '^iteration:' .claude/closedloop-loop.local.md
+  grep '^iteration:' .closedloop-ai/closedloop-loop.local.md
 
   # View progress log:
-  tail -20 .claude/closedloop-progress.log
+  tail -20 .closedloop-ai/closedloop-progress.log
 
   # View learning system status:
   ls -la .learnings/sessions/
@@ -673,10 +673,10 @@ update_iteration() {
 
 # Create state file
 create_state_file() {
-  mkdir -p .claude
+  mkdir -p .closedloop-ai
 
   # WORKDIR is the closedloop work directory passed by the caller
-  # (e.g., /path/to/worktree/.claude/work)
+  # (e.g., /path/to/worktree/.closedloop-ai/work)
   mkdir -p "$WORKDIR"
 
   # Build the prompt - this is what gets passed to claude -p

--- a/plugins/code/skills/codex-review/scripts/run_codex_review.sh
+++ b/plugins/code/skills/codex-review/scripts/run_codex_review.sh
@@ -101,6 +101,12 @@ ${REVISIONS_BLOCK}
 
 Read the plan at: ${PLAN_FILE}
 
+Review for implementability, not just conceptual correctness. Ask: if a different engineer executed this plan literally, could they still produce behavior that contradicts the plan's intent while believing they followed it? If yes, flag the plan as underspecified and propose exact wording that removes the ambiguity.
+
+Before raising or dismissing any finding, verify the plan's claims against the current codebase by reading the referenced files and searching for adjacent callsites or related logic. Do not rely on plan text alone.
+
+For large or multi-area plans, use subagents in parallel to audit separate file clusters or subsystems, then synthesize their results into a single review.
+
 Analyze for:
 1. Goal alignment -- does the plan actually accomplish what was requested? Would executing it fully deliver the feature, fix the bug, or achieve the stated objective? Flag if the plan misses the core intent or only partially addresses it.
 2. Over-engineering -- is the plan more complex than necessary? Flag unnecessary abstractions, helper utilities, configuration layers, or indirection that a simpler approach would avoid.
@@ -111,7 +117,13 @@ Analyze for:
 7. Architectural concerns or flawed assumptions
 8. Security or performance risks
 9. Test coverage -- does the plan include unit and/or integration tests for the changes? Flag if new logic, endpoints, or behaviors lack corresponding test tasks.
-10. Unclear or ambiguous task descriptions
+10. Unclear, ambiguous, or easy-to-misimplement task descriptions -- flag tasks that are technically correct in intent but leave room for materially wrong implementations. Focus on missing algorithms, missing ordering constraints, unspecified overwrite behavior, unspecified canonical-write targets, and vague "apply this pattern everywhere" instructions.
+11. Canonical state and invariant preservation -- for any plan that migrates, renames, caches, mirrors, or falls back between multiple representations/locations, verify that it explicitly defines: the canonical source of truth after the change; read behavior when old and new state both exist; write behavior when old and new state both exist; whether legacy state must be migrated, ignored, or cleaned up. Flag plans that permit split-brain state, continued mutation of legacy state, or mixed-state behavior that never converges.
+12. Task specificity and omission resistance -- check whether each task is concrete enough that an implementer cannot accidentally skip part of it. Flag tasks that rely on shorthand like "apply the same pattern," "update all handlers," or "mirror the above change" without naming exact functions, branches, side effects, and cleanup paths. Prefer plans that enumerate the concrete callsites or require a verification sweep proving none were missed.
+13. Behavioral precision and algorithmic ambiguity -- check whether key behavioral words are operationalized into exact steps. Flag terms like "merge," "prefer," "preserve," "reuse," "best effort," "safe," "destination-precedence," "fallback," or "migrate" when the plan does not specify the exact algorithm, overwrite semantics, and non-goals. If two reasonable engineers could implement the sentence in opposite ways, the task is too ambiguous.
+14. Order-of-operations and sequencing constraints -- check whether the plan specifies the required order between validation, reads, migration, locking, PID checks, writes, cleanup, and response generation. Flag tasks where doing the right steps in the wrong order would change behavior, create races, or violate invariants. Require explicit sequencing whenever earlier steps affect what later steps are allowed to read or write.
+15. Lifecycle symmetry and cleanup completeness -- for every create/read/write/start path in the plan, verify the corresponding stop/delete/reset/cleanup path is also updated. Flag one-sided migrations where the plan updates creation or reads but not teardown, cancellation, cleanup, backfill, or legacy-path removal. This includes "clear both locations," "stop both process types," and "remove stale artifacts from all relevant stores."
+16. Test fidelity to real execution paths -- evaluate not just whether tests exist, but whether they exercise the real behavior boundary that enforces the contract. Flag test tasks that: reimplement production logic inside mocks; only test helpers when the risk lives in route/handler orchestration; mock away ordering, filesystem, or state-transition behavior that is the actual source of risk; do not cover mixed-state, partial-migration, or contradiction scenarios. Require the plan to specify the test level where needed: unit, integration, route/handler, or end-to-end.
 
 Format each finding as:
 


### PR DESCRIPTION
- run-loop.sh: STATE_FILE and PROGRESS_LOG to .closedloop-ai/
- run-loop.sh: mkdir -p .closedloop-ai instead of .claude
- cancel-code.md: allowed-tools paths updated
- amend-plan.md: workdir defaults and examples updated
- README.md: usage examples and documentation updated

Risks: Must deploy with symphony-alpha and closedloop-electron; dual-path kill route in both apps provides safety window