### PR TITLE
FEAT-190: add PR auto-detection, fix partition cap, add small-diff fast path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code-review v1.3.0
+
+#### Added
+- PR auto-detection in local mode: when the current branch has an open PR, `resolve-scope` now auto-detects it via `gh pr view` and scopes the review to the PR diff instead of `main...HEAD`
+- Small-diff fast path: diffs with <=150 LOC and <=5 files now route to a single fast-path reviewer agent instead of spawning the full 5-agent fleet, reducing review time and token usage
+- Fast-path reviewer performs three scoped passes (Bug Hunter, Bug Hunter B / Unified Auditor, Premise) in a single agent run
+- Partition cap enforcement with unconditional force-merge fallback when budget-respecting merges cannot reduce partition count below the cap
+
+#### Changed
+- Deferred cache-status printing from Task 6 to Task 8 (standard flow) or Task 7 (hygiene-only exit) to allow fast-path routing to suppress cache output
+- `extract-patches` `--partitions-file` is now optional; omitting it produces only `patches_all.txt`
+- Reviewer/model routing lines in local output and GitHub summary are now conditional on `fast_path`
+- Footer omits `--cache-result` on fast-path runs (cache intentionally bypassed)
+- Renamed Step 4 to Step 4A (standard flow) and added Step 4B (fast-path flow); Step 5.5 now gated on `fast_path == false`
+
+### code v1.5.6
+
+#### Added
+- Severity gate for Codex debate rounds 5+ in `run_codex_review.sh` -- only flags findings that would cause functionally wrong behavior (incorrect output, data loss, crashes, security holes); suppresses wording ambiguities, hypothetical misimplementations, and style suggestions
+
+#### Changed
+- Split Codex debate round handling into three tiers: round 1 (initial review), rounds 2-4 (standard re-review), rounds 5+ (severity-gated re-review with elevated approval bar)
+- Codex responses with no verdict AND no findings now emit `CODEX_EMPTY` instead of defaulting to `NEEDS_CHANGES`, distinguishing truncated/empty responses from genuine review feedback
+
 ### code v1.5.5
 
 #### Changed

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -13,7 +13,7 @@ Run a multi-agent code review with partitioned deep review, deterministic hygien
 ## Usage
 
 ```
-/start                              # Review all changes on current branch vs main (default)
+/start                              # Review open PR diff for current branch, or main...HEAD if no PR
 /start staged                       # Review only staged changes
 /start file1 file2                  # Review specific files
 /start 123                          # Review PR #123 diff locally (no posting)
@@ -63,7 +63,7 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 ### Task 3: Parse scope and resolve diff
 - Mark todo "Parse scope and get diff data" as `in_progress`
 - Run Bash: `python <HELPERS> resolve-scope --mode <MODE> --setup-json <CR_DIR>/setup.json [--pr-number <N>] [--scope-args "<REMAINING_ARGS>"] [--base-ref-override <REF>] > <CR_DIR>/scope.json`
-- Read `<CR_DIR>/scope.json` for `DIFF_SCOPE`, `BASE_REF`, `HEAD_REF`, `REVIEW_BRANCH`, `DIFF_TIP`, `PR_NUMBER`, `PATH_FILTER`, `SCOPE_KIND`
+- Read `<CR_DIR>/scope.json` for `DIFF_SCOPE`, `BASE_REF`, `HEAD_REF`, `REVIEW_BRANCH`, `DIFF_TIP`, `PR_NUMBER`, `PATH_FILTER`, `SCOPE_KIND`, `PR_AUTO_DETECTED`
 - Finalize `CACHE_DIR` now that scope/PR context is known (must happen before auto-incremental)
 - See: [Step 2 — Parse Arguments](#parse-arguments-remaining-after-flag-removal)
 
@@ -71,6 +71,7 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 - Evaluate auto-incremental eligibility using `REVIEW_BRANCH:BASE_REF` as the state key and `DIFF_TIP` as the ref
 - Set `REVIEW_MODE_LINE` to one of the **exact** prescribed strings — do NOT improvise
 - Print `<REVIEW_MODE_LINE>`
+- If `PR_AUTO_DETECTED` is true, print `"Auto-detected PR #<PR_NUMBER> for branch <REVIEW_BRANCH>."`
 - See: [Auto Incremental Mode](#auto-incremental-mode-phase-4--local-only)
 
 ### Task 5: Get diff data + fetch intent (GitHub: also get PR metadata)
@@ -85,8 +86,10 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 ### Task 6: Compute prompt hash + cache check (if CACHE_DIR set)
 - Prompt assets already copied in Task 2 (prep-assets)
 - Compute `PROMPT_HASH` and `CONTEXT_KEY` using `<DIFF_TIP>`
-- Run cache-check via `python <HELPERS> cache-check ...`
-- Print `cache_result.json -> status_message` to report cache status
+- Run cache-check via `python <HELPERS> cache-check ... > /dev/null` (redirect stdout to suppress inline print)
+- Read `<CR_DIR>/cache_result.json` and store `status_message` as `CACHE_STATUS_MESSAGE`
+- Do NOT print cache status here — it is printed later in Task 7 (hygiene exit) or Task 8 (after routing)
+- If `CACHE_DIR` is empty, set `CACHE_STATUS_MESSAGE=""`
 - Skip if `CACHE_DIR` is empty
 - See: [Step 2.1](#step-21-compute-prompt-hash--context-key-when-caching-is-active), [Step 2.2](#step-22-bha-cache-check-when-caching-is-active)
 
@@ -94,33 +97,41 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 - Mark todo "Run deterministic hygiene checks" as `in_progress`
 - Run Bash: `python <HELPERS> hygiene --diff-data <CR_DIR>/diff_data.json > <CR_DIR>/hygiene.json`
 - Mark todo as `completed`
-- **If HYGIENE_ONLY**: present hygiene findings and EXIT — skip all remaining tasks
+- **If HYGIENE_ONLY**: if `CACHE_DIR` is set and `CACHE_STATUS_MESSAGE` is non-empty, print `CACHE_STATUS_MESSAGE`. Then present hygiene findings and EXIT — skip all remaining tasks
 - See: [Step 2.5](#step-25-deterministic-hygiene-checks)
 
 ### Task 8: Route models + partition + extract patches
 - Mark todo "Assess scope and route models" as `in_progress`
 - Run Bash: `python <HELPERS> route --diff-data <CR_DIR>/diff_data.json --critic-gates .claude/settings/critic-gates.json --intent <INTENT> > <CR_DIR>/route.json`
-- Read `<CR_DIR>/route.json` for `models`, `domain_critics`, `max_bha_agents`
-- Run Bash: `python <HELPERS> partition --diff-data <CR_DIR>/diff_data.json --loc-budget 500 --max-files 25 --max-bha-agents <MAX_BHA_AGENTS> > <CR_DIR>/partitions.json` (use `uncached_diff_data.json` when caching is active)
-- Run Bash: `python <HELPERS> extract-patches --partitions-file <CR_DIR>/partitions.json --diff-scope "<DIFF_SCOPE>" --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>`
+- Read `<CR_DIR>/route.json` for `models`, `domain_critics`, `max_bha_agents`, `fast_path`
+- **If `fast_path` is false (standard flow):**
+  - Print `CACHE_STATUS_MESSAGE` if non-empty
+  - Run Bash: `python <HELPERS> partition --diff-data <CR_DIR>/diff_data.json --loc-budget 500 --max-files 25 --max-bha-agents <MAX_BHA_AGENTS> > <CR_DIR>/partitions.json` (use `uncached_diff_data.json` when caching is active)
+  - Run Bash: `python <HELPERS> extract-patches --partitions-file <CR_DIR>/partitions.json --diff-scope "<DIFF_SCOPE>" --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>`
+- **If `fast_path` is true:**
+  - Print `"Fast path selected: 1 reviewer (<MODEL>)."` where `<MODEL>` = `route.json -> models.fast_path_reviewer`
+  - If `CACHE_DIR` is set, print `"BHA Cache: bypassed in fast-path mode."` and delete `<CR_DIR>/agent_cached_bha.json` if it exists
+  - Skip partition entirely (no `partitions.json` created)
+  - Run Bash: `python <HELPERS> extract-patches --diff-scope "<DIFF_SCOPE>" --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>` (no `--partitions-file` -- only `patches_all.txt` is created)
+  - Update TodoWrite: replace "Spawn reviewer agents in parallel" with "Run fast-path review"
 - Mark todo as `completed`
-- See: [Step 3](#step-3-assess-scope-and-route-models), [Step 4 — Partitioning](#file-partitioning-critical-for-large-diffs)
+- See: [Step 3](#step-3-assess-scope-and-route-models), [Step 4A](#step-4a-spawn-reviewer-agents-fast_path--false), [Step 4B](#step-4b-fast-path-single-agent-review-fast_path--true)
 
 ### Task 9: Spawn agents
-- Mark todo "Spawn reviewer agents in parallel" as `in_progress`
+- Mark todo as `in_progress` (text depends on `fast_path` -- either "Spawn reviewer agents in parallel" or "Run fast-path review")
 - Prompt assets already in `<CR_DIR>` from Task 2 (prep-assets)
-- Spawn ALL agents using `subagent_type: "code:code-review-worker"` with `run_in_background: true`
-- Use the exact per-agent prompt template from the reference section
-- See: [Step 4 — Spawn Reviewer Agents](#step-4-spawn-reviewer-agents)
+- **If `fast_path == false`**: Spawn the standard reviewer fleet using `subagent_type: "code:code-review-worker"` with `run_in_background: true`. See [Step 4A](#step-4a-spawn-reviewer-agents-fast_path--false)
+- **If `fast_path == true`**: Spawn exactly one fast-path reviewer task using `subagent_type: "code:code-review-worker"` with `run_in_background: true`. See [Step 4B](#step-4b-fast-path-single-agent-review-fast_path--true)
+- Task 9 spawns background task(s) ONLY. Do NOT call `TaskOutput` here -- collection happens in Task 10
 
 ### Task 10: Collect + validate findings
 - Mark todo "Collect, normalize, and validate findings" as `in_progress`
-- Collect ALL agent outputs via `TaskOutput` (block=true for each)
+- Collect the task(s) spawned by Task 9 via `TaskOutput` (block=true for each). Perform one initial parallel `TaskOutput` sweep. If any retry task is spawned (WRITE_DENIED fallback or failure recovery), perform an additional `TaskOutput` sweep for those retry tasks
 - Run Bash: `python <HELPERS> collect-findings --cr-dir <CR_DIR> --hygiene <CR_DIR>/hygiene.json`
 - Run Bash: `python <HELPERS> validate --findings <CR_DIR>/findings.json --diff-data <CR_DIR>/diff_data.json > <CR_DIR>/validate_output.json`
-- Run cache-update if `CACHE_DIR` is set (add `--exclude-test-partitions` flag)
+- Run `cache-update` only when `fast_path == false` AND `CACHE_DIR` is set (add `--exclude-test-partitions` flag)
 - Mark todo as `completed`
-- See: [Step 5](#step-5-collect-normalize-and-validate-findings), [Step 5.5](#step-55-bha-cache-update-when-caching-is-active)
+- See: [Step 5](#step-5-collect-normalize-and-validate-findings), [Step 5.5 (fast_path == false AND CACHE_DIR set)](#step-55-bha-cache-update-fast_path--false-and-cache_dir-set)
 
 ### Task 11: Present results
 - **GitHub mode**: follow Steps 6 and 8 in `github-review.md` — write findings JSON, threads JSON, and summary.md to `.claude/`
@@ -273,7 +284,7 @@ Run the `resolve-scope` subcommand to handle all scope resolution deterministica
 python <HELPERS> resolve-scope --mode <MODE> --setup-json <CR_DIR>/setup.json [--pr-number <N>] [--scope-args "<REMAINING_ARGS>"] [--base-ref-override <REF>] > <CR_DIR>/scope.json
 ```
 
-Read `<CR_DIR>/scope.json` for: `DIFF_SCOPE`, `BASE_REF`, `HEAD_REF`, `REVIEW_BRANCH`, `DIFF_TIP`, `PR_NUMBER`, `PATH_FILTER`, `SCOPE_KIND`.
+Read `<CR_DIR>/scope.json` for: `DIFF_SCOPE`, `BASE_REF`, `HEAD_REF`, `REVIEW_BRANCH`, `DIFF_TIP`, `PR_NUMBER`, `PATH_FILTER`, `SCOPE_KIND`, `PR_AUTO_DETECTED`.
 
 The helper handles PR branch lookup (`gh pr view`), `git fetch`, `origin/` prefixes, `--base` overrides, path filter preservation, and scope kind classification.
 
@@ -291,9 +302,9 @@ Omit `--pr-number` if no PR number is set. Read `<CR_DIR>/cache_config.json` —
 
 **After scope parsing and before `parse-diff`**, check for auto-incremental eligibility:
 
-Determine `DIFF_TIP` based on scope:
-- PR number provided: `DIFF_TIP="origin/${HEAD_REF}"` (remote ref)
-- No PR number: `DIFF_TIP="HEAD"` (local ref)
+Use `DIFF_TIP` from `scope.json` (set by `resolve-scope` based on scope kind). Do not re-derive it here.
+
+Store `PR_AUTO_DETECTED` from `scope.json` but do not print anything yet.
 
 Run the `auto-incremental` subcommand to evaluate eligibility:
 
@@ -321,6 +332,8 @@ python <HELPERS> auto-incremental \
 - Set `REVIEW_MODE_LINE` from `review_mode_line`
 
 Print `<REVIEW_MODE_LINE>` (always, at the start of every run). Use the EXACT string from the JSON — do NOT improvise or rephrase.
+
+If `PR_AUTO_DETECTED` is true, print `"Auto-detected PR #<PR_NUMBER> for branch <REVIEW_BRANCH>."` immediately after `REVIEW_MODE_LINE`.
 
 ### GitHub Mode: Get PR Metadata
 
@@ -409,7 +422,8 @@ python <HELPERS> cache-check \
   --schema-version 1 \
   --output-dir <CR_DIR> \
   --global-cache <GLOBAL_CACHE> \
-  --context-key <CONTEXT_KEY>
+  --context-key <CONTEXT_KEY> \
+  > /dev/null
 ```
 
 This produces three files:
@@ -417,7 +431,9 @@ This produces three files:
 - `<CR_DIR>/agent_cached_bha.json` — cached BHA findings (glob-compatible with `agent_*`)
 - `<CR_DIR>/uncached_diff_data.json` — filtered diff_data with only uncached files
 
-Read `<CR_DIR>/cache_result.json` and print the `status_message` field to report cache status.
+Read `<CR_DIR>/cache_result.json` and store the `status_message` field as `CACHE_STATUS_MESSAGE`. Do NOT print it here -- it is printed later in Task 7 (hygiene-only exit) or Task 8 (after reading `route.json` and determining `fast_path`).
+
+If `CACHE_DIR` is empty, set `CACHE_STATUS_MESSAGE=""`.
 
 ---
 
@@ -440,6 +456,8 @@ Mark todo as `completed`.
 **If `HYGIENE_ONLY` is true**, skip all agent spawning and validation. Output hygiene findings directly and exit:
 
 ```
+If CACHE_DIR is set and CACHE_STATUS_MESSAGE is non-empty, print CACHE_STATUS_MESSAGE.
+
 Mark todo "Present hygiene findings" as in_progress.
 
 Parse `<CR_DIR>/hygiene.json` and present findings in the local presentation format:
@@ -483,19 +501,22 @@ python <HELPERS> route --diff-data <CR_DIR>/diff_data.json --critic-gates .claud
 Read `<CR_DIR>/route.json` with the Read tool.
 
 The script outputs:
+- **fast_path**: `true` when `total_loc <= 150` and `len(files_to_review) <= 5` and no domain critics; `false` otherwise
 - **size_category**: "Small" (<=500), "Medium" (501-2000), or "Large" (2001+)
-- **models**: Model assignments for each agent role. `bug_hunter_a` is `{"default": "opus", "test_only": "sonnet"}`. `premise_reviewer` is "opus" (fix/refactor/mixed) or "sonnet" (feature).
+- **models**: Model assignments for each agent role. `bug_hunter_a` is `{"default": "opus", "test_only": "sonnet"}`. `premise_reviewer` is "opus" (fix/refactor/mixed) or "sonnet" (feature). `fast_path_reviewer` is "sonnet".
 - **high_risk_files**: Top 5 files by risk score
 - **domain_critics**: Selected domain critics from critic-gates.json (max 1)
 - **max_bha_agents**: Maximum BHA partitions (9 minus non-BHA agents). Pass this to `--max-bha-agents` on the partition call.
 
-Report to user: model routing decision, which agents will run (including Premise Reviewer), and domain critics (if any).
+After reading `route.json`, branch on `fast_path`. See Task 8 summary for branching logic.
 
 Mark todo as `completed`.
 
 ---
 
-## Step 4: Spawn Reviewer Agents
+## Step 4A: Spawn Reviewer Agents (fast_path == false)
+
+**Skip this section if `fast_path` is true -- see [Step 4B](#step-4b-fast-path-single-agent-review-fast_path--true) instead.**
 
 Mark todo "Spawn reviewer agents in parallel" as `in_progress`.
 
@@ -780,6 +801,142 @@ Call all `TaskOutput` calls in a **single message** (parallel) so they resolve t
 
 ---
 
+## Step 4B: Fast-Path Single-Agent Review (fast_path == true)
+
+**Skip this section if `fast_path` is false -- see [Step 4A](#step-4a-spawn-reviewer-agents-fast_path--false) instead.**
+
+Mark todo "Run fast-path review" as `in_progress`.
+
+The fast-path spawns a single agent that performs all review passes in one run. Use the standard per-agent prompt wrapper from Step 4A unchanged (`mode: standalone`, `<output_file>`, `<patches_file>`, `<files_assigned>`), with the fast-path-specific suffix below.
+
+### Fast-Path Agent
+
+- **`subagent_type`**: `"code:code-review-worker"`
+- **`model`**: from `route.json -> models.fast_path_reviewer` (not hardcoded)
+- **`run_in_background`**: `true`
+- **`AGENT_ID`**: `"fast"`
+- **`<output_file>`**: `{CR_DIR}/agent_fast.json`
+- **`<patches_file>`**: `{CR_DIR}/patches_all.txt`
+- **`<files_assigned>`**: ALL `files_to_review`
+
+The agent MUST read: `<CR_DIR>/patches_all.txt`, `<CR_DIR>/shared_prompt.txt`, `<CR_DIR>/bha_suffix.txt`, `<CR_DIR>/intent_context.json`, repository root `CLAUDE.md`, and any directory-level `CLAUDE.md` files relevant to changed paths.
+
+### Fast-Path Agent Suffix
+
+Replace `{AGENT_SPECIFIC_SUFFIX}` with:
+
+```
+You are the Fast Path Reviewer — a single agent performing all review passes for a small diff.
+
+Perform three scoped passes against the patches file, writing ALL findings to a single output file:
+
+=== PASS 1: Bug Hunter ===
+Read <CR_DIR>/bha_suffix.txt for your role and focus areas.
+Standard severity/priority rules apply.
+Use Read, Grep, and Glob for codebase context. Do NOT use Bash.
+
+=== PASS 2: Bug Hunter B / Unified Auditor ===
+You are Bug Hunter B — a codebase-aware reviewer focused on cross-file issues.
+
+You will explore files outside your assigned list for CONTEXT — but every finding you report
+must be filed against a file in your <files_assigned> list. If you discover a bug in an
+unassigned file while exploring, discard it.
+
+Focus areas:
+- DRY: Use Grep to search for similar function/component names. Flag >60% structural
+  similarity with existing code. Cite the existing file path. The finding goes on YOUR assigned file (the new duplicate), not the existing one.
+- API contracts: Read service implementations to verify call correctness.
+  Check that parameters match (undefined vs null vs empty string matters).
+- Pattern consistency: Find existing examples of similar code, verify new code matches.
+- Import validation: Verify imports resolve to real modules.
+
+For DRY claims, one concrete example of prior art is sufficient (cite file path + function name).
+
+IMPORTANT: Read the repository root CLAUDE.md file before starting your review. Use it for
+DRY detection (check Learned Patterns for known conventions) and pattern consistency checks.
+
+Then as the Unified Auditor — check changes against project rules and architectural conventions.
+
+Read all applicable CLAUDE.md files:
+- Repository root CLAUDE.md
+- Any directory-level CLAUDE.md files relevant to changed file paths
+
+For each changed file, check against:
+1. Rules tagged [mistake] in CLAUDE.md Learned Patterns — these are HIGH severity
+2. Rules tagged [convention] — these are MEDIUM severity
+3. Rules tagged [pattern] — these are MEDIUM severity (verify pattern is followed)
+4. Explicit rules in the main CLAUDE.md sections (Architecture, Type Definitions, etc.)
+5. Architectural conventions: data access patterns, type locations, service layer responsibilities, code organization
+
+For every finding, cite the exact rule text from CLAUDE.md.
+Use Grep and Glob to verify claims. Do NOT flag issues without searching first.
+
+Standard severity/priority rules apply for all pass 2 findings.
+
+=== PASS 3: Premise Reviewer ===
+You are the Premise Reviewer — you question whether the changes in this diff were necessary at all.
+
+FIRST, Read {CR_DIR}/intent_context.json to understand the author's stated motivation (PR title/body
+or commit messages). If the file has empty fields, infer intent from the diff content instead.
+
+Then Read the patches file and use Read, Grep, and Glob to investigate the EXISTING codebase.
+Your job is to find evidence that contradicts the stated motivation for these changes.
+
+Focus areas — flag ONLY when you have concrete proof:
+- Non-existent bug "fix": The author claims to fix a bug, but the original code was correct.
+  Verify the bug can actually trigger: trace the input source — is the "untrusted" input
+  actually self-authored config, a constant, or data the process itself writes? For security
+  claims specifically, evaluate the threat model: if an attacker must already have write access
+  to the input source, the vulnerability doesn't exist. Also flag internal contradictions where
+  the fix undermines its own premise (e.g., sanitizing "untrusted" input then passing it to
+  os.path.expandvars() — which re-introduces the exact exposure it claimed to prevent).
+- Redundant workaround: The problem the code works around is already handled by the framework,
+  library, or upstream code — verify by reading the relevant source
+- Phantom dead-code removal: Code was removed as "unused" but is still imported, referenced,
+  or dynamically invoked elsewhere — verify with Grep
+- Duplicate abstraction: A new helper/utility/wrapper was added, but an existing one with
+  equivalent functionality already exists — cite the existing implementation
+- Unnecessary perf optimization: The code adds caching, memoization, or batching for a path
+  that is not a bottleneck (e.g., called once at startup, processes <100 items)
+- Regressive fix: A change removes or restricts intentional behavior in the name of safety
+  or correctness, but the removed behavior was necessary for the feature to work. Check
+  whether the original code's behavior (e.g., shell pipelines, environment expansion, broad
+  permissions) was documented or relied upon by callers — if so, the fix introduces a
+  functional regression that outweighs any theoretical benefit.
+
+Do NOT flag: correctness issues, style violations, DRY problems, CLAUDE.md compliance,
+naming conventions, or missing tests. Other agents cover those areas.
+
+IMPORTANT — The following constraints apply ONLY to findings emitted in this pass 3:
+- Overrides to shared prompt constraints for the "Premise" category:
+  The shared prompt requires findings to be "Introduced in this changeset" (constraint 3) and
+  "The original author would likely fix it if aware" (constraint 4). For Premise findings,
+  replace these with:
+    3. The changeset's stated motivation is contradicted by evidence you found in the codebase
+    4. The change is net-negative: it adds complexity, removes working code, or introduces risk
+       for a problem that does not exist
+  All other shared prompt constraints (file in scope, discrete and actionable, concrete evidence)
+  still apply.
+- Use ONLY priority 0 (BLOCKING) or priority 1 (HIGH). Never use priority 2 or 3.
+- Confidence must be >= 0.7. If you are not confident the premise is wrong, do not report it.
+- category MUST be "Premise" for every finding in this pass.
+- For the `line` field, use the first added line in the primary file's changed range.
+- The `recommendation` field must state the actionable outcome plainly.
+
+These Premise constraints do NOT apply to findings from passes 1 and 2.
+
+Use Read, Grep, and Glob for codebase context. Do NOT use Bash.
+```
+
+### Fast-Path Spawn + Collection Contract
+
+- Spawn exactly one background task (`AGENT_ID: "fast"`). Task 10 collects it.
+- `DONE ... file=WRITE_DENIED` is a success path, not a failure. Extract `<findings_json>` from `TaskOutput` and write it to `<CR_DIR>/agent_fast.json`. Retry only when the task fails to return `DONE`, times out/crashes, or returns malformed findings with no usable output file.
+- On failure (not WRITE_DENIED): retry once with `model: "haiku"`, same `AGENT_ID: "fast"`, same output file `<CR_DIR>/agent_fast.json`. Delete any existing `agent_fast.json` before retrying. Do NOT create `agent_fast_retry.json`.
+- If retry also fails: warn and continue with zero fast-path findings.
+
+---
+
 ## Step 5: Collect, Normalize, and Validate Findings
 
 Mark todo "Collect, normalize, and validate findings" as `in_progress`.
@@ -836,9 +993,9 @@ Mark todo as `completed`.
 
 ---
 
-## Step 5.5: BHA Cache Update (when caching is active)
+## Step 5.5: BHA Cache Update (fast_path == false AND CACHE_DIR set)
 
-**Skip this step if `CACHE_DIR` is empty.**
+**Skip this step if `fast_path` is true OR `CACHE_DIR` is empty.**
 
 After collecting all BHA findings, update the cache manifest so the next push/re-review can reuse results for unchanged files:
 
@@ -883,9 +1040,24 @@ Output in this format:
 
 **Scope:** [staged/branch/files]
 **Files Reviewed:** [count]
+```
+
+**Reviewers and Model Routing lines are conditional on `fast_path`:**
+
+- **If `fast_path == false`:**
+```markdown
 **Reviewers:** Bug Hunter A, Bug Hunter B, Unified Auditor, Premise Reviewer
 [+ domain specialist if triggered]
 **Model Routing:** [Small/Medium/Large] — [model assignments summary]
+```
+
+- **If `fast_path == true`:**
+```markdown
+**Reviewers:** Fast Path Reviewer (single-agent mode)
+**Model Routing:** Fast path — <MODEL> single reviewer
+```
+
+Then continue with:
 
 ---
 
@@ -1013,7 +1185,7 @@ python <HELPERS> footer \
   > <CR_DIR>/footer.json
 ```
 
-**Note:** Omit `--cache-result` if `CACHE_DIR` is empty (no caching active). The `--cr-dir` flag lets footer read `review_mode_line` from `auto_incremental.json` automatically — no need to pass `--review-mode-line` explicitly.
+**Note:** Omit `--cache-result` if `CACHE_DIR` is empty (no caching active) OR if `fast_path` is true (cache was intentionally bypassed). The footer will show `"Cache: disabled"` as the existing fallback when `--cache-result` is absent. The `--cr-dir` flag lets footer read `review_mode_line` from `auto_incremental.json` automatically — no need to pass `--review-mode-line` explicitly.
 
 Read `<CR_DIR>/footer.json` with the Read tool. It contains:
 ```json

--- a/plugins/code-review/prompts/github-review.md
+++ b/plugins/code-review/prompts/github-review.md
@@ -191,14 +191,31 @@ SUMMARY_EOF
 
 ### Summary Format
 
+Read `<CR_DIR>/route.json` before rendering. Extract `fast_path`, `models["fast_path_reviewer"]`, and `domain_critics`.
+
 ```markdown
 ## Code Review Summary
 
 **Status:** [Approved | Changes Requested | Needs Attention]
+```
 
-**Reviewers:** Bug Hunter A, Bug Hunter B, Unified Auditor
+**Reviewers line is conditional on `fast_path`:**
+
+- **If `fast_path == true`:**
+```markdown
+**Reviewers:** Fast Path Reviewer (single-agent mode)
+**Model Routing:** Fast path — <MODEL> single reviewer
+```
+
+- **If `fast_path == false`:**
+```markdown
+**Reviewers:** Bug Hunter A, Bug Hunter B, Unified Auditor, Premise Reviewer
 [+ domain specialist if triggered]
+```
 
+Then continue with the remaining summary content:
+
+```markdown
 ### Findings
 
 | Severity | Count |

--- a/plugins/code-review/tools/python/code_review_helpers.py
+++ b/plugins/code-review/tools/python/code_review_helpers.py
@@ -93,6 +93,10 @@ DEFAULT_MAX_BHA_AGENTS = 5
 REBALANCE_LOC_BUDGET = 1200
 MIXED_PARTITION_SPLIT_THRESHOLD = 50
 
+# Fast-path routing thresholds
+FAST_PATH_MAX_LOC = 150
+FAST_PATH_MAX_FILES = 5
+
 # Validation thresholds
 CONFIDENCE_DISCARD_THRESHOLD = 0.5
 LINE_TOLERANCE = 3
@@ -163,6 +167,63 @@ def _run_git(args: list[str], workdir: str | None = None) -> str:
     cmd += args
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     return result.stdout
+
+
+def _detect_open_pr() -> int | None:
+    """Detect an open PR for the current branch via ``gh pr view``.
+
+    Returns the PR number or ``None`` when detection fails for any reason
+    (no open PR, ``gh`` not installed, network error, malformed output).
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", "--json", "number", "-q", ".number"],
+            capture_output=True, text=True, check=True,
+        )
+        return int(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError, ValueError):
+        return None
+
+
+def _resolve_pr_scope(
+    pr_number: int,
+    current_branch: str,
+    *,
+    allow_guess_fallback: bool,
+) -> dict[str, str | int]:
+    """Resolve diff scope fields for a given PR number.
+
+    When *allow_guess_fallback* is ``True`` (explicit ``--pr-number``), a
+    ``CalledProcessError`` from ``gh pr view`` falls back to
+    ``base_ref="main"`` / ``head_ref=current_branch``.  When ``False``
+    (auto-detect path), errors propagate so the caller can revert to branch
+    scope.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "baseRefName,headRefName",
+             "-q", ".baseRefName,.headRefName"],
+            capture_output=True, text=True, check=True,
+        )
+        lines = result.stdout.strip().splitlines()
+        base_ref = lines[0].strip() if len(lines) > 0 else "main"
+        head_ref = lines[1].strip() if len(lines) > 1 else current_branch
+    except subprocess.CalledProcessError:
+        if not allow_guess_fallback:
+            raise
+        base_ref = "main"
+        head_ref = current_branch
+
+    return {
+        "diff_scope": f"origin/{base_ref}...origin/{head_ref}",
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "review_branch": head_ref,
+        "diff_tip": f"origin/{head_ref}",
+        "path_filter": "",
+        "scope_kind": "pr",
+        "pr_number": pr_number,
+    }
 
 
 def _parse_scope(scope: str) -> list[str]:
@@ -744,40 +805,60 @@ def cmd_partition(args: argparse.Namespace) -> int:
             new_partitions.append(part)
     partitions = new_partitions
 
-    # Pass 2 -- Agent cap enforcement
-    # If len(partitions) > max_bha_agents, merge the two smallest same-type partitions.
+    # Pass 2a -- Budget-respecting merges (all same-type pairs)
+    # Enumerate ALL same-type partition pairs, merge the lowest-total-LOC pair
+    # that satisfies both REBALANCE_LOC_BUDGET and max_files.
     while len(partitions) > max_bha_agents:
-        # Try same-type merges first (test with test, impl with impl)
-        merged = False
+        best_pair: tuple[int, int, int, bool] | None = None  # (idx_a, idx_b, merged_loc, is_test)
         for is_test in (True, False):
             same_type = [
                 (i, p) for i, p in enumerate(partitions) if p["is_test_only"] == is_test
             ]
             if len(same_type) < 2:
                 continue
-            # Sort by total_loc ascending to find the two smallest
-            same_type.sort(key=lambda x: x[1]["total_loc"])
-            idx_a, part_a = same_type[0]
-            idx_b, part_b = same_type[1]
-            merged_loc = part_a["total_loc"] + part_b["total_loc"]
-            merged_file_count = len(part_a["files"]) + len(part_b["files"])
-            if merged_loc <= REBALANCE_LOC_BUDGET and merged_file_count <= max_files:
-                merged_files = part_a["files"] + part_b["files"]
-                new_part: dict[str, Any] = {
-                    "id": 0,
-                    "files": merged_files,
-                    "total_loc": merged_loc,
-                    "is_test_only": is_test,
-                }
-                # Remove the two originals (remove higher index first)
-                remove_indices = sorted([idx_a, idx_b], reverse=True)
-                for ri in remove_indices:
-                    partitions.pop(ri)
-                partitions.append(new_part)
-                merged = True
-                break
-        if not merged:
-            break  # No valid same-type merge possible, stop
+            for ai in range(len(same_type)):
+                for bi in range(ai + 1, len(same_type)):
+                    idx_a, part_a = same_type[ai]
+                    idx_b, part_b = same_type[bi]
+                    merged_loc = part_a["total_loc"] + part_b["total_loc"]
+                    merged_file_count = len(part_a["files"]) + len(part_b["files"])
+                    if merged_loc <= REBALANCE_LOC_BUDGET and merged_file_count <= max_files:
+                        if best_pair is None or merged_loc < best_pair[2]:
+                            best_pair = (idx_a, idx_b, merged_loc, is_test)
+        if best_pair is None:
+            break  # No valid same-type merge possible, proceed to Phase 2b
+        idx_a, idx_b, merged_loc, is_test = best_pair
+        part_a = partitions[idx_a]
+        part_b = partitions[idx_b]
+        merged_files = part_a["files"] + part_b["files"]
+        new_part: dict[str, Any] = {
+            "id": 0,
+            "files": merged_files,
+            "total_loc": merged_loc,
+            "is_test_only": is_test,
+        }
+        for ri in sorted([idx_a, idx_b], reverse=True):
+            partitions.pop(ri)
+        partitions.append(new_part)
+
+    # Pass 2b -- Unconditional cap enforcement (force-merge fallback)
+    # When Phase 2a cannot reduce further, ignore budget and max_files constraints.
+    # Sort by total_loc ascending, merge the two smallest partitions (any type).
+    force_merged_count = 0
+    while len(partitions) > max_bha_agents:
+        partitions.sort(key=lambda p: p["total_loc"])
+        part_a = partitions.pop(0)
+        part_b = partitions.pop(0)
+        merged_files = part_a["files"] + part_b["files"]
+        is_test_only = all(f.get("is_test", False) for f in merged_files)
+        new_part = {
+            "id": 0,
+            "files": merged_files,
+            "total_loc": part_a["total_loc"] + part_b["total_loc"],
+            "is_test_only": is_test_only,
+        }
+        partitions.append(new_part)
+        force_merged_count += 1
 
     # Pass 3 -- Trivial merge
     # Merge partitions below TRIVIAL_PARTITION_THRESHOLD into same-type normal partitions.
@@ -821,7 +902,7 @@ def cmd_partition(args: argparse.Namespace) -> int:
         part["id"] = idx
 
     json.dump(
-        {"partitions": partitions, "test_file_paths": test_file_paths},
+        {"partitions": partitions, "test_file_paths": test_file_paths, "force_merged_count": force_merged_count},
         sys.stdout,
         indent=2,
     )
@@ -884,6 +965,7 @@ def cmd_route(args: argparse.Namespace) -> int:
         "bug_hunter_b": "sonnet",
         "unified_auditor": "sonnet",
         "premise_reviewer": premise_model,
+        "fast_path_reviewer": "sonnet",
     }
 
     # Risk scoring for high-risk files (large diffs)
@@ -925,10 +1007,17 @@ def cmd_route(args: argparse.Namespace) -> int:
 
     max_bha_agents = 9 - 3 - len(selected_domain_critics)  # 3 = BHB + Auditor + Premise
 
+    fast_path = (
+        total_loc <= FAST_PATH_MAX_LOC
+        and len(files_to_review) <= FAST_PATH_MAX_FILES
+        and not selected_domain_critics
+    )
+
     json.dump(
         {
             "size_category": size_category,
             "total_loc": total_loc,
+            "fast_path": fast_path,
             "models": models,
             "high_risk_files": high_risk_files,
             "domain_critics": selected_domain_critics,
@@ -2373,36 +2462,60 @@ def cmd_resolve_scope(args: argparse.Namespace) -> int:
     path_filter = ""
     scope_kind = "branch"
 
-    if pr_number is not None:
-        # Fetch PR base/head from gh
-        try:
-            result = subprocess.run(
-                ["gh", "pr", "view", str(pr_number), "--json", "baseRefName,headRefName",
-                 "-q", ".baseRefName,.headRefName"],
-                capture_output=True, text=True, check=True,
-            )
-            lines = result.stdout.strip().splitlines()
-            base_ref = lines[0].strip() if len(lines) > 0 else "main"
-            head_ref = lines[1].strip() if len(lines) > 1 else current_branch
-        except subprocess.CalledProcessError:
-            base_ref = "main"
-            head_ref = current_branch
+    pr_auto_detected = False
 
-        # Fetch origin head (allow failure)
+    if pr_number is not None:
+        # Explicit --pr-number: use _resolve_pr_scope with guess fallback.
+        # FileNotFoundError / OSError propagate as hard failures.
+        pr_scope = _resolve_pr_scope(pr_number, current_branch, allow_guess_fallback=True)
+        base_ref = str(pr_scope["base_ref"])
+        head_ref = str(pr_scope["head_ref"])
+        diff_scope = str(pr_scope["diff_scope"])
+        diff_tip = str(pr_scope["diff_tip"])
+        review_branch = str(pr_scope["review_branch"])
+        path_filter = str(pr_scope["path_filter"])
+        scope_kind = str(pr_scope["scope_kind"])
+
+        # Fetch origin head (allow failure for explicit PR)
         subprocess.run(
             ["git", "fetch", "origin", head_ref],
             capture_output=True, text=True,
         )
 
-        diff_scope = f"origin/{base_ref}...origin/{head_ref}"
-        diff_tip = f"origin/{head_ref}"
-        scope_kind = "pr"
-        review_branch = head_ref
-
     elif mode == "local":
         if not scope_args or scope_args.strip() in ("", "branch"):
-            diff_scope = "main...HEAD"
-            scope_kind = "branch"
+            # Try auto-detecting an open PR for the current branch
+            detected_pr = _detect_open_pr()
+            if detected_pr is not None:
+                try:
+                    pr_scope = _resolve_pr_scope(
+                        detected_pr, current_branch, allow_guess_fallback=False,
+                    )
+                    # Three-step success: fetch must also succeed
+                    subprocess.run(
+                        ["git", "fetch", "origin", str(pr_scope["head_ref"])],
+                        capture_output=True, text=True, check=True,
+                    )
+                    # All three steps succeeded
+                    base_ref = str(pr_scope["base_ref"])
+                    head_ref = str(pr_scope["head_ref"])
+                    diff_scope = str(pr_scope["diff_scope"])
+                    diff_tip = str(pr_scope["diff_tip"])
+                    review_branch = str(pr_scope["review_branch"])
+                    path_filter = str(pr_scope["path_filter"])
+                    scope_kind = str(pr_scope["scope_kind"])
+                    pr_number = detected_pr
+                    pr_auto_detected = True
+                except (subprocess.CalledProcessError, FileNotFoundError,
+                        OSError, ValueError):
+                    # Any failure: fall back to branch scope
+                    pr_number = None
+                    pr_auto_detected = False
+                    diff_scope = "main...HEAD"
+                    scope_kind = "branch"
+            else:
+                diff_scope = "main...HEAD"
+                scope_kind = "branch"
         elif scope_args.strip() == "staged":
             diff_scope = "--cached"
             scope_kind = "staged"
@@ -2437,6 +2550,7 @@ def cmd_resolve_scope(args: argparse.Namespace) -> int:
         "pr_number": pr_number,
         "path_filter": path_filter,
         "scope_kind": scope_kind,
+        "pr_auto_detected": pr_auto_detected,
     }
     json.dump(result_out, sys.stdout, indent=2)
     sys.stdout.write("\n")
@@ -3195,9 +3309,12 @@ def cmd_extract_patches(args: argparse.Namespace) -> int:
     batch_size: int = getattr(args, "batch_size", _EXTRACT_PATCHES_BATCH_SIZE)
 
     # Read partitions for per-partition patches
-    with open(partitions_file) as f:
-        pdata = json.load(f)
-    partitions: list[dict[str, Any]] = pdata.get("partitions", [])
+    if partitions_file is not None:
+        with open(partitions_file) as f:
+            pdata = json.load(f)
+        partitions: list[dict[str, Any]] = pdata.get("partitions", [])
+    else:
+        partitions = []
 
     # Read full diff_data for patches_all.txt (includes cached files too)
     with open(diff_data_path) as f:
@@ -3445,7 +3562,7 @@ def _register_subparsers(subparsers: argparse._SubParsersAction) -> None:  # typ
 
     # extract-patches
     p_ep = subparsers.add_parser("extract-patches", help="Extract git diff patches to disk files")
-    p_ep.add_argument("--partitions-file", required=True, help="Path to partitions.json")
+    p_ep.add_argument("--partitions-file", default=None, help="Path to partitions.json")
     p_ep.add_argument("--diff-scope", required=True, help="Git diff scope string")
     p_ep.add_argument("--diff-data", required=True, help="Path to full diff_data.json (for patches_all.txt)")
     p_ep.add_argument("--cr-dir", required=True, help="Output directory for patch files")

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -18,6 +18,7 @@ from code_review_helpers import (
     _classify_intent,
     _compute_composite_key,
     _compute_patch_hash,
+    _detect_open_pr,  # noqa: F401
     _entry_matches_v2,
     _first_added_line,
     _format_comment_body,
@@ -37,6 +38,7 @@ from code_review_helpers import (
     _parse_name_status,
     _parse_numstat,
     _parse_u0_output,
+    _resolve_pr_scope,  # noqa: F401
     _run_gc,
     _severity_for_hygiene_file,
     _write_manifest,
@@ -47,6 +49,8 @@ from code_review_helpers import (
     CACHE_MANIFEST_FILENAME,
     CACHE_SCHEMA_VERSION_V2,
     DEFAULT_MAX_BHA_AGENTS,
+    FAST_PATH_MAX_FILES,  # noqa: F401
+    FAST_PATH_MAX_LOC,  # noqa: F401
     REVIEW_STATE_FILENAME,
     cmd_auto_incremental,
     cmd_cache_check,
@@ -726,6 +730,48 @@ class TestRoute:
         result = self._run_route(data)
         assert result["models"]["premise_reviewer"] == "opus"
 
+    def test_fast_path_small_diff(self) -> None:
+        files = ["a.ts", "b.ts", "c.ts"]
+        loc = {f: {"added": 17, "removed": 16} for f in files}  # 33 * 3 = ~99 LOC
+        data = _make_diff_data(files=files, loc=loc)
+        data["total_loc"] = 100
+        result = self._run_route(data)
+        assert result["fast_path"] is True
+        assert result["models"]["fast_path_reviewer"] == "sonnet"
+
+    def test_fast_path_false_above_loc(self) -> None:
+        files = ["a.ts", "b.ts", "c.ts"]
+        loc = {f: {"added": 34, "removed": 33} for f in files}
+        data = _make_diff_data(files=files, loc=loc)
+        data["total_loc"] = 200
+        result = self._run_route(data)
+        assert result["fast_path"] is False
+
+    def test_fast_path_false_above_files(self) -> None:
+        files = [f"f{i}.ts" for i in range(6)]
+        loc = {f: {"added": 9, "removed": 8} for f in files}
+        data = _make_diff_data(files=files, loc=loc)
+        data["total_loc"] = 100
+        result = self._run_route(data)
+        assert result["fast_path"] is False
+
+    def test_fast_path_disabled_when_domain_critics(self, tmp_path: Path) -> None:
+        gates = {
+            "defaults": {"reviewBudget": 2},
+            "moduleCritics": [
+                {"patterns": [".ts"], "critics": ["ts-reviewer"]},
+            ],
+        }
+        gates_path = tmp_path / "critic-gates.json"
+        gates_path.write_text(json.dumps(gates))
+        files = ["a.ts", "b.ts", "c.ts"]
+        loc = {f: {"added": 17, "removed": 16} for f in files}
+        data = _make_diff_data(files=files, loc=loc)
+        data["total_loc"] = 100
+        result = self._run_route(data, str(gates_path))
+        assert len(result["domain_critics"]) > 0
+        assert result["fast_path"] is False
+
 
 # ---------------------------------------------------------------------------
 # Partition post-processing
@@ -833,6 +879,67 @@ class TestPartitionPostProcessing:
         data = _make_diff_data(files=files, loc=loc)
         result = self._run_partition(data, loc_budget=150, max_files=20, max_bha_agents=5)
         assert len(result["partitions"]) <= 5
+
+    def test_cap_enforcement_force_merges_large_partitions(self) -> None:
+        # 10 files at 800 LOC each -> 10 partitions (800+800=1600 > loc_budget=1000).
+        # 1600 > REBALANCE_LOC_BUDGET=1200, so Phase 2a cannot merge any pair.
+        # Phase 2b force-merges down to max_bha_agents=5.
+        files = [f"f{i}.ts" for i in range(10)]
+        loc = {f: {"added": 800, "removed": 0} for f in files}
+        data = _make_diff_data(files=files, loc=loc)
+        result = self._run_partition(data, loc_budget=1000, max_files=20, max_bha_agents=5)
+        assert len(result["partitions"]) == 5
+        assert result["force_merged_count"] > 0
+
+    def test_cap_enforcement_cross_type_force_merge(self) -> None:
+        # 4 impl files + 4 test files at 700 LOC each -> 8 partitions.
+        # 700+700=1400 > REBALANCE_LOC_BUDGET=1200, Phase 2a can't merge.
+        # Phase 2b force-merges cross-type until 4 partitions.
+        impl_files = [f"src/f{i}.ts" for i in range(4)]
+        test_files = [f"tests/test_f{i}.ts" for i in range(4)]
+        files = impl_files + test_files
+        loc = {f: {"added": 700, "removed": 0} for f in files}
+        data = _make_diff_data(files=files, loc=loc)
+        result = self._run_partition(data, loc_budget=1000, max_files=20, max_bha_agents=4)
+        assert len(result["partitions"]) == 4
+        assert result["force_merged_count"] > 0
+
+    def test_cap_enforcement_force_merge_ignores_max_files(self) -> None:
+        # 6 files at 700 LOC, max_files=1 blocks all merges in Phase 2a.
+        # 700+700=1400 > REBALANCE_LOC_BUDGET=1200, so Phase 2a can't merge anyway.
+        # Phase 2b ignores max_files, force-merges to 3 partitions.
+        files = [f"f{i}.ts" for i in range(6)]
+        loc = {f: {"added": 700, "removed": 0} for f in files}
+        data = _make_diff_data(files=files, loc=loc)
+        result = self._run_partition(data, loc_budget=1000, max_files=1, max_bha_agents=3)
+        assert len(result["partitions"]) == 3
+        assert result["force_merged_count"] > 0
+
+    def test_cap_enforcement_skips_smallest_pair_when_max_files_blocks(self) -> None:
+        # 4 same-type partitions: two smallest have 15 files each (30 > max_files=25),
+        # two larger have 1 file each with LOC that fits budget when merged.
+        # Phase 2a should skip the blocked smallest pair and merge the legal pair.
+        # Build: 15 small files at 5 LOC each -> grouped into one partition of 75 LOC,
+        # another 15 small files at 5 LOC each -> another partition of 75 LOC,
+        # one large file at 500 LOC, one large file at 500 LOC.
+        # 500+500=1000 <= REBALANCE_LOC_BUDGET=1200 and 1+1=2 <= max_files=25: legal merge.
+        small_files_a = [f"src/a{i}.ts" for i in range(15)]
+        small_files_b = [f"src/b{i}.ts" for i in range(15)]
+        large_files = ["src/big1.ts", "src/big2.ts"]
+        files = small_files_a + small_files_b + large_files
+        loc: dict[str, dict[str, int]] = {}
+        for f in small_files_a + small_files_b:
+            loc[f] = {"added": 5, "removed": 0}
+        for f in large_files:
+            loc[f] = {"added": 500, "removed": 0}
+        data = _make_diff_data(files=files, loc=loc)
+        # loc_budget=80 so each group of 15 small files lands in its own partition (15*5=75 < 80,
+        # but each 500 LOC file exceeds budget and gets its own partition). Result: 4 partitions.
+        result = self._run_partition(data, loc_budget=80, max_files=25, max_bha_agents=3)
+        assert len(result["partitions"]) == 3
+        # Phase 2a merged the two 500-LOC partitions (legal), not the 15-file ones (blocked).
+        # No force merge needed.
+        assert result["force_merged_count"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -4089,9 +4196,11 @@ class TestResolveScope:
             _sys.stdout = old_stdout
 
     def test_local_branch(self, tmp_path: Path) -> None:
-        result = self._run("local", tmp_path=tmp_path)
+        with patch("code_review_helpers._detect_open_pr", return_value=None):
+            result = self._run("local", tmp_path=tmp_path)
         assert result["diff_scope"] == "main...HEAD"
         assert result["scope_kind"] == "branch"
+        assert result["pr_auto_detected"] is False
 
     def test_staged(self, tmp_path: Path) -> None:
         result = self._run("local", scope_args="staged", tmp_path=tmp_path)
@@ -4105,7 +4214,8 @@ class TestResolveScope:
         assert result["path_filter"] == "-- file1.ts file2.ts"
 
     def test_base_override(self, tmp_path: Path) -> None:
-        result = self._run("local", base_ref_override="develop", tmp_path=tmp_path)
+        with patch("code_review_helpers._detect_open_pr", return_value=None):
+            result = self._run("local", base_ref_override="develop", tmp_path=tmp_path)
         assert "origin/develop" in result["diff_scope"]
         assert result["base_ref"] == "develop"
 
@@ -4113,6 +4223,177 @@ class TestResolveScope:
         result = self._run("local", scope_args="file1.ts", base_ref_override="develop", tmp_path=tmp_path)
         assert "origin/develop" in result["diff_scope"]
         assert "-- file1.ts" in result["path_filter"]
+
+    # -- PR auto-detection tests ------------------------------------------------
+
+    def _gh_pr_view_detect(self, pr_number: str = "675") -> subprocess.CompletedProcess[str]:
+        """Mock result for ``gh pr view --json number``."""
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=pr_number + "\n")
+
+    def _gh_pr_view_refs(
+        self, base: str = "main", head: str = "feat-x",
+    ) -> subprocess.CompletedProcess[str]:
+        """Mock result for ``gh pr view <N> --json baseRefName,headRefName``."""
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=f"{base}\n{head}\n")
+
+    def _git_fetch_ok(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    def _mock_subprocess_side_effect(
+        self,
+        detect_result: subprocess.CompletedProcess[str] | Exception | None = None,
+        resolve_result: subprocess.CompletedProcess[str] | Exception | None = None,
+        fetch_result: subprocess.CompletedProcess[str] | Exception | None = None,
+    ):
+        """Return a side_effect callable that dispatches on command prefix."""
+        def _side_effect(cmd, **_kwargs):  # noqa: ANN001, ANN202
+            cmd_list = list(cmd)
+            # Detection: gh pr view --json number
+            if cmd_list[:2] == ["gh", "pr"] and "number" in " ".join(cmd_list):
+                if isinstance(detect_result, Exception):
+                    raise detect_result
+                return detect_result
+            # Resolution: gh pr view <N> --json baseRefName,headRefName
+            if cmd_list[:2] == ["gh", "pr"] and "baseRefName" in " ".join(cmd_list):
+                if isinstance(resolve_result, Exception):
+                    raise resolve_result
+                return resolve_result
+            # git fetch
+            if cmd_list[:2] == ["git", "fetch"]:
+                if isinstance(fetch_result, Exception):
+                    raise fetch_result
+                return fetch_result
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        return _side_effect
+
+    def test_pr_auto_detected_when_open_pr(self, tmp_path: Path) -> None:
+        side_effect = self._mock_subprocess_side_effect(
+            detect_result=self._gh_pr_view_detect("675"),
+            resolve_result=self._gh_pr_view_refs("main", "feat-x"),
+            fetch_result=self._git_fetch_ok(),
+        )
+        with patch("code_review_helpers.subprocess.run", side_effect=side_effect):
+            result = self._run("local", tmp_path=tmp_path)
+        assert result["scope_kind"] == "pr"
+        assert result["pr_auto_detected"] is True
+        assert result["pr_number"] == 675
+        assert result["diff_scope"] == "origin/main...origin/feat-x"
+        assert result["base_ref"] == "main"
+        assert result["head_ref"] == "feat-x"
+        assert result["review_branch"] == "feat-x"
+        assert result["diff_tip"] == "origin/feat-x"
+
+    def test_pr_auto_detect_falls_back_on_no_pr(self, tmp_path: Path) -> None:
+        side_effect = self._mock_subprocess_side_effect(
+            detect_result=subprocess.CalledProcessError(1, "gh"),
+        )
+        with patch("code_review_helpers.subprocess.run", side_effect=side_effect):
+            result = self._run("local", tmp_path=tmp_path)
+        assert result["scope_kind"] == "branch"
+        assert result["diff_scope"] == "main...HEAD"
+        assert result["pr_auto_detected"] is False
+
+    def test_explicit_pr_number_resolves_pr_scope_without_auto_detect(self, tmp_path: Path) -> None:
+        side_effect = self._mock_subprocess_side_effect(
+            resolve_result=self._gh_pr_view_refs("main", "feat-x"),
+            fetch_result=self._git_fetch_ok(),
+        )
+        with patch("code_review_helpers.subprocess.run", side_effect=side_effect):
+            result = self._run("local", pr_number=100, tmp_path=tmp_path)
+        assert result["scope_kind"] == "pr"
+        assert result["pr_number"] == 100
+        assert result["pr_auto_detected"] is False
+        assert result["diff_scope"] == "origin/main...origin/feat-x"
+        assert result["base_ref"] == "main"
+        assert result["head_ref"] == "feat-x"
+        assert result["review_branch"] == "feat-x"
+        assert result["diff_tip"] == "origin/feat-x"
+
+    def test_explicit_pr_number_gh_missing_is_hard_failure(self, tmp_path: Path) -> None:
+        side_effect = self._mock_subprocess_side_effect(
+            resolve_result=FileNotFoundError("gh not found"),
+        )
+        import pytest
+        with patch("code_review_helpers.subprocess.run", side_effect=side_effect):
+            with pytest.raises(FileNotFoundError):
+                self._run("local", pr_number=100, tmp_path=tmp_path)
+
+    def test_explicit_pr_number_gh_oserror_is_hard_failure(self, tmp_path: Path) -> None:
+        side_effect = self._mock_subprocess_side_effect(
+            resolve_result=OSError("spawn failed"),
+        )
+        import pytest
+        with patch("code_review_helpers.subprocess.run", side_effect=side_effect):
+            with pytest.raises(OSError):
+                self._run("local", pr_number=100, tmp_path=tmp_path)
+
+    def test_pr_auto_detect_falls_back_when_gh_missing(self, tmp_path: Path) -> None:
+        side_effect = self._mock_subprocess_side_effect(
+            detect_result=FileNotFoundError("gh not found"),
+        )
+        with patch("code_review_helpers.subprocess.run", side_effect=side_effect):
+            result = self._run("local", tmp_path=tmp_path)
+        assert result["scope_kind"] == "branch"
+        assert result["diff_scope"] == "main...HEAD"
+        assert result["pr_auto_detected"] is False
+
+    def test_pr_auto_detect_falls_back_on_malformed_number(self, tmp_path: Path) -> None:
+        bad_detect = subprocess.CompletedProcess(args=[], returncode=0, stdout="not-a-number\n")
+        side_effect = self._mock_subprocess_side_effect(detect_result=bad_detect)
+        with patch("code_review_helpers.subprocess.run", side_effect=side_effect):
+            result = self._run("local", tmp_path=tmp_path)
+        assert result["scope_kind"] == "branch"
+        assert result["pr_auto_detected"] is False
+
+    def test_pr_auto_detect_falls_back_on_fetch_failure(self, tmp_path: Path) -> None:
+        side_effect = self._mock_subprocess_side_effect(
+            detect_result=self._gh_pr_view_detect("675"),
+            resolve_result=self._gh_pr_view_refs("main", "feat-x"),
+            fetch_result=subprocess.CalledProcessError(128, "git fetch"),
+        )
+        with patch("code_review_helpers.subprocess.run", side_effect=side_effect):
+            result = self._run("local", tmp_path=tmp_path)
+        assert result["pr_auto_detected"] is False
+        assert result["pr_number"] is None
+        assert result["scope_kind"] == "branch"
+        assert result["diff_scope"] == "main...HEAD"
+        assert result["diff_tip"] == "HEAD"
+
+    def test_pr_auto_detect_succeeds_but_resolve_fails(self, tmp_path: Path) -> None:
+        side_effect = self._mock_subprocess_side_effect(
+            detect_result=self._gh_pr_view_detect("675"),
+            resolve_result=subprocess.CalledProcessError(1, "gh"),
+        )
+        with patch("code_review_helpers.subprocess.run", side_effect=side_effect):
+            result = self._run("local", tmp_path=tmp_path)
+        assert result["pr_auto_detected"] is False
+        assert result["scope_kind"] == "branch"
+        assert result["diff_scope"] == "main...HEAD"
+
+    def test_pr_auto_detected_when_scope_args_branch_literal(self, tmp_path: Path) -> None:
+        side_effect = self._mock_subprocess_side_effect(
+            detect_result=self._gh_pr_view_detect("675"),
+            resolve_result=self._gh_pr_view_refs("main", "feat-x"),
+            fetch_result=self._git_fetch_ok(),
+        )
+        with patch("code_review_helpers.subprocess.run", side_effect=side_effect):
+            result = self._run("local", scope_args="branch", tmp_path=tmp_path)
+        assert result["scope_kind"] == "pr"
+        assert result["pr_auto_detected"] is True
+        assert result["pr_number"] == 675
+        assert result["diff_scope"] == "origin/main...origin/feat-x"
+
+    def test_pr_auto_detected_respects_base_override(self, tmp_path: Path) -> None:
+        side_effect = self._mock_subprocess_side_effect(
+            detect_result=self._gh_pr_view_detect("675"),
+            resolve_result=self._gh_pr_view_refs("main", "feat-x"),
+            fetch_result=self._git_fetch_ok(),
+        )
+        with patch("code_review_helpers.subprocess.run", side_effect=side_effect):
+            result = self._run("local", base_ref_override="develop", tmp_path=tmp_path)
+        assert result["diff_scope"] == "origin/develop...origin/feat-x"
+        assert result["base_ref"] == "develop"
+        assert result["pr_auto_detected"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -4462,3 +4743,45 @@ class TestExtractPatches:
         full_diff_cmds = [c for c in captured_cmds if "patches_p" not in " ".join(str(x) for x in c)]
         # Should be multiple batches (>1 command for the full diff)
         assert len(full_diff_cmds) >= 5
+
+    def test_extract_patches_no_partitions_file(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+        from unittest.mock import patch as mock_patch
+
+        from code_review_helpers import cmd_extract_patches
+
+        cr_dir = tmp_path / "cr"
+        cr_dir.mkdir()
+
+        diff_data = {"files_to_review": ["a.ts", "b.ts"]}
+        diff_data_file = tmp_path / "diff_data.json"
+        diff_data_file.write_text(json.dumps(diff_data))
+
+        def mock_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+            stdout = kwargs.get("stdout")
+            if stdout and hasattr(stdout, "write"):
+                stdout.write(f"diff output for {' '.join(cmd)}\n")
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
+                ns = argparse.Namespace(
+                    partitions_file=None, diff_scope="main...HEAD",
+                    diff_data=str(diff_data_file), cr_dir=str(cr_dir),
+                    workdir=None, batch_size=50,
+                )
+                cmd_extract_patches(ns)
+                _sys.stdout.seek(0)
+                result = json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+
+        assert result["partition_patches"] == []
+        assert result["full_patch"] == "patches_all.txt"
+        assert (cr_dir / "patches_all.txt").exists()
+        # No partition patch files should exist
+        assert not list(cr_dir.glob("patches_p*.txt"))

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/skills/codex-review/scripts/run_codex_review.sh
+++ b/plugins/code/skills/codex-review/scripts/run_codex_review.sh
@@ -83,9 +83,10 @@ prompt_file="$tmp_dir/prompt.txt"
 # ── Build the review prompt ──────────────────────────────────────────────────
 
 REVISIONS_BLOCK=""
+SEVERITY_GATE=""
 if [[ "$ROUND" -eq 1 ]]; then
   REVIEW_INTRO="Claude has created an implementation plan. Review it and provide feedback."
-else
+elif [[ "$ROUND" -le 4 ]]; then
   REVIEW_INTRO="Claude has addressed your previous feedback and updated the plan. Re-review the plan for remaining issues."
   if [[ -n "$REVISIONS_FILE" ]] && [[ -s "$REVISIONS_FILE" ]]; then
     REVISIONS_BLOCK="
@@ -93,6 +94,25 @@ else
 Claude's revision summary (including any findings that were rejected with evidence) is at: ${REVISIONS_FILE}
 Read it before reviewing the plan -- if Claude rejected a finding with valid evidence, do not re-raise it."
   fi
+else
+  # Round 5+: raise the bar -- only flag things that would cause wrong behavior
+  REVIEW_INTRO="Claude has addressed your previous feedback and updated the plan. This is round ${ROUND}. Re-review for any remaining critical issues."
+  if [[ -n "$REVISIONS_FILE" ]] && [[ -s "$REVISIONS_FILE" ]]; then
+    REVISIONS_BLOCK="
+
+Claude's revision summary (including any findings that were rejected with evidence) is at: ${REVISIONS_FILE}
+Read it before reviewing the plan -- if Claude rejected a finding with valid evidence, do not re-raise it."
+  fi
+  SEVERITY_GATE="
+IMPORTANT -- Severity threshold for round ${ROUND}:
+At this stage of the debate, only flag findings where a competent engineer following the plan would produce functionally wrong behavior -- incorrect output, data loss, crashes, security holes, or silently broken features. Do NOT flag:
+- Wording ambiguities that a reasonable implementer would resolve correctly
+- Missing prose for behavior that is already obvious from context
+- Hypothetical misimplementations that require actively misreading the plan
+- Test coverage gaps for edge cases that are unlikely in practice
+- Style or naming suggestions
+
+If you find no issues meeting this bar, respond with VERDICT: APPROVED."
 fi
 
 cat > "$prompt_file" <<PROMPT_EOF
@@ -136,6 +156,7 @@ Format each finding as:
 ---
 
 Be direct and specific. Only flag genuine, significant issues. Propose solutions, not just problems.
+${SEVERITY_GATE}
 
 The LAST line of your response MUST be exactly one of these two lines (nothing after it):
 VERDICT: APPROVED
@@ -273,9 +294,12 @@ if echo "$feedback_content" | grep -q "VERDICT: APPROVED"; then
   echo "VERDICT:APPROVED"
 elif echo "$feedback_content" | grep -q "VERDICT: NEEDS_CHANGES"; then
   echo "VERDICT:NEEDS_CHANGES"
-else
-  # No explicit verdict found -- treat as needs changes
+elif echo "$feedback_content" | grep -q "^### Finding"; then
+  # Has findings but no explicit verdict -- treat as needs changes
   echo "VERDICT:NEEDS_CHANGES"
+else
+  # No verdict AND no findings -- likely truncated response, not a real review
+  echo "CODEX_EMPTY"
 fi
 
 # Always emit session token and log ID for round-to-round continuity


### PR DESCRIPTION
Local mode now auto-detects open PRs via `gh pr view` and uses the PR diff scope instead of `main...HEAD`, preventing scope explosion on diverged branches. The partition cap enforcement loop is fixed with a force-merge fallback that guarantees partition count never exceeds max_bha_agents. Small diffs (<=150 LOC, <=5 files) now use a single Sonnet reviewer instead of the full 5-agent fleet.

Also adds a round-aware severity gate to the codex-review script so later debate rounds only flag functionally wrong behavior, and fixes truncated-response detection in verdict extraction.

These changes together reduce review time for small PRs from ~33 minutes to ~1-2 minutes.