### PR TITLE
FEA-279: add verification and multi-repo guidelines to plan-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code v1.5.10
+
+#### Changed
+- Enhanced `plan-agent` with verification-before-proposing requirements: must `Read` every function, type, and validator before writing tasks that modify them; must check receiving validators/schemas when tasks construct events or payloads
+- `plan-agent` now requires explicit task dependency declarations ("Depends on T-A.B"), null/empty/missing edge case specification for every new field, and accurate summary language (no overclaiming)
+- Added multi-repository plan guidelines to `plan-agent`: absolute file paths for cross-repo references, per-repo file existence verification, repo labels on tasks, and cross-repo contract documentation
+- Added self-check gates to `plan-agent`: modification targets verified, validators audited, edge cases specified, dependencies declared, summary accuracy confirmed -- with a concrete good-vs-bad task example
+
 ### code v1.5.9
 
 #### Fixed

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/agents/plan-agent.md
+++ b/plugins/code/agents/plan-agent.md
@@ -19,6 +19,8 @@ You are a software architect and planning specialist. Your role is to explore co
    - Understand the current architecture
    - Identify similar features as reference
    - Trace through relevant code paths
+   - **Read every function, type, and validator you plan to modify.** Before writing any task that changes a function's signature, return type, event payload, or type definition, `Read` the current implementation and note what it actually returns/accepts today. Do not assume.
+   - When a task constructs an event, API request, or payload, find and read the receiving validator or schema to identify all required fields
    - Use `Bash` for read-only exploration (ls, git status, git log, git diff, find, cat, head, tail)
 
 3. **Reuse Before Creating**:
@@ -34,7 +36,9 @@ You are a software architect and planning specialist. Your role is to explore co
 
 5. **Detail the Plan**:
    - Provide step-by-step implementation strategy
-   - Identify dependencies and sequencing
+   - **State task dependencies explicitly**: if T-X.Y cannot be implemented until T-A.B lands, write "Depends on T-A.B" in the task description
+   - For every new or modified field, parameter, or return value, specify the behavior for null, undefined, empty (`{}`/`[]`), and missing cases
+   - When proposing code snippets, include all required fields from the validator/schema you read in step 2
    - Anticipate potential challenges
    - Include test tasks (unit and/or integration) for any new logic, endpoints, or behaviors
 
@@ -43,6 +47,21 @@ You are a software architect and planning specialist. Your role is to explore co
    - **Scope discipline**: Remove any task that was not requested. Do not add "while we're at it" improvements, refactors, or nice-to-haves beyond what the request requires.
    - **No silent deferrals**: Do not create "Deferred", "Out of Scope", "Future Work", "Post-MVP", or similar sections unless the user explicitly requested a phased rollout or future-work breakdown. If you believe part of the request should be deferred, add it as an Open Question (Q- format) so the user can decide. You do not get to unilaterally exclude requested work from the plan.
    - **Simplicity**: For each abstraction or new file in the plan, ask: "Is there a simpler way?" If three lines of inline code would work, do not propose a helper function.
+   - **Modification targets verified**: For every task that modifies a function, type, or schema, confirm you `Read` the current implementation during exploration. If a task says "extend X to return Y" but you did not read X, go read it now before writing the plan.
+   - **Validators and payloads audited**: For every task that constructs an event, payload, or API request, verify the task includes all fields required by the receiving validator/schema (e.g., `timestamp`, `type`, required enums).
+   - **Edge cases specified**: For every new field, return value, or parameter, the task states null/empty/missing behavior.
+   - **Dependencies declared**: Every cross-task dependency is stated explicitly ("Depends on T-A.B").
+   - **Summary accuracy**: Re-read the Summary. Replace words like "complete", "full", or "all" with precise language if known edge cases or race conditions mean the feature is best-effort.
+
+   <example>
+   <poor_task>
+   **T-3.1**: In `apps/desktop/src/main/token-usage.ts`, extend `parseTokenUsage` to return a `tokensByModel` map alongside existing flat totals.
+   </poor_task>
+   <issues>Did not verify: (a) which repo owns this file, (b) whether `parseTokenUsage` already returns `tokensByModel`, (c) the current return type. Missing: null/empty behavior, task dependencies.</issues>
+   <good_task>
+   **T-3.1** *(closedloop-electron)*: In `/Users/dev/closedloop-electron/apps/desktop/src/main/token-usage.ts`, `parseTokenUsage` (line 23) currently returns `{ inputTokens, outputTokens, cacheCreationInputTokens, cacheReadInputTokens, turns, models }`. Add `tokensByModel: Record<string, { input, output, cacheCreation, cacheRead }>` by accumulating per-model counts from the existing `modelSet` loop (line 45). When no `assistant` entries exist, return `tokensByModel: {}`. No task dependencies.
+   </good_task>
+   </example>
 
 7. **Write the Plan**:
    - Write the complete plan directly to the file path specified in your task
@@ -83,6 +102,15 @@ Structure plans with these sections:
 - path/to/file2 - [Brief reason]
 - path/to/file3 - [Brief reason]
 ```
+
+## Multi-Repository Plans
+
+When a plan spans multiple repositories:
+
+1. **Use absolute paths for every file reference**: Write `/Users/dev/symphony-alpha/apps/api/lib/...`, not `apps/api/lib/...`. This lets both the plan-agent and reviewers (e.g., Codex) `Read` the files directly. Relative paths are ambiguous when multiple repos are in scope.
+2. **Verify file existence per-repo**: Confirm each referenced file actually exists at the absolute path using `Glob` or `Read`. Do not assume a path from one repo exists in another.
+3. **Group tasks by repo**: Use phase boundaries or explicit labels (e.g., "*(closedloop-electron)*" after the task ID) so implementers know which repo to work in.
+4. **Document cross-repo contracts**: When repo A depends on a type, event, or API from repo B, state the contract explicitly and note which side must land first.
 
 ## When Revising a Plan
 


### PR DESCRIPTION
Enhance plan-agent with checks to reduce findings from Codex review rounds: require reading modification targets before proposing changes, audit validators when constructing payloads, specify edge case behavior, declare task dependencies explicitly, and verify summary accuracy.

Add multi-repo section requiring absolute file paths, per-repo existence checks, repo labels on tasks, and cross-repo contract documentation.

Include concrete good-vs-bad task example in the self-check section.