### PR TITLE
FEA-398: migrate workdir state to .closedloop-ai/

### DIFF
--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/agents/plan-importer.md
+++ b/plugins/code/agents/plan-importer.md
@@ -20,7 +20,7 @@ You import an external markdown plan into the ClosedLoop `plan.json` format. You
 
 - `$CLOSEDLOOP_WORKDIR/plan.json` - Schema-compliant plan JSON
 - `$CLOSEDLOOP_WORKDIR/plan.md` - The markdown `content` field value (for human review)
-- `$CLOSEDLOOP_WORKDIR/.closedloop/imported-plan` - Marker file written on successful validation
+- `$CLOSEDLOOP_WORKDIR/.closedloop-ai/imported-plan` - Marker file written on successful validation
 
 ## Process
 
@@ -174,8 +174,8 @@ Common issues to fix:
 On successful validation (`status: "VALID"`), create the imported-plan marker:
 
 ```bash
-mkdir -p "$CLOSEDLOOP_WORKDIR/.closedloop"
-echo "imported" > "$CLOSEDLOOP_WORKDIR/.closedloop/imported-plan"
+mkdir -p "$CLOSEDLOOP_WORKDIR/.closedloop-ai"
+echo "imported" > "$CLOSEDLOOP_WORKDIR/.closedloop-ai/imported-plan"
 ```
 
 ## Quality Checklist
@@ -189,7 +189,7 @@ echo "imported" > "$CLOSEDLOOP_WORKDIR/.closedloop/imported-plan"
 | JSON sync | Structured arrays match markdown content exactly |
 | Valid JSON | No trailing commas, newlines escaped as `\n` in content string |
 | Validation | `validate_plan.py` returns `status: "VALID"` |
-| Marker file | `.closedloop/imported-plan` written on success |
+| Marker file | `.closedloop-ai/imported-plan` written on success |
 
 ## Completion
 
@@ -197,4 +197,4 @@ Output `<promise>PLAN_IMPORTED</promise>` ONLY when ALL are true:
 
 1. `$CLOSEDLOOP_WORKDIR/plan.json` exists and passed validation (`status: "VALID"`)
 2. `$CLOSEDLOOP_WORKDIR/plan.md` exists and contains the markdown content
-3. `$CLOSEDLOOP_WORKDIR/.closedloop/imported-plan` marker file exists
+3. `$CLOSEDLOOP_WORKDIR/.closedloop-ai/imported-plan` marker file exists

--- a/plugins/code/hooks/loop-stop-hook.sh
+++ b/plugins/code/hooks/loop-stop-hook.sh
@@ -47,7 +47,7 @@ fi
 
 # Source closedloop config from WORKDIR if found
 if [[ -n "$CLOSEDLOOP_WORKDIR" ]]; then
-  CLOSEDLOOP_CONFIG="$CLOSEDLOOP_WORKDIR/.closedloop/config.env"
+  CLOSEDLOOP_CONFIG="$CLOSEDLOOP_WORKDIR/.closedloop-ai/config.env"
   if [[ -f "$CLOSEDLOOP_CONFIG" ]]; then
     source "$CLOSEDLOOP_CONFIG"
   fi
@@ -90,14 +90,14 @@ STATE_FILE_SUFFIX=$(echo "$AGENT_CONFIG" | jq -r '.state_file_suffix // "loop.lo
 
 echo "$(date): Agent config - validation=$VALIDATION_SCRIPT, max_iter=$MAX_ITERATIONS_DEFAULT, promise=$PROMISE, state_suffix=$STATE_FILE_SUFFIX" >> "$DEBUG_LOG"
 
-# Build state file path (in CLOSEDLOOP_WORKDIR/.closedloop/)
+# Build state file path (in CLOSEDLOOP_WORKDIR/.closedloop-ai/)
 # Exit early if CLOSEDLOOP_WORKDIR is not set - no loop context
 if [[ -z "$CLOSEDLOOP_WORKDIR" ]]; then
   echo "$(date): No CLOSEDLOOP_WORKDIR, exiting loop-stop-hook" >> "$DEBUG_LOG"
   exit 0
 fi
 
-STATE_FILE="$CLOSEDLOOP_WORKDIR/.closedloop/$STATE_FILE_SUFFIX"
+STATE_FILE="$CLOSEDLOOP_WORKDIR/.closedloop-ai/$STATE_FILE_SUFFIX"
 
 if [[ ! -f "$STATE_FILE" ]]; then
   echo "$(date): No active loop - state file not found: $STATE_FILE" >> "$DEBUG_LOG"

--- a/plugins/code/hooks/pretooluse-hook.sh
+++ b/plugins/code/hooks/pretooluse-hook.sh
@@ -139,7 +139,7 @@ DEBUG_LOG="$CLOSEDLOOP_WORKDIR/.learnings/pretooluse-hook-debug.log"
 echo "$(date): PreToolUse hook started, tool=$TOOL_NAME" >> "$DEBUG_LOG"
 
 # Source closedloop config and skip learning injection if disabled
-CLOSEDLOOP_CONFIG="$CLOSEDLOOP_WORKDIR/.closedloop/config.env"
+CLOSEDLOOP_CONFIG="$CLOSEDLOOP_WORKDIR/.closedloop-ai/config.env"
 if [[ -f "$CLOSEDLOOP_CONFIG" ]]; then
     source "$CLOSEDLOOP_CONFIG"
 fi

--- a/plugins/code/hooks/session-end-hook.sh
+++ b/plugins/code/hooks/session-end-hook.sh
@@ -68,11 +68,6 @@ fi
 # Remove any orphaned .agent-types files in CLOSEDLOOP_WORKDIR (if known)
 # ============================================================================
 
-# Fallback: Check CWD's config.env (CLOSEDLOOP_WORKDIR was discovered above before cleanup)
-if [[ -z "$CLOSEDLOOP_WORKDIR" ]] && [[ -f "$CWD/.closedloop/config.env" ]]; then
-    source "$CWD/.closedloop/config.env"
-fi
-
 if [[ -n "$CLOSEDLOOP_WORKDIR" ]] && [[ -d "$CLOSEDLOOP_WORKDIR/.agent-types" ]]; then
     echo "$(date): Cleaning up agent-types directory: $CLOSEDLOOP_WORKDIR/.agent-types" >> "$DEBUG_LOG"
 

--- a/plugins/code/hooks/subagent-start-hook.sh
+++ b/plugins/code/hooks/subagent-start-hook.sh
@@ -35,7 +35,7 @@ fi
 
 # Source closedloop config from WORKDIR if found
 if [[ -n "$CLOSEDLOOP_WORKDIR" ]]; then
-    CLOSEDLOOP_CONFIG="$CLOSEDLOOP_WORKDIR/.closedloop/config.env"
+    CLOSEDLOOP_CONFIG="$CLOSEDLOOP_WORKDIR/.closedloop-ai/config.env"
     if [[ -f "$CLOSEDLOOP_CONFIG" ]]; then
         source "$CLOSEDLOOP_CONFIG"
     fi
@@ -72,13 +72,13 @@ if [[ -f "$LOOP_CONFIG" ]] && [[ -n "$AGENT_TYPE" ]]; then
         MAX_ITERATIONS="${CLOSEDLOOP_MAX_ITERATIONS:-$CONFIG_MAX_ITERATIONS}"
         PRD_FILE="${CLOSEDLOOP_PRD_FILE:-}"
         WORKDIR="${CLOSEDLOOP_WORKDIR:-$CWD}"
-        STATE_FILE="$WORKDIR/.closedloop/$STATE_FILE_SUFFIX"
+        STATE_FILE="$WORKDIR/.closedloop-ai/$STATE_FILE_SUFFIX"
 
         echo "$(date): Loop agent detected: $AGENT_TYPE, state_file=$STATE_FILE" >> "$DEBUG_LOG"
 
         # Only create if state file doesn't exist (idempotent)
         if [[ ! -f "$STATE_FILE" ]] && [[ -n "$WORKDIR" ]]; then
-            mkdir -p "$WORKDIR/.closedloop"
+            mkdir -p "$WORKDIR/.closedloop-ai"
 
             PROMPT="Create a comprehensive implementation plan for the requirements in @${PRD_FILE}.
 

--- a/plugins/code/hooks/subagent-stop-hook.sh
+++ b/plugins/code/hooks/subagent-stop-hook.sh
@@ -36,7 +36,7 @@ fi
 
 # Source closedloop config from WORKDIR if found
 if [[ -n "$CLOSEDLOOP_WORKDIR" ]]; then
-    CLOSEDLOOP_CONFIG="$CLOSEDLOOP_WORKDIR/.closedloop/config.env"
+    CLOSEDLOOP_CONFIG="$CLOSEDLOOP_WORKDIR/.closedloop-ai/config.env"
     if [[ -f "$CLOSEDLOOP_CONFIG" ]]; then
         source "$CLOSEDLOOP_CONFIG"
     fi

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -706,8 +706,8 @@ $prompt
 EOF
 
   # Update config.env with self-learning flag (preserve other keys)
-  mkdir -p "$WORKDIR/.closedloop"
-  CONFIG_FILE="$WORKDIR/.closedloop/config.env"
+  mkdir -p "$WORKDIR/.closedloop-ai"
+  CONFIG_FILE="$WORKDIR/.closedloop-ai/config.env"
   TMP_FILE="${CONFIG_FILE}.tmp.$$"
   if [[ -f "$CONFIG_FILE" ]]; then
     sed '/^CLOSEDLOOP_SELF_LEARNING=/d' "$CONFIG_FILE" > "$TMP_FILE"

--- a/plugins/code/scripts/setup-closedloop.sh
+++ b/plugins/code/scripts/setup-closedloop.sh
@@ -148,9 +148,9 @@ if [[ ! -f "$CLOSEDLOOP_PROMPT_FILE" ]]; then
 fi
 
 # Write full config to WORKDIR
-mkdir -p "$WORKDIR/.closedloop"
+mkdir -p "$WORKDIR/.closedloop-ai"
 
-cat > "$WORKDIR/.closedloop/config.env" << EOF
+cat > "$WORKDIR/.closedloop-ai/config.env" << EOF
 CLOSEDLOOP_WORKDIR="$WORKDIR"
 CLOSEDLOOP_PRD_FILE="$PRD_FILE"
 CLOSEDLOOP_PLAN_FILE="$PLAN_FILE"
@@ -159,5 +159,5 @@ CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
 CLOSEDLOOP_PROMPT_FILE="$CLOSEDLOOP_PROMPT_FILE"
 EOF
 
-echo "ClosedLoop config written to $WORKDIR/.closedloop/config.env"
-cat "$WORKDIR/.closedloop/config.env"
+echo "ClosedLoop config written to $WORKDIR/.closedloop-ai/config.env"
+cat "$WORKDIR/.closedloop-ai/config.env"

--- a/plugins/code/scripts/setup-loop.sh
+++ b/plugins/code/scripts/setup-loop.sh
@@ -118,7 +118,7 @@ CONFIG_MAX_ITERATIONS=$(echo "$AGENT_CONFIG" | jq -r '.max_iterations // 10')
 # Use command line override or config default
 MAX_ITERATIONS="${MAX_ITERATIONS:-$CONFIG_MAX_ITERATIONS}"
 
-STATE_FILE="$WORKDIR/.closedloop/$STATE_FILE_SUFFIX"
+STATE_FILE="$WORKDIR/.closedloop-ai/$STATE_FILE_SUFFIX"
 
 # Idempotency checks
 if [[ -f "$WORKDIR/plan.json" ]]; then
@@ -132,7 +132,7 @@ if [[ -f "$STATE_FILE" ]]; then
 fi
 
 # Create state file
-mkdir -p "$WORKDIR/.closedloop"
+mkdir -p "$WORKDIR/.closedloop-ai"
 
 PROMPT="Create a comprehensive implementation plan for the requirements in @${PRD_FILE}.
 

--- a/plugins/code/skills/closedloop-env/scripts/get-env.sh
+++ b/plugins/code/skills/closedloop-env/scripts/get-env.sh
@@ -3,7 +3,7 @@
 # Usage: get-env.sh <CLOSEDLOOP_WORKDIR>
 
 WORKDIR="${1:-.}"
-CONFIG_FILE="$WORKDIR/.closedloop/config.env"
+CONFIG_FILE="$WORKDIR/.closedloop-ai/config.env"
 
 if [[ ! -f "$CONFIG_FILE" ]]; then
     echo "Error: Config file not found at $CONFIG_FILE" >&2

--- a/plugins/code/tools/python/test_pretooluse_hook.py
+++ b/plugins/code/tools/python/test_pretooluse_hook.py
@@ -338,7 +338,7 @@ def session_env(tmp_path: Path) -> tuple[Path, Path, str]:
     (session_dir / f"session-{session_id}.workdir").write_text(str(workdir))
 
     # Create workdir with config.env (self-learning disabled)
-    closedloop_dir = workdir / ".closedloop"
+    closedloop_dir = workdir / ".closedloop-ai"
     closedloop_dir.mkdir(parents=True)
     (closedloop_dir / "config.env").write_text("CLOSEDLOOP_SELF_LEARNING=false\n")
 
@@ -404,7 +404,7 @@ class TestSelfLearningOff:
 def test_ignores_legacy_home_patterns(session_env: tuple[Path, Path, str]) -> None:
     """Should not inject patterns from legacy `~/.claude/.learnings`."""
     cwd, workdir, session_id = session_env
-    (workdir / ".closedloop" / "config.env").write_text(
+    (workdir / ".closedloop-ai" / "config.env").write_text(
         "CLOSEDLOOP_SELF_LEARNING=true\n"
     )
 
@@ -431,7 +431,7 @@ def test_ignores_legacy_home_patterns(session_env: tuple[Path, Path, str]) -> No
 def test_injects_when_only_plain_awk_is_available(session_env: tuple[Path, Path, str]) -> None:
     """Should continue injecting tool learnings when only plain awk is available."""
     cwd, workdir, session_id = session_env
-    (workdir / ".closedloop" / "config.env").write_text(
+    (workdir / ".closedloop-ai" / "config.env").write_text(
         "CLOSEDLOOP_SELF_LEARNING=true\n"
     )
 

--- a/plugins/code/tools/python/test_self_learning_flag.py
+++ b/plugins/code/tools/python/test_self_learning_flag.py
@@ -12,8 +12,8 @@ RUN_LOOP_SH = SCRIPTS_DIR / "run-loop.sh"
 
 @pytest.fixture()
 def workdir(tmp_path: Path) -> Path:
-    """Create a minimal workdir with .closedloop/ directory."""
-    (tmp_path / ".closedloop").mkdir()
+    """Create a minimal workdir with .closedloop-ai/ directory."""
+    (tmp_path / ".closedloop-ai").mkdir()
     (tmp_path / ".learnings").mkdir()
     return tmp_path
 
@@ -62,7 +62,7 @@ def _base_env(
         GREEN='\\033[0;32m'
         NC='\\033[0m'
         PROGRESS_LOG="/dev/null"
-        STATE_FILE="{workdir}/.closedloop/state.local.md"
+        STATE_FILE="{workdir}/.closedloop-ai/state.local.md"
         WORKDIR="{workdir}"
         MAX_ITERATIONS=5
         COMPLETION_PROMISE="COMPLETE"
@@ -100,7 +100,7 @@ class TestCreateStateFilePersistsSelfLearning:
         result = _run_script(self._build_script(workdir, "true"), cwd=str(workdir))
         assert result.returncode == 0, f"Script failed: {result.stderr}"
 
-        content = (workdir / ".closedloop" / "state.local.md").read_text()
+        content = (workdir / ".closedloop-ai" / "state.local.md").read_text()
         assert 'self_learning: "true"' in content
 
     def test_state_file_contains_self_learning_false(self, workdir: Path) -> None:
@@ -108,12 +108,12 @@ class TestCreateStateFilePersistsSelfLearning:
         result = _run_script(self._build_script(workdir, "false"), cwd=str(workdir))
         assert result.returncode == 0, f"Script failed: {result.stderr}"
 
-        content = (workdir / ".closedloop" / "state.local.md").read_text()
+        content = (workdir / ".closedloop-ai" / "state.local.md").read_text()
         assert 'self_learning: "false"' in content
 
     def test_config_env_written_with_self_learning(self, workdir: Path) -> None:
         """create_state_file writes CLOSEDLOOP_SELF_LEARNING to config.env."""
-        config_env = workdir / ".closedloop" / "config.env"
+        config_env = workdir / ".closedloop-ai" / "config.env"
         config_env.write_text("CLOSEDLOOP_WORKDIR=/tmp/test\n")
 
         result = _run_script(self._build_script(workdir, "true"), cwd=str(workdir))
@@ -179,7 +179,7 @@ class TestSelfLearningResume:
 
     def test_get_field_reads_self_learning(self, workdir: Path) -> None:
         """get_field can extract self_learning from state frontmatter."""
-        state_file = workdir / ".closedloop" / "state.local.md"
+        state_file = workdir / ".closedloop-ai" / "state.local.md"
         # Write frontmatter without indentation -- must start at column 0
         state_file.write_text(
             "---\n"

--- a/plugins/code/tools/python/test_subagent_start_hook.py
+++ b/plugins/code/tools/python/test_subagent_start_hook.py
@@ -25,7 +25,7 @@ def session_env(tmp_path: Path) -> tuple[Path, Path, str]:
     (session_dir / f"session-{session_id}.workdir").write_text(str(workdir))
 
     # Create workdir structure
-    closedloop_dir = workdir / ".closedloop"
+    closedloop_dir = workdir / ".closedloop-ai"
     closedloop_dir.mkdir(parents=True)
 
     learnings_dir = workdir / ".learnings"
@@ -46,7 +46,7 @@ def run_start_hook(
     # Write config.env
     workdir_file = Path(cwd) / ".closedloop-ai" / f"session-{session_id}.workdir"
     workdir = workdir_file.read_text().strip()
-    config_path = Path(workdir) / ".closedloop" / "config.env"
+    config_path = Path(workdir) / ".closedloop-ai" / "config.env"
     sl_value = "true" if self_learning else "false"
     config_path.write_text(f"CLOSEDLOOP_SELF_LEARNING={sl_value}\n")
 

--- a/plugins/code/tools/python/test_subagent_stop_hook.py
+++ b/plugins/code/tools/python/test_subagent_stop_hook.py
@@ -25,7 +25,7 @@ def session_env(tmp_path: Path) -> tuple[Path, Path, str]:
     (session_dir / f"session-{session_id}.workdir").write_text(str(workdir))
 
     # Create workdir structure
-    closedloop_dir = workdir / ".closedloop"
+    closedloop_dir = workdir / ".closedloop-ai"
     closedloop_dir.mkdir(parents=True)
 
     learnings_dir = workdir / ".learnings"
@@ -53,7 +53,7 @@ def run_stop_hook(
     # Write config.env
     workdir_file = Path(cwd) / ".closedloop-ai" / f"session-{session_id}.workdir"
     workdir = workdir_file.read_text().strip()
-    config_path = Path(workdir) / ".closedloop" / "config.env"
+    config_path = Path(workdir) / ".closedloop-ai" / "config.env"
     sl_value = "true" if self_learning else "false"
     config_path.write_text(
         f"CLOSEDLOOP_SELF_LEARNING={sl_value}\n{config_env_extra}"

--- a/plugins/judges/.claude-plugin/plugin.json
+++ b/plugins/judges/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "judges",
   "description": "LLM Judges plugin",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/judges/skills/run-judges/SKILL.md
+++ b/plugins/judges/skills/run-judges/SKILL.md
@@ -190,7 +190,7 @@ Use `sub_step` as numeric phase order and optional `sub_step_name` to capture th
 SUB_STEP_NUM=0
 SUB_STEP_LABEL="context_manager"   # context_manager | batch_1 … | aggregate | validate
 
-mkdir -p "$CLOSEDLOOP_WORKDIR/.closedloop"
+mkdir -p "$CLOSEDLOOP_WORKDIR/.closedloop-ai"
 {
   echo "SUB_STEP=${SUB_STEP_NUM}"
   echo "SUB_STEP_NAME=${SUB_STEP_LABEL}"
@@ -198,13 +198,13 @@ mkdir -p "$CLOSEDLOOP_WORKDIR/.closedloop"
   echo "PARENT_STEP_NAME=${CLOSEDLOOP_PARENT_STEP_NAME:-unknown}"
   echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   echo "START_EPOCH=$(date +%s)"
-} > "$CLOSEDLOOP_WORKDIR/.closedloop/perf-substep-start.env"
+} > "$CLOSEDLOOP_WORKDIR/.closedloop-ai/perf-substep-start.env"
 ```
 
 **End of phase (run Bash once at the end of each phase, after the phase work is done):** Read start time, compute duration, append one line to `perf.jsonl`, then remove the temp file.
 
 ```bash
-source "$CLOSEDLOOP_WORKDIR/.closedloop/perf-substep-start.env"
+source "$CLOSEDLOOP_WORKDIR/.closedloop-ai/perf-substep-start.env"
 END_EPOCH=$(date +%s)
 ENDED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 DURATION=$((END_EPOCH - START_EPOCH))
@@ -222,7 +222,7 @@ jq -n -c \
   --argjson exit_code 0 \
   --argjson skipped false \
   '{event:$event,run_id:$run_id,iteration:$iteration,step:$step,step_name:$step_name,sub_step:$sub_step,sub_step_name:$sub_step_name,started_at:$started_at,ended_at:$ended_at,duration_s:$duration_s,exit_code:$exit_code,skipped:$skipped}' >> "$CLOSEDLOOP_WORKDIR/perf.jsonl"
-rm -f "$CLOSEDLOOP_WORKDIR/.closedloop/perf-substep-start.env"
+rm -f "$CLOSEDLOOP_WORKDIR/.closedloop-ai/perf-substep-start.env"
 ```
 
 **Order of operations per phase:** Run the "start of phase" Bash first (set `SUB_STEP_NUM` and `SUB_STEP_LABEL` at the top, then run the block), then perform the phase work, then run the "end of phase" Bash.


### PR DESCRIPTION
Completes the v1.1.0 directory migration by moving all workdir-scoped state (config.env, loop state, imported-plan marker, perf-substep files) from $WORKDIR/.closedloop/ to $WORKDIR/.closedloop-ai/. The CWD-level session mapping was already migrated; this catches the remaining writers in scripts, hooks, skills, and the plan-importer agent.

Scope:
- plugins/code: setup-closedloop.sh, setup-loop.sh, run-loop.sh, subagent-start-hook.sh, subagent-stop-hook.sh, loop-stop-hook.sh, pretooluse-hook.sh, session-end-hook.sh (legacy fallback removed), closedloop-env/get-env.sh, plan-importer.md, 4 test fixtures. Minor version bump to 1.7.0.
- plugins/judges: run-judges/SKILL.md perf-substep-start.env path. Patch version bump to 1.5.1.

Risk: In-flight loops with state at `$WORKDIR/.closedloop/` will be orphaned on upgrade. Hooks look exclusively at `$WORKDIR/.closedloop-ai/` now, so the old `config.env` won't be sourced (hooks degrade to no-op: self-learning off, no crash) and the old `state.local.md` won't be found (loop restarts from iteration 1, losing counter/run_id/start_sha). `imported-plan` marker will be re-imported on next run (idempotent, harmless). Temp `perf-substep-start.env` files are phase-scoped, zero impact. No auto-migration: users with mid-loop state should either `rm -rf $WORKDIR/.closedloop/` or `mv $WORKDIR/.closedloop/* $WORKDIR/.closedloop-ai/` before their next run. `.gitignore` retains the `.closedloop/` entry so orphans don't surface in `git status`.