### PR TITLE
FEA-372: Add post-loop code review and fix skill

### DIFF
--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/skills/fix/SKILL.md
+++ b/plugins/code-review/skills/fix/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: fix
+description: Verify and fix code review findings, then run project verification. Use this skill whenever the user wants to address, fix, or remediate code review findings after running /code-review:start, when there are BLOCKING or HIGH severity issues to resolve, or when the user says things like "fix the review comments", "address the findings", or "remediate code review issues". Only applies when a prior code review session directory exists. Accepts a review session directory path and optional --max-cycles flag.
+---
+
+# Fix Code Review Findings
+
+Verify and remediate BLOCKING and HIGH severity findings from a prior `/code-review:start` run, then run project verification (test, lint, typecheck, build). Caps at a configurable number of review-fix cycles to prevent infinite loops.
+
+## Usage
+
+```
+/code-review:fix .closedloop-ai/code-review/cr-abc123
+/code-review:fix .closedloop-ai/code-review/cr-abc123 --max-cycles 1
+```
+
+**Finding the session directory:** The most recent review session is the latest `cr-*` directory under `.closedloop-ai/code-review/`:
+```bash
+ls -td .closedloop-ai/code-review/cr-* | head -1
+```
+
+---
+
+## Step 1: Parse Arguments and Load Findings
+
+Parse `$ARGUMENTS` to extract:
+- **CR_DIR** (required positional): Path to the code-review session directory
+- **--max-cycles N** (optional, default: 2): Maximum review-fix cycles. Initialize `CYCLE = 1`.
+
+Validation:
+- If CR_DIR is missing: auto-discover by running `ls -td .closedloop-ai/code-review/cr-* | head -1`. If no session directories exist, print error "No code review session found. Run /code-review:start first." and exit
+- If `<CR_DIR>/validate_output.json` does not exist: print error "No validate_output.json found in <CR_DIR>. Run /code-review:start first." and exit
+
+### Load Findings
+
+- Read `<CR_DIR>/validate_output.json`
+- Extract the `validated` array
+- Filter to findings where `severity` is `BLOCKING` or `HIGH`
+- Count and log MEDIUM/LOW findings that will be skipped
+- If no BLOCKING/HIGH findings: print "No actionable findings (BLOCKING/HIGH). Review complete." and mark all todos completed and exit
+
+### Create Todo List
+
+```json
+TodoWrite([
+  {"content": "Parse arguments and load findings", "status": "completed", "activeForm": "Parsing arguments"},
+  {"content": "Verify findings", "status": "pending", "activeForm": "Verifying findings"},
+  {"content": "Fix confirmed findings", "status": "pending", "activeForm": "Fixing findings"},
+  {"content": "Run project verification", "status": "pending", "activeForm": "Running verification"},
+  {"content": "Re-review", "status": "pending", "activeForm": "Re-reviewing"},
+  {"content": "Print summary", "status": "pending", "activeForm": "Printing summary"}
+])
+```
+
+---
+
+## Step 2: Verify Each Finding
+
+For each BLOCKING/HIGH finding, launch a verification subagent to determine if it is a real bug or a false positive.
+
+For each finding, launch a Task with `model: sonnet` and tools `Read, Grep, Glob`:
+
+**Prompt template** (inline all values -- no shell variables):
+```
+Determine if this code review finding is a real bug or a false positive.
+
+**Finding:**
+- File: <file>
+- Line: <line>
+- Severity: <severity>
+- Category: <category>
+- Issue: <issue>
+- Explanation: <explanation>
+- Code snippet: <code_snippet>
+- Recommendation: <recommendation>
+
+Read the cited file and 50 lines of surrounding context. Check for error handling, type guards, intentional patterns, or inline justifications that would make this a false positive. Verify the issue actually exists at the cited line.
+
+Output exactly one of:
+CONFIRMED: <brief reasoning why this is a real bug>
+REJECTED: <brief reasoning why this is a false positive>
+```
+
+Launch all verification agents **in parallel** (multiple Task calls in a single message).
+
+### Collect Results
+
+- Parse each agent's response for `CONFIRMED` or `REJECTED`
+- Filter to only CONFIRMED findings
+- If no confirmed findings remain: print "All findings were false positives. No fixes needed." and mark remaining todos as completed and exit
+
+---
+
+## Step 3: Fix Confirmed Findings
+
+Group related confirmed findings by file. Findings in the same file should be fixed together.
+
+Fix each finding **one at a time, sequentially** -- do NOT launch fix agents in parallel. Separate findings may affect the same source files, so each fix must see the results of prior fixes to avoid conflicts.
+
+For each finding or group, launch a Task with `model: sonnet` and tools `Read, Write, Edit, Grep, Glob`:
+
+**Prompt template** (inline all values -- no shell variables):
+```
+Fix this code review finding. Apply the minimal change needed -- do NOT refactor surrounding code, add new features, or add unnecessary error handling.
+
+**Finding:**
+- File: <file>
+- Line: <line>
+- Issue: <issue>
+- Explanation: <explanation>
+- Recommendation: <recommendation>
+
+Read the file, apply the fix, and confirm what you changed.
+```
+
+Wait for each fix agent to complete before launching the next one. Track the list of modified files for re-review in Step 5.
+
+---
+
+## Step 4: Run Project Verification
+
+Launch a Task with `subagent_type: "code:build-validator"`:
+
+```
+Run all validation commands (test, lint, typecheck, build) for this project. Report VALIDATION_PASSED, VALIDATION_FAILED, or NO_VALIDATION.
+```
+
+- **VALIDATION_PASSED** or **NO_VALIDATION**: Proceed to Step 5
+- **VALIDATION_FAILED**: Delegate fix to a Sonnet subagent and retry the validator, up to 5 attempts total. Log a warning and proceed on persistent failure.
+
+---
+
+## Step 5: Re-review (Conditional)
+
+- If `CYCLE >= MAX_CYCLES`: log any remaining concerns as warnings, proceed to Step 6
+- If `CYCLE < MAX_CYCLES` AND fixes were applied in Step 3:
+  - Increment `CYCLE`
+  - Invoke the code review on only the modified files using the Skill tool: `Skill(skill="code-review:start", args="<file1> <file2> ...")`
+  - Find the new session directory (`ls -td .closedloop-ai/code-review/cr-* | head -1`) and read its `validate_output.json`
+  - If new BLOCKING/HIGH findings exist: loop back to Step 2 with the new findings
+  - If clean: proceed to Step 6
+
+---
+
+## Step 6: Summary
+
+Print a structured summary of the fix session:
+
+```markdown
+## Fix Summary
+
+| Metric | Value |
+|--------|-------|
+| Findings received | N |
+| Confirmed (not false positive) | N |
+| Fixed | N |
+| Remaining (warnings) | N |
+| Verification | PASSED/FAILED/NO_VALIDATION |
+| Cycles used | N of MAX |
+```
+
+Mark all todos as `completed`.
+
+---
+
+$ARGUMENTS

--- a/plugins/code-review/skills/fix/SKILL.md
+++ b/plugins/code-review/skills/fix/SKILL.md
@@ -1,148 +1,136 @@
 ---
 name: fix
-description: Verify and fix code review findings, then run project verification. Use this skill whenever the user wants to address, fix, or remediate code review findings after running /code-review:start, when there are BLOCKING or HIGH severity issues to resolve, or when the user says things like "fix the review comments", "address the findings", or "remediate code review issues". Only applies when a prior code review session directory exists. Accepts a review session directory path and optional --max-cycles flag.
+description: Verify and fix BLOCKING/HIGH code review findings from a prior review session, then run project verification.
+argument-hint: "<cr-dir>"
 ---
 
 # Fix Code Review Findings
 
-Verify and remediate BLOCKING and HIGH severity findings from a prior `/code-review:start` run, then run project verification (test, lint, typecheck, build). Caps at a configurable number of review-fix cycles to prevent infinite loops.
+Single verify-and-fix pass for BLOCKING/HIGH findings from a prior code review. The caller controls re-review cycles.
 
-## Usage
+## Arguments
 
-```
-/code-review:fix .closedloop-ai/code-review/cr-abc123
-/code-review:fix .closedloop-ai/code-review/cr-abc123 --max-cycles 1
-```
-
-**Finding the session directory:** The most recent review session is the latest `cr-*` directory under `.closedloop-ai/code-review/`:
-```bash
-ls -td .closedloop-ai/code-review/cr-* | head -1
-```
+$ARGUMENTS
 
 ---
 
 ## Step 1: Parse Arguments and Load Findings
 
-Parse `$ARGUMENTS` to extract:
-- **CR_DIR** (required positional): Path to the code-review session directory
-- **--max-cycles N** (optional, default: 2): Maximum review-fix cycles. Initialize `CYCLE = 1`.
-
-Validation:
-- If CR_DIR is missing: auto-discover by running `ls -td .closedloop-ai/code-review/cr-* | head -1`. If no session directories exist, print error "No code review session found. Run /code-review:start first." and exit
-- If `<CR_DIR>/validate_output.json` does not exist: print error "No validate_output.json found in <CR_DIR>. Run /code-review:start first." and exit
-
-### Load Findings
-
-- Read `<CR_DIR>/validate_output.json`
-- Extract the `validated` array
-- Filter to findings where `severity` is `BLOCKING` or `HIGH`
-- Count and log MEDIUM/LOW findings that will be skipped
-- If no BLOCKING/HIGH findings: print "No actionable findings (BLOCKING/HIGH). Review complete." and mark all todos completed and exit
-
-### Create Todo List
-
 ```json
 TodoWrite([
-  {"content": "Parse arguments and load findings", "status": "completed", "activeForm": "Parsing arguments"},
+  {"content": "Parse arguments and load findings", "status": "in_progress", "activeForm": "Parsing arguments"},
   {"content": "Verify findings", "status": "pending", "activeForm": "Verifying findings"},
   {"content": "Fix confirmed findings", "status": "pending", "activeForm": "Fixing findings"},
   {"content": "Run project verification", "status": "pending", "activeForm": "Running verification"},
-  {"content": "Re-review", "status": "pending", "activeForm": "Re-reviewing"},
   {"content": "Print summary", "status": "pending", "activeForm": "Printing summary"}
 ])
 ```
+
+Extract **CR_DIR** (positional) from `$ARGUMENTS`.
+
+<constraints>
+- CR_DIR missing: auto-discover via `ls -td .closedloop-ai/code-review/cr-* | head -1`. No directories found → error "No code review session found. Run a code review first." → exit.
+- `CR_DIR/validate_output.json` missing → error "No validate_output.json found in CR_DIR. Run a code review first." → exit.
+</constraints>
+
+### Load Findings
+
+Read `CR_DIR/validate_output.json`. Each entry in the `validated` array:
+```json
+{"file": "path/to/file.ts", "line": 42, "severity": "HIGH", "category": "Correctness", "issue": "[P1] Brief title", "explanation": "...", "recommendation": "...", "code_snippet": "...", "priority": 1, "confidence": 0.9}
+```
+
+Filter to `severity` = `"BLOCKING"` or `"HIGH"`. Log skipped MEDIUM count.
+No BLOCKING/HIGH findings → print "No actionable findings. Review complete." → mark all todos completed → exit.
 
 ---
 
 ## Step 2: Verify Each Finding
 
-For each BLOCKING/HIGH finding, launch a verification subagent to determine if it is a real bug or a false positive.
+For each BLOCKING/HIGH finding, launch an `Agent` tool call with `subagent_type: "general-purpose"`, `model: "sonnet"`. Inline all finding values — no shell variables.
 
-For each finding, launch a Task with `model: sonnet` and tools `Read, Grep, Glob`:
+Launch all verification agents **in parallel** (multiple Agent tool calls in a single message).
 
-**Prompt template** (inline all values -- no shell variables):
+**Prompt template:**
+
 ```
-Determine if this code review finding is a real bug or a false positive.
+<context>
+Verify whether this code review finding is a real bug or a false positive.
+File: {file} | Line: {line} | Severity: {severity} | Category: {category}
+Issue: {issue}
+Explanation: {explanation}
+Code snippet: {code_snippet}
+Recommendation: {recommendation}
+</context>
 
-**Finding:**
-- File: <file>
-- Line: <line>
-- Severity: <severity>
-- Category: <category>
-- Issue: <issue>
-- Explanation: <explanation>
-- Code snippet: <code_snippet>
-- Recommendation: <recommendation>
+<instructions>
+Read the cited file and 50 lines of surrounding context. Reason through:
+1. PREMISE: What is this code supposed to do? (cite function/context)
+2. EVIDENCE: What concrete evidence proves or disproves the issue? (trace execution path, cite file:line)
+3. GUARD CHECK: Is there error handling or upstream logic that prevents this? (cite search result or "verified none exists at file:line")
+4. VERDICT: Real bug or false positive?
 
-Read the cited file and 50 lines of surrounding context. Check for error handling, type guards, intentional patterns, or inline justifications that would make this a false positive. Verify the issue actually exists at the cited line.
+If analysis concludes the issue is NOT a problem, verdict MUST be REJECTED.
+</instructions>
 
-Output exactly one of:
-CONFIRMED: <brief reasoning why this is a real bug>
-REJECTED: <brief reasoning why this is a false positive>
+<examples>
+CONFIRMED — proven bug:
+Input flows from req.body (line 12) → processData (line 30) → SQL query (line 47) with no escaping. Searched for sanitize/escape calls — none exist.
+{"verdict": "CONFIRMED", "reasoning": "Unsanitized user input flows directly into SQL query at line 47 with no upstream validation."}
+
+REJECTED — false positive:
+Flagged null dereference at line 85, but variable is guarded by type check at line 78 (if (x !== null)) covering all paths to line 85.
+{"verdict": "REJECTED", "reasoning": "Null dereference prevented by type guard at line 78 covering all paths to line 85."}
+</examples>
+
+<output_format>
+Output ONLY: {"verdict": "CONFIRMED"|"REJECTED", "reasoning": "...citing specific evidence..."}
+</output_format>
 ```
-
-Launch all verification agents **in parallel** (multiple Task calls in a single message).
 
 ### Collect Results
 
-- Parse each agent's response for `CONFIRMED` or `REJECTED`
-- Filter to only CONFIRMED findings
-- If no confirmed findings remain: print "All findings were false positives. No fixes needed." and mark remaining todos as completed and exit
+Parse each response for `verdict` field. Keep only `"CONFIRMED"` findings.
+No confirmed findings → print "All findings were false positives. No fixes needed." → mark todos completed → exit.
 
 ---
 
 ## Step 3: Fix Confirmed Findings
 
-Group related confirmed findings by file. Findings in the same file should be fixed together.
+Group confirmed findings by file. Fix **sequentially** (one agent at a time) — findings may share source files, so each fix must see prior results.
 
-Fix each finding **one at a time, sequentially** -- do NOT launch fix agents in parallel. Separate findings may affect the same source files, so each fix must see the results of prior fixes to avoid conflicts.
+For each finding/group, launch `Agent` with `subagent_type: "general-purpose"`, `model: "sonnet"`:
 
-For each finding or group, launch a Task with `model: sonnet` and tools `Read, Write, Edit, Grep, Glob`:
-
-**Prompt template** (inline all values -- no shell variables):
 ```
-Fix this code review finding. Apply the minimal change needed -- do NOT refactor surrounding code, add new features, or add unnecessary error handling.
+Fix this code review finding. Minimal change only — no refactoring, no new features, no unnecessary error handling.
+File: {file} | Line: {line}
+Issue: {issue}
+Explanation: {explanation}
+Recommendation: {recommendation}
 
-**Finding:**
-- File: <file>
-- Line: <line>
-- Issue: <issue>
-- Explanation: <explanation>
-- Recommendation: <recommendation>
-
-Read the file, apply the fix, and confirm what you changed.
+Read the file, apply the fix, confirm what changed.
 ```
 
-Wait for each fix agent to complete before launching the next one. Track the list of modified files for re-review in Step 5.
+Track modified files for Step 5 summary.
 
 ---
 
 ## Step 4: Run Project Verification
 
-Launch a Task with `subagent_type: "code:build-validator"`:
+Launch `Agent` with `subagent_type: "code:build-validator"`:
 
 ```
-Run all validation commands (test, lint, typecheck, build) for this project. Report VALIDATION_PASSED, VALIDATION_FAILED, or NO_VALIDATION.
+Run all validation commands (test, lint, typecheck, build). Report VALIDATION_PASSED, VALIDATION_FAILED, or NO_VALIDATION.
 ```
 
-- **VALIDATION_PASSED** or **NO_VALIDATION**: Proceed to Step 5
-- **VALIDATION_FAILED**: Delegate fix to a Sonnet subagent and retry the validator, up to 5 attempts total. Log a warning and proceed on persistent failure.
+Do NOT run validation commands directly — the `build-validator` discovers and runs them.
+
+- **PASSED** or **NO_VALIDATION** → proceed to Step 5
+- **FAILED** → launch `general-purpose` subagent (`model: "sonnet"`) to fix, re-run `build-validator`. Max 5 attempts. Warn and proceed on persistent failure.
 
 ---
 
-## Step 5: Re-review (Conditional)
-
-- If `CYCLE >= MAX_CYCLES`: log any remaining concerns as warnings, proceed to Step 6
-- If `CYCLE < MAX_CYCLES` AND fixes were applied in Step 3:
-  - Increment `CYCLE`
-  - Invoke the code review on only the modified files using the Skill tool: `Skill(skill="code-review:start", args="<file1> <file2> ...")`
-  - Find the new session directory (`ls -td .closedloop-ai/code-review/cr-* | head -1`) and read its `validate_output.json`
-  - If new BLOCKING/HIGH findings exist: loop back to Step 2 with the new findings
-  - If clean: proceed to Step 6
-
----
-
-## Step 6: Summary
+## Step 5: Summary
 
 Print a structured summary of the fix session:
 
@@ -156,11 +144,7 @@ Print a structured summary of the fix session:
 | Fixed | N |
 | Remaining (warnings) | N |
 | Verification | PASSED/FAILED/NO_VALIDATION |
-| Cycles used | N of MAX |
+| Modified files | file1, file2, ... |
 ```
 
 Mark all todos as `completed`.
-
----
-
-$ARGUMENTS

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/prompts/prompt.md
+++ b/plugins/code/prompts/prompt.md
@@ -129,7 +129,7 @@ TodoWrite([
   {"content": "Phase 2.7: Plan finalization", "status": "pending", "activeForm": "Finalizing plan"},
   {"content": "Phase 3: Implementation", "status": "pending", "activeForm": "Implementing"},
   {"content": "Phase 4: Code simplification", "status": "pending", "activeForm": "Simplifying code"},
-  {"content": "Phase 5: Testing and Code Review", "status": "pending", "activeForm": "Testing"},
+  {"content": "Phase 5: Testing and Validation", "status": "pending", "activeForm": "Testing"},
   {"content": "Phase 6: Visual inspection", "status": "pending", "activeForm": "Inspecting visuals"},
   {"content": "Phase 7: Logging and completion", "status": "pending", "activeForm": "Completing"}
 ])
@@ -393,7 +393,7 @@ Here are the key phases you must complete:
 - The agent applies simplifications directly — do not edit code yourself
 - This runs BEFORE testing so that tests validate the final simplified code
 
-**PHASE 5: TESTING AND CODE REVIEW**
+**PHASE 5: TESTING AND VALIDATION**
 
 - **Update state.json** with phase tracking (see State Tracking table above)
 
@@ -403,12 +403,7 @@ Here are the key phases you must complete:
 - The test-engineer will identify testable code and write appropriate unit/integration tests
 - Skip this step only if: (a) no code was implemented, or (b) the project has no test framework
 
-**Step 2: Code review**
-- Launch @code:code-reviewer with prompt:
-  "WORKDIR=$CLOSEDLOOP_WORKDIR. Review the code changes made in this session. Check for: security issues (especially authorization and tenant scoping on data-access endpoints), type safety, correctness, performance (unbounded parallel calls), code duplication across changed files, and package boundary violations."
-- Fix all blockers and critical bugs until none remain (delegate fixes to subagents, not orchestrator)
-
-**Step 3: Run validation via build-validator agent:**
+**Step 2: Run validation via build-validator agent:**
 1. Launch @code:build-validator with `WORKDIR=$CLOSEDLOOP_WORKDIR`
 2. Process the result:
    - `VALIDATION_PASSED`: Stamp the build cache, then proceed to Phase 6:
@@ -431,7 +426,7 @@ Here are the key phases you must complete:
 
         1. **FIRST** - Write state.json with AWAITING_USER status:
            ```bash
-           echo '{"phase": "Phase 5: Testing and Code Review", "status": "AWAITING_USER", "reason": "Validation failed after 20 attempts", "userAction": {"description": "Fix validation issues manually and run the command to continue", "file": null, "command": "/code:code $ARGUMENTS"}, "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}' > $CLOSEDLOOP_WORKDIR/state.json
+           echo '{"phase": "Phase 5: Testing and Validation", "status": "AWAITING_USER", "reason": "Validation failed after 20 attempts", "userAction": {"description": "Fix validation issues manually and run the command to continue", "file": null, "command": "/code:code $ARGUMENTS"}, "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"}' > $CLOSEDLOOP_WORKDIR/state.json
            ```
         2. **ONLY AFTER state.json is written** - Output `<promise>COMPLETE</promise>`
         3. Tell the user: "Validation failed after 20 attempts. Fix issues manually and run `/code:code $ARGUMENTS` to continue."

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -436,6 +436,151 @@ run_background_pruning() {
   fi
 }
 
+# Run post-loop code review after implementation completes
+run_post_loop_review() {
+  local workdir="$1"
+
+  # Skip if START_SHA is not available (no git context)
+  if [[ -z "$START_SHA" ]]; then
+    log_progress "Post-loop code review skipped: no START_SHA"
+    return 0
+  fi
+
+  # Skip if no code changes were made (check working tree + staged + committed)
+  local changed_count
+  changed_count=$( {
+    git diff --name-only "$START_SHA" 2>/dev/null;        # uncommitted changes vs start
+    git diff --name-only --cached 2>/dev/null;             # staged changes
+    git diff --name-only "$START_SHA" HEAD 2>/dev/null;    # committed changes
+  } | sort -u | wc -l | tr -d ' ')
+  if [[ "$changed_count" -eq 0 ]]; then
+    echo -e "\n${GREEN}No code changes detected. Skipping post-loop code review.${NC}"
+    log_progress "Post-loop code review skipped: no changes since $START_SHA"
+    return 0
+  fi
+
+  echo -e "\n${BLUE}═══════════════════════════════════════════════════════════${NC}"
+  echo -e "${BLUE}Post-Loop Code Review${NC}"
+  echo -e "${BLUE}═══════════════════════════════════════════════════════════${NC}"
+
+  log_progress "Starting post-loop code review ($changed_count files changed)"
+
+  local review_start_epoch
+  review_start_epoch=$(date +%s)
+  local review_output
+  review_output=$(mktemp)
+  local review_stderr
+  review_stderr=$(mktemp)
+
+  # Run code review scoped to this run's changes
+  # Uses same pipeline pattern as main loop iterations (background subshell + wait)
+  local formatter="$SCRIPTS_DIR/../tools/python/stream_formatter.py"
+  local review_exit_file
+  review_exit_file=$(mktemp)
+  set +e
+  (
+    claude \
+      --allowed-tools=Bash,Grep,Glob,Read,Write,Edit,Task,TodoWrite \
+      --output-format stream-json \
+      --verbose \
+      -p "/code-review:start --base $START_SHA" 2>"$review_stderr" \
+      | { grep --line-buffered '^{' || true; } \
+      | tee "$review_output" \
+      | tee -a "${workdir}/claude-output.jsonl" \
+      | python3 "$formatter"
+    echo "${PIPESTATUS[0]}" > "$review_exit_file"
+  ) &
+  wait $! 2>/dev/null || true
+  local review_exit
+  review_exit=$(cat "$review_exit_file" 2>/dev/null || echo 1)
+  rm -f "$review_exit_file"
+  set -e
+
+  # Find the most recent CR_DIR (code-review session directory)
+  local cr_dir
+  cr_dir=$(ls -td .closedloop-ai/code-review/cr-* 2>/dev/null | head -1)
+
+  # Read verdict from CR_DIR/verdict.json (written by code-review:start)
+  local verdict="approve"
+  if [[ -n "$cr_dir" ]] && [[ -f "$cr_dir/verdict.json" ]]; then
+    verdict=$(jq -r '.verdict // "approve"' "$cr_dir/verdict.json" 2>/dev/null || echo "approve")
+  fi
+
+  # Emit perf event
+  local review_end_epoch
+  review_end_epoch=$(date +%s)
+  local review_duration=$((review_end_epoch - review_start_epoch))
+  emit_perf_event "$(jq -n -c \
+    --arg event "post_loop_review" \
+    --arg run_id "$RUN_ID" \
+    --arg verdict "$verdict" \
+    --argjson duration_s "$review_duration" \
+    --argjson exit_code "$review_exit" \
+    '{event:$event,run_id:$run_id,verdict:$verdict,duration_s:$duration_s,exit_code:$exit_code}'
+  )"
+
+  rm -f "$review_output" "$review_stderr"
+
+  if [[ "$verdict" == "approve" ]]; then
+    echo -e "\n${GREEN}Code review passed${NC}"
+    log_progress "Post-loop code review: approved"
+    return 0
+  fi
+
+  echo -e "\n${YELLOW}Code review found issues (verdict: $verdict). Running fix cycle...${NC}"
+  log_progress "Post-loop code review: $verdict, running fix"
+
+  if [[ -z "$cr_dir" ]]; then
+    echo -e "${RED}Warning: Could not determine code review session directory. Skipping fix.${NC}"
+    log_progress "Post-loop fix skipped: CR_DIR not found"
+    return 0
+  fi
+
+  # Run fix command
+  local fix_start_epoch
+  fix_start_epoch=$(date +%s)
+  local fix_output
+  fix_output=$(mktemp)
+  local fix_stderr
+  fix_stderr=$(mktemp)
+  local fix_exit_file
+  fix_exit_file=$(mktemp)
+
+  set +e
+  (
+    claude \
+      --allowed-tools=Bash,Grep,Glob,Read,Write,Edit,Task,TodoWrite \
+      --output-format stream-json \
+      --verbose \
+      -p "/code-review:fix $cr_dir --max-cycles 2" 2>"$fix_stderr" \
+      | { grep --line-buffered '^{' || true; } \
+      | tee "$fix_output" \
+      | tee -a "${workdir}/claude-output.jsonl" \
+      | python3 "$formatter"
+    echo "${PIPESTATUS[0]}" > "$fix_exit_file"
+  ) &
+  wait $! 2>/dev/null || true
+  local fix_exit
+  fix_exit=$(cat "$fix_exit_file" 2>/dev/null || echo 1)
+  rm -f "$fix_exit_file"
+  set -e
+
+  # Emit perf event for fix
+  local fix_end_epoch
+  fix_end_epoch=$(date +%s)
+  emit_perf_event "$(jq -n -c \
+    --arg event "post_loop_fix" \
+    --arg run_id "$RUN_ID" \
+    --argjson duration_s "$((fix_end_epoch - fix_start_epoch))" \
+    --argjson exit_code "$fix_exit" \
+    '{event:$event,run_id:$run_id,duration_s:$duration_s,exit_code:$exit_code}'
+  )"
+
+  rm -f "$fix_output" "$fix_stderr"
+
+  log_progress "Post-loop fix cycle completed (exit: $fix_exit)"
+}
+
 # Show help
 show_help() {
   cat << 'EOF'
@@ -710,11 +855,12 @@ EOF
   CONFIG_FILE="$WORKDIR/.closedloop/config.env"
   TMP_FILE="${CONFIG_FILE}.tmp.$$"
   if [[ -f "$CONFIG_FILE" ]]; then
-    sed '/^CLOSEDLOOP_SELF_LEARNING=/d' "$CONFIG_FILE" > "$TMP_FILE"
+    sed -e '/^CLOSEDLOOP_SELF_LEARNING=/d' -e '/^CLOSEDLOOP_START_SHA=/d' "$CONFIG_FILE" > "$TMP_FILE"
   else
     : > "$TMP_FILE"
   fi
   echo "CLOSEDLOOP_SELF_LEARNING=${SELF_LEARNING:-false}" >> "$TMP_FILE"
+  echo "CLOSEDLOOP_START_SHA=${START_SHA}" >> "$TMP_FILE"
   mv "$TMP_FILE" "$CONFIG_FILE"
 
   echo -e "${GREEN}Created new ClosedLoop loop state${NC}"
@@ -857,6 +1003,9 @@ main() {
       # Final post-iteration processing
       post_iteration_processing "$effective_workdir" "$iteration"
 
+      # Run post-loop code review
+      run_post_loop_review "$effective_workdir"
+
       # Clean up
       release_lock "$effective_workdir"
       rm -f "$STATE_FILE"
@@ -991,6 +1140,9 @@ main() {
 
         # Write runs.log entry
         write_runs_log_entry "$effective_workdir" "$iteration" "completed"
+
+        # Run post-loop code review
+        run_post_loop_review "$effective_workdir"
 
         # Clean up
         release_lock "$effective_workdir"

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -465,120 +465,138 @@ run_post_loop_review() {
 
   log_progress "Starting post-loop code review ($changed_count files changed)"
 
-  local review_start_epoch
-  review_start_epoch=$(date +%s)
-  local review_output
-  review_output=$(mktemp)
-  local review_stderr
-  review_stderr=$(mktemp)
-
-  # Run code review scoped to this run's changes
-  # Uses same pipeline pattern as main loop iterations (background subshell + wait)
   local formatter="$SCRIPTS_DIR/../tools/python/stream_formatter.py"
-  local review_exit_file
-  review_exit_file=$(mktemp)
-  set +e
-  (
-    claude \
-      --allowed-tools=Bash,Grep,Glob,Read,Write,Edit,Task,TodoWrite \
-      --output-format stream-json \
-      --verbose \
-      -p "/code-review:start --base $START_SHA" 2>"$review_stderr" \
-      | { grep --line-buffered '^{' || true; } \
-      | tee "$review_output" \
-      | tee -a "${workdir}/claude-output.jsonl" \
-      | python3 "$formatter"
-    echo "${PIPESTATUS[0]}" > "$review_exit_file"
-  ) &
-  wait $! 2>/dev/null || true
-  local review_exit
-  review_exit=$(cat "$review_exit_file" 2>/dev/null || echo 1)
-  rm -f "$review_exit_file"
-  set -e
+  local max_cycles="${POST_LOOP_REVIEW_CYCLES:-2}"
+  local cycle=1
 
-  # Find the most recent CR_DIR (code-review session directory)
-  local cr_dir
-  cr_dir=$(ls -td .closedloop-ai/code-review/cr-* 2>/dev/null | head -1)
+  while [[ "$cycle" -le "$max_cycles" ]]; do
+    echo -e "\n${BLUE}Review cycle $cycle of $max_cycles${NC}"
 
-  # Read verdict from CR_DIR/verdict.json (written by code-review:start)
-  local verdict="approve"
-  if [[ -n "$cr_dir" ]] && [[ -f "$cr_dir/verdict.json" ]]; then
-    verdict=$(jq -r '.verdict // "approve"' "$cr_dir/verdict.json" 2>/dev/null || echo "approve")
-  fi
+    # --- Run review ---
+    local review_start_epoch
+    review_start_epoch=$(date +%s)
+    local review_output
+    review_output=$(mktemp)
+    local review_stderr
+    review_stderr=$(mktemp)
+    local review_exit_file
+    review_exit_file=$(mktemp)
 
-  # Emit perf event
-  local review_end_epoch
-  review_end_epoch=$(date +%s)
-  local review_duration=$((review_end_epoch - review_start_epoch))
-  emit_perf_event "$(jq -n -c \
-    --arg event "post_loop_review" \
-    --arg run_id "$RUN_ID" \
-    --arg verdict "$verdict" \
-    --argjson duration_s "$review_duration" \
-    --argjson exit_code "$review_exit" \
-    '{event:$event,run_id:$run_id,verdict:$verdict,duration_s:$duration_s,exit_code:$exit_code}'
-  )"
+    set +e
+    (
+      claude \
+        --allowed-tools=Bash,Grep,Glob,Read,Write,Edit,Task,TodoWrite \
+        --output-format stream-json \
+        --verbose \
+        -p "/code-review:start --base $START_SHA" 2>"$review_stderr" \
+        | { grep --line-buffered '^{' || true; } \
+        | tee "$review_output" \
+        | tee -a "${workdir}/claude-output.jsonl" \
+        | python3 "$formatter"
+      echo "${PIPESTATUS[0]}" > "$review_exit_file"
+    ) &
+    wait $! 2>/dev/null || true
+    local review_exit
+    review_exit=$(cat "$review_exit_file" 2>/dev/null || echo 1)
+    rm -f "$review_exit_file"
+    set -e
 
-  rm -f "$review_output" "$review_stderr"
+    # Guard: if the review process itself failed, don't consume stale results
+    if [[ "$review_exit" -ne 0 ]]; then
+      log_progress "Post-loop review failed (exit $review_exit). Skipping fix."
+      rm -f "$review_output" "$review_stderr"
+      return 0
+    fi
 
-  if [[ "$verdict" == "approve" ]]; then
-    echo -e "\n${GREEN}Code review passed${NC}"
-    log_progress "Post-loop code review: approved"
-    return 0
-  fi
+    # Find the most recent CR_DIR (code-review session directory)
+    local cr_dir
+    cr_dir=$(ls -td .closedloop-ai/code-review/cr-* 2>/dev/null | head -1)
 
-  echo -e "\n${YELLOW}Code review found issues (verdict: $verdict). Running fix cycle...${NC}"
-  log_progress "Post-loop code review: $verdict, running fix"
+    # Read verdict from CR_DIR/verdict.json (written by code-review:start)
+    local verdict="approve"
+    if [[ -n "$cr_dir" ]] && [[ -f "$cr_dir/verdict.json" ]]; then
+      verdict=$(jq -r '.verdict // "approve"' "$cr_dir/verdict.json" 2>/dev/null || echo "approve")
+    fi
 
-  if [[ -z "$cr_dir" ]]; then
-    echo -e "${RED}Warning: Could not determine code review session directory. Skipping fix.${NC}"
-    log_progress "Post-loop fix skipped: CR_DIR not found"
-    return 0
-  fi
+    # Emit perf event
+    local review_end_epoch
+    review_end_epoch=$(date +%s)
+    local review_duration=$((review_end_epoch - review_start_epoch))
+    emit_perf_event "$(jq -n -c \
+      --arg event "post_loop_review" \
+      --arg run_id "$RUN_ID" \
+      --arg verdict "$verdict" \
+      --argjson cycle "$cycle" \
+      --argjson duration_s "$review_duration" \
+      --argjson exit_code "$review_exit" \
+      '{event:$event,run_id:$run_id,verdict:$verdict,cycle:$cycle,duration_s:$duration_s,exit_code:$exit_code}'
+    )"
 
-  # Run fix command
-  local fix_start_epoch
-  fix_start_epoch=$(date +%s)
-  local fix_output
-  fix_output=$(mktemp)
-  local fix_stderr
-  fix_stderr=$(mktemp)
-  local fix_exit_file
-  fix_exit_file=$(mktemp)
+    rm -f "$review_output" "$review_stderr"
 
-  set +e
-  (
-    claude \
-      --allowed-tools=Bash,Grep,Glob,Read,Write,Edit,Task,TodoWrite \
-      --output-format stream-json \
-      --verbose \
-      -p "/code-review:fix $cr_dir --max-cycles 2" 2>"$fix_stderr" \
-      | { grep --line-buffered '^{' || true; } \
-      | tee "$fix_output" \
-      | tee -a "${workdir}/claude-output.jsonl" \
-      | python3 "$formatter"
-    echo "${PIPESTATUS[0]}" > "$fix_exit_file"
-  ) &
-  wait $! 2>/dev/null || true
-  local fix_exit
-  fix_exit=$(cat "$fix_exit_file" 2>/dev/null || echo 1)
-  rm -f "$fix_exit_file"
-  set -e
+    if [[ "$verdict" == "approve" ]]; then
+      echo -e "\n${GREEN}Code review passed${NC}"
+      log_progress "Post-loop code review: approved (cycle $cycle)"
+      return 0
+    fi
 
-  # Emit perf event for fix
-  local fix_end_epoch
-  fix_end_epoch=$(date +%s)
-  emit_perf_event "$(jq -n -c \
-    --arg event "post_loop_fix" \
-    --arg run_id "$RUN_ID" \
-    --argjson duration_s "$((fix_end_epoch - fix_start_epoch))" \
-    --argjson exit_code "$fix_exit" \
-    '{event:$event,run_id:$run_id,duration_s:$duration_s,exit_code:$exit_code}'
-  )"
+    echo -e "\n${YELLOW}Code review found issues (verdict: $verdict). Running fix cycle...${NC}"
+    log_progress "Post-loop code review: $verdict, running fix (cycle $cycle)"
 
-  rm -f "$fix_output" "$fix_stderr"
+    if [[ -z "$cr_dir" ]]; then
+      echo -e "${RED}Warning: Could not determine code review session directory. Skipping fix.${NC}"
+      log_progress "Post-loop fix skipped: CR_DIR not found"
+      return 0
+    fi
 
-  log_progress "Post-loop fix cycle completed (exit: $fix_exit)"
+    # --- Run fix ---
+    local fix_start_epoch
+    fix_start_epoch=$(date +%s)
+    local fix_output
+    fix_output=$(mktemp)
+    local fix_stderr
+    fix_stderr=$(mktemp)
+    local fix_exit_file
+    fix_exit_file=$(mktemp)
+
+    set +e
+    (
+      claude \
+        --allowed-tools=Bash,Grep,Glob,Read,Write,Edit,Task,TodoWrite \
+        --output-format stream-json \
+        --verbose \
+        -p "/code-review:fix $cr_dir" 2>"$fix_stderr" \
+        | { grep --line-buffered '^{' || true; } \
+        | tee "$fix_output" \
+        | tee -a "${workdir}/claude-output.jsonl" \
+        | python3 "$formatter"
+      echo "${PIPESTATUS[0]}" > "$fix_exit_file"
+    ) &
+    wait $! 2>/dev/null || true
+    local fix_exit
+    fix_exit=$(cat "$fix_exit_file" 2>/dev/null || echo 1)
+    rm -f "$fix_exit_file"
+    set -e
+
+    # Emit perf event for fix
+    local fix_end_epoch
+    fix_end_epoch=$(date +%s)
+    emit_perf_event "$(jq -n -c \
+      --arg event "post_loop_fix" \
+      --arg run_id "$RUN_ID" \
+      --argjson cycle "$cycle" \
+      --argjson duration_s "$((fix_end_epoch - fix_start_epoch))" \
+      --argjson exit_code "$fix_exit" \
+      '{event:$event,run_id:$run_id,cycle:$cycle,duration_s:$duration_s,exit_code:$exit_code}'
+    )"
+
+    rm -f "$fix_output" "$fix_stderr"
+
+    log_progress "Post-loop fix cycle $cycle completed (exit: $fix_exit)"
+    cycle=$((cycle + 1))
+  done
+
+  log_progress "Post-loop review: max cycles ($max_cycles) reached, proceeding"
 }
 
 # Show help


### PR DESCRIPTION
## Summary

- Adds comprehensive code review as the final step in the run-loop pipeline, replacing the lightweight in-loop `code:code-reviewer` with the full `code-review:start` pipeline after implementation completes
- Creates a new `code-review:fix` skill that verifies findings, fixes confirmed issues serially, runs build validation, and supports configurable re-review cycles
- Writes `CLOSEDLOOP_START_SHA` to `config.env` so the review can scope its diff to only this run's changes

**Implementation plan:** [PLN-233](https://app.closedloop.ai/implementation-plans/PLN-233)

## Changes

### `plugins/code/prompts/prompt.md`
- Remove Phase 5 Step 2 (lightweight single-agent code reviewer)
- Renumber Step 3 → Step 2
- Rename phase from "Testing and Code Review" to "Testing and Validation"

### `plugins/code/scripts/run-loop.sh`
- Add `run_post_loop_review()` function (~130 lines) invoked after both completion-promise and max-iterations exit paths
- Detects changes via working tree + staged + committed diffs against `START_SHA`
- Runs `code-review:start --base $START_SHA`, reads `verdict.json` from the session directory
- If verdict is not `approve`, invokes `code-review:fix` with `--max-cycles 2`
- Write `CLOSEDLOOP_START_SHA` to `config.env` in `create_state_file()`

### `plugins/code-review/skills/fix/SKILL.md` (new)
- 6-step pipeline: parse findings → verify with sonnet agents (parallel) → fix serially → build-validator → conditional re-review → summary
- Only acts on BLOCKING/HIGH severity findings; MEDIUM/LOW are logged
- Auto-discovers most recent `cr-*` session directory when not provided
- Capped at configurable `--max-cycles` (default 2) to prevent infinite loops

### `plugins/code-review/commands/fix.md` (new)
- Thin command wrapper for manual `/code-review:fix` invocation

### Version bumps
- `code`: 1.6.0 → 1.7.0
- `code-review`: 1.4.0 → 1.5.0

## Test plan

- [ ] Run `run-loop.sh` on a project with an intentional bug — verify post-loop review catches it and fix skill addresses it
- [ ] Run on clean code — verify review returns `approve` and no fix cycle triggers
- [ ] Run `/code-review:fix` manually on a prior review session directory
- [ ] Verify `CLOSEDLOOP_START_SHA` is written to `config.env`
- [ ] Verify Ctrl+C during post-loop review is handled gracefully
- [ ] Verify Phase 5 no longer launches `code:code-reviewer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)