### PR TITLE
FEA-517: Harden loop bootstrap argument handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .env.local
 .env.*.local
 .ruff_cache/
+.venv/
 
 # Tests
 **/route-knowledge.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ This repository is a plugin monorepo under `plugins/`.
 
 ## Commit & Pull Request Guidelines
 - Follow conventional commits (`feat(code): ...`, `fix(platform): ...`) and preserve repo scope style (`AI-####:` style tags are present in history).
+- Use the repository `.gitmessage` template for all new commits and amended commit messages.
 - Recommended branches: `feat/*`, `fix/*`, `docs/*`, `refactor/*`.
 - PR workflow: fork, create topic branch from `main`, rebase onto upstream, then open PR from your fork.
 - PR description should include purpose, affected plugins/files, and exact commands run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code v1.9.1
+
+#### Added
+- `--request-file` parameter in `codex-review` skill and `run_codex_review.sh` so Codex reads the original user request before reviewing and judges the plan against the actual request, not just the plan's self-framing
+- "Re-scoped" revision-summary bucket in `plan-agent` for findings accepted as the minimal required or enabling change
+- Additional tests in `test_setup_closedloop.py` covering unquoted paths with spaces in slash-command arguments
+
+#### Changed
+- `plan-agent` scope discipline now distinguishes between required work, justified localized enabling refactors, and true optional scope creep — findings are no longer rejected solely because they look broader than the current task
+- `/plan-with-codex` command switched from `Agent(resume=...)` to `SendMessage` for plan-agent continuation across rounds, preserving full prior context via transcript auto-resume
+- Round-aware Codex review prompts in `run_codex_review.sh`: round 1 is a broad material audit, rounds 2-4 are delta reviews that verify prior findings, rounds 5+ are blocker-only convergence reviews
+- `debate-loop.sh` now forwards the original prompt to `run_codex_review.sh` via `--request-file` and uses the refactor-aware revision guidance when asking plan-agent to revise
+- `setup-closedloop.sh` argument parser tolerates unquoted paths containing spaces by joining consecutive non-flag tokens into a single value for `--prd`, `--plan`, `--add-dir`, and the positional workdir
+- `/code` slash command now invokes `setup-closedloop.sh` via `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-closedloop.sh"` for portability
+- `run-loop.sh` now emits quoted `/code:code` arguments for workdir, `--prompt`, `--prd`, and `--add-dir` in loop state, preserving argument boundaries for values that contain spaces
+- `plan-with-codex` command gains `SendMessage` in its allowed-tools list
+
+### platform v1.1.1
+
+#### Changed
+- `upload-artifact` skill now reads `CLOSEDLOOP_API_KEY` and `NEXT_PUBLIC_MCP_SERVER_URL` from the current shell environment instead of `.env.local`, and falls back to MCP mode when either variable is missing
+- `upload_artifact.py` defaults `--api-key` and `--url` to the `CLOSEDLOOP_API_KEY` and `NEXT_PUBLIC_MCP_SERVER_URL` environment variables, exiting with a clear parser error when neither the flag nor the env var is set
+
 ### bootstrap v1.2.0
 
 #### Changed

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/agents/plan-agent.md
+++ b/plugins/code/agents/plan-agent.md
@@ -44,7 +44,7 @@ You are a software architect and planning specialist. Your role is to explore co
 
 6. **Self-Check Before Writing**:
    - **Goal alignment**: Re-read the original request. Does your plan fully accomplish it? Would executing every task actually deliver the feature, fix the bug, or achieve the objective?
-   - **Scope discipline**: Remove any task that was not requested. Do not add "while we're at it" improvements, refactors, or nice-to-haves beyond what the request requires.
+   - **Scope discipline**: Remove any task that was not requested. Do not add "while we're at it" improvements, broad refactors, or nice-to-haves beyond what the request requires. However, a localized refactor is allowed when it is the most practical way to implement the requested change safely, keep an already bloated or fragile file from getting worse, or make the touched behavior testable and maintainable.
    - **No silent deferrals**: Do not create "Deferred", "Out of Scope", "Future Work", "Post-MVP", or similar sections unless the user explicitly requested a phased rollout or future-work breakdown. If you believe part of the request should be deferred, add it as an Open Question (Q- format) so the user can decide. You do not get to unilaterally exclude requested work from the plan.
    - **Simplicity**: For each abstraction or new file in the plan, ask: "Is there a simpler way?" If three lines of inline code would work, do not propose a helper function.
    - **Modification targets verified**: For every task that modifies a function, type, or schema, confirm you `Read` the current implementation during exploration. If a task says "extend X to return Y" but you did not read X, go read it now before writing the plan.
@@ -118,8 +118,12 @@ When given feedback to address:
 
 1. **If a context brief file is provided**, read it first -- it contains pre-fetched code snippets for the files and symbols referenced in the feedback, so you can skip most exploration. Then read the current plan file and the feedback file.
 2. **Verify each finding against the codebase before acting on it.** Start with the context brief if available. Use `Grep`, `Glob`, and `Read` for anything not covered by the brief or when you need additional context beyond what was pre-fetched. Reviewers can hallucinate or misunderstand the codebase.
-3. For verified findings: address the concern. If the reviewer proposed a concrete fix, adopt it directly unless you have a strong reason not to.
-4. For findings that don't hold up: reject them with a brief explanation and evidence (e.g., "Finding 2 claims X is missing, but `path/to/file:42` already implements it").
+3. For verified findings: classify them before acting:
+   - **Required for correctness/completeness**: incorporate the change into the plan.
+   - **Justified enabling refactor**: if the reviewer is asking for a localized restructuring because that is the most pragmatic way to implement safely in a bloated, fragile, or overly coupled area, incorporate it or narrow it to the minimal refactor needed.
+   - **Optional follow-up / true scope creep**: keep it out of the plan and explain why it is not required to deliver the request.
+   If the reviewer proposed a concrete fix, adopt it directly unless you have a strong reason not to.
+4. Do not reject a finding solely because it is broader than the current task or involves refactoring. Reject only if it does not hold up against the codebase, misreads the request, or is truly optional beyond the minimum work needed to deliver the request safely. When you push back, state which bucket it falls into and cite evidence (e.g., "Finding 2 proposes a broad repository-wide cleanup, but the only required change is localized to `path/to/file:42-85`").
 5. Write the updated plan back to the same file path using the `Write` tool
 6. **If a revisions file path was provided**, write a revision summary to it. Format:
 
@@ -130,8 +134,11 @@ When given feedback to address:
 - **Finding 1** (title): [what changed in the plan]
 - **Finding 3** (title): [what changed in the plan]
 
+### Re-scoped
+- **Finding 4** (title): [accepted concern, but narrowed to the minimal required or enabling change]
+
 ### Rejected
-- **Finding 2** (title): [why, with evidence -- e.g., "X already exists at `path/to/file:42`"]
+- **Finding 2** (title): [why, with evidence -- e.g., "X already exists at `path/to/file:42`" or "this is optional follow-up work, not required to deliver the request safely"]
 ```
 
 This file is read by the reviewer on the next round so they have full context on what was addressed and what was pushed back on.

--- a/plugins/code/commands/code.md
+++ b/plugins/code/commands/code.md
@@ -6,7 +6,7 @@ allowed-tools: Bash, Edit, Write, Task, TodoWrite
 
 # Bootstrap ClosedLoop
 
-!`${CLAUDE_PLUGIN_ROOT}/scripts/setup-closedloop.sh $ARGUMENTS`
+!`bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-closedloop.sh" $ARGUMENTS`
 
 Follow the orchestrator instructions in the prompt file specified by `CLOSEDLOOP_PROMPT_FILE` in the config output above. You are running inside a ClosedLoop loop which provides fresh context on each iteration. Your previous work is visible in files and git history.
 

--- a/plugins/code/commands/plan-with-codex.md
+++ b/plugins/code/commands/plan-with-codex.md
@@ -1,7 +1,7 @@
 ---
 description: "Iterative plan refinement debate between Claude and Codex"
 argument-hint: --max-rounds N --plan-file PATH --codex-model MODEL <prompt>
-allowed-tools: Bash, Read, Write, Glob, Grep, TodoWrite, Task, AskUserQuestion
+allowed-tools: Bash, Read, Write, Glob, Grep, TodoWrite, Task, AskUserQuestion, SendMessage
 skills: code:codex-review
 effort: max
 model: opus
@@ -13,15 +13,15 @@ You orchestrate iterative plan refinement: Claude (via `code:plan-agent`) create
 
 <constraints>
 1. **NEVER edit the plan file directly.** All plan creation/modification goes through the plan-agent. If you're about to use Edit or Write on the plan file, STOP and delegate to the plan-agent.
-2. **ALWAYS resume agents via the `resume` parameter.** The plan-agent retains full session context when resumed. Do NOT launch fresh unless resume actually fails with an error. The Agent tool's return says "use SendMessage" -- IGNORE this. SendMessage does not work for completed agents. Always use `Agent(resume="<agent_id>")`.
+2. **Continue the plan-agent via SendMessage across rounds.** Capture the `agent_id` returned by the first `Agent(...)` call and reuse it for every subsequent plan-agent interaction via `SendMessage(to="<agent_id>", ...)`. Completed subagents auto-resume from transcript in the background, preserving full prior context. Only launch a fresh `Agent(...)` when no in-memory `agent_id` is available (cross-session resume after a previous Claude Code session ended) or when a SendMessage call actually errors -- fresh launches must use a self-contained prompt.
 3. **The Codex/Claude debate loop is fully automated.** After the user approves in Step 1.5, do NOT ask for confirmation between rounds -- proceed directly.
 </constraints>
 
 <templates>
 
-### Plan-Agent Call
+### Plan-Agent -- Initial Launch
 
-All plan-agent interactions use this shape. Vary only `description` and `prompt`:
+First plan-agent call in a session, or fallback when no `agent_id` is in memory. Vary only `description` and `prompt`:
 
 ```
 Agent(
@@ -30,12 +30,27 @@ Agent(
   mode="acceptEdits",
   run_in_background=false,
   description="<DESCRIPTION>",
-  prompt="<PROMPT>",
-  resume="<agent_id>"
+  prompt="<PROMPT>"
 )
 ```
 
-**Resume rule:** If an in-memory agent_id exists (from a prior launch in this session), always attempt `resume` first. Only if the call returns an error, launch fresh. If no agent_id exists (cross-session resume), launch fresh immediately -- do not attempt resume. When launching fresh, omit `resume` and prepend to the prompt: "Read the plan at {plan-file-abs} first. Original request: <prompt from sidecar>." If `{stem}.exclusions` exists, also append: "The user has confirmed these items are out of scope -- do not re-add them: <contents of exclusions file>." Always store the returned agent_id for subsequent calls.
+**Capture the returned `agent_id`** from the Agent tool's result line (format: `agentId: <id>`) and reuse it for every subsequent plan-agent interaction in this session.
+
+### Plan-Agent -- Continuation (preferred after initial launch)
+
+For every plan-agent interaction after the initial launch, continue the same agent via SendMessage against the stored `agent_id`. Completed agents auto-resume from transcript in the background with full prior context intact -- this preserves the plan-agent's own memory of what it changed in earlier rounds:
+
+```
+SendMessage(
+  to="<stored_agent_id>",
+  summary="<5-10 word summary>",
+  message="<PROMPT>"
+)
+```
+
+SendMessage returns immediately with a queued acknowledgment ("had no active task; resumed from transcript in the background"). The agent then runs in the background and you will receive a `<task-notification>` with status and result when it finishes. **Do NOT proceed to the next step until that notification arrives.** If you need the agent's full output, read the `<output-file>` path from the notification.
+
+**Resume rule:** The first plan-agent interaction in a session uses Initial Launch; every later interaction uses Continuation with the stored `agent_id`. If no `agent_id` is in memory (cross-session resume after a previous Claude Code session ended), use Initial Launch and prepend to the prompt: "Read the plan at {plan-file-abs} first. Original request: <prompt from sidecar>." If `{stem}.exclusions` exists, also append: "The user has confirmed these items are out of scope -- do not re-add them: <contents of exclusions file>." After any Initial Launch (first round or fallback), store the new `agent_id`. If a SendMessage call returns an actual error (not just the normal queued acknowledgment), fall back to Initial Launch with the self-contained prompt.
 
 ### State Write
 
@@ -128,11 +143,11 @@ If (b) or plan doesn't exist: continue to Step 1. Error if no prompt is resolvab
 
 Announce: "Creating plan with plan-agent..."
 
-Launch the plan-agent (omit `resume` -- this is the initial launch):
+Use the Initial Launch template:
 - description: "Create implementation plan"
 - prompt: "<user's prompt>. Write the plan to {plan-file-abs}."
 
-**Store the returned agent_id** for all subsequent rounds.
+**Store the returned `agent_id`** for all subsequent rounds.
 
 Verify plan file exists and is non-empty (Read it). Announce: "Plan created ({byte_count} bytes) at {plan-file-abs}"
 
@@ -183,9 +198,11 @@ Update the plan at {plan-file-abs}:
 Write back to {plan-file-abs}.
 ```
 
-Resume the plan-agent:
-- description: "Update plan with answered questions and deferral decisions"
-- prompt: (built as above)
+Continue the plan-agent via SendMessage (using the stored `agent_id`):
+- summary: "Apply answers and deferrals"
+- message: (the text built above)
+
+Wait for the `<task-notification>` before re-reading the plan to verify the update.
 
 **After the plan-agent returns**, update the exclusions sidecar (do NOT modify `{stem}.prompt`). This is a full rewrite each pass -- not an append -- so reversed decisions are reflected:
 
@@ -205,7 +222,7 @@ Re-read and repeat until no open questions or deferred items remain.
 
 > Plan created at `{plan-file-abs}`. Review it and let me know when you're ready to start the Codex debate, or share any changes you'd like made first.
 
-**If user requests changes:** Resume plan-agent with their feedback as the prompt. Loop back until user confirms.
+**If user requests changes:** Continue plan-agent via SendMessage with their feedback as the `message`. Wait for the `<task-notification>`, then re-read the plan. Loop back until the user confirms.
 
 **When user confirms** ("start", "go", "looks good", "proceed"):
 
@@ -224,6 +241,7 @@ Activate `code:codex-review` skill and run:
 bash <base_directory>/scripts/run_codex_review.sh \
   --plan-file {plan-file-abs} \
   --feedback-file {feedback-file-abs} \
+  --request-file {stem}.prompt \
   --revisions-file {revisions-file-abs} \
   --round {N} \
   --codex-model {codex-model} \
@@ -251,11 +269,11 @@ Read the feedback file and display full Codex feedback to the user.
 
 Update TodoWrite: "Round {N}/{max}: Revising plan..."
 
-**Resume the plan-agent** with the feedback:
-- description: "Revise plan based on Codex feedback"
-- prompt: "Revise the plan at {plan-file-abs} based on feedback at {feedback-file-abs}. Verify each finding against the codebase before acting on it -- reject any that don't hold up. After updating the plan, write a revision summary to {revisions-file-abs}."
+**Continue the plan-agent via SendMessage** (using the stored `agent_id`):
+- summary: "Revise plan per Codex feedback"
+- message: "Revise the plan at {plan-file-abs} based on feedback at {feedback-file-abs}. Verify each finding against the codebase before acting on it. Do not dismiss a finding solely because it looks broader than the request or involves refactoring -- distinguish between required work, justified enabling refactor, and true optional scope creep. Reject only findings that do not hold up or are genuinely optional beyond the minimum needed to deliver the request safely. After updating the plan, write a revision summary to {revisions-file-abs}."
 
-Verify plan was updated. Write state: `ROUND={N+1}, PHASE=codex_review`, preserve current `CODEX_SESSION_ID` and `LOG_ID`. Continue to next round.
+Wait for the `<task-notification>`, then verify the plan was updated. Write state: `ROUND={N+1}, PHASE=codex_review`, preserve current `CODEX_SESSION_ID` and `LOG_ID`. Continue to next round.
 
 ## Step 3: Final Report
 

--- a/plugins/code/scripts/debate-loop.sh
+++ b/plugins/code/scripts/debate-loop.sh
@@ -128,6 +128,13 @@ run_codex_review() {
     --round "$round"
     --codex-model "$CODEX_MODEL"
   )
+  if [[ -n "$PROMPT" ]]; then
+    local request_file
+    request_file=$(mktemp)
+    TMPFILES+=("$request_file")
+    printf '%s' "$PROMPT" > "$request_file"
+    review_args+=(--request-file "$request_file")
+  fi
   if [[ -n "$CODEX_SESSION_ID" ]]; then
     review_args+=(--session-id "$CODEX_SESSION_ID")
   fi
@@ -551,7 +558,7 @@ while [[ $round -le $MAX_ROUNDS ]]; do
   run_claude \
     -p "Resume the plan agent from your conversation history and pass it this task:
 
-'Revise the plan at ${PLAN_FILE_ABS} based on feedback at ${FEEDBACK_FILE}. Write the updated plan back to ${PLAN_FILE_ABS}.'
+'Revise the plan at ${PLAN_FILE_ABS} based on feedback at ${FEEDBACK_FILE}. Verify each finding against the codebase before acting on it. Do not dismiss a finding solely because it looks broader than the request or involves refactoring -- distinguish between required work, justified enabling refactor, and true optional scope creep. Reject only findings that do not hold up or are genuinely optional beyond the minimum needed to deliver the request safely. Write the updated plan back to ${PLAN_FILE_ABS}.'
 
 Do not spawn a new plan agent -- resume the existing session." \
     -r "$SESSION_ID" \
@@ -568,7 +575,7 @@ Do not spawn a new plan agent -- resume the existing session." \
       run_claude \
         -p "Use the Agent tool to invoke the code:plan-agent with the following task:
 
-'Revise the plan at ${PLAN_FILE_ABS} based on feedback at ${FEEDBACK_FILE}. Write the updated plan back to ${PLAN_FILE_ABS}.
+'Revise the plan at ${PLAN_FILE_ABS} based on feedback at ${FEEDBACK_FILE}. Verify each finding against the codebase before acting on it. Do not dismiss a finding solely because it looks broader than the request or involves refactoring -- distinguish between required work, justified enabling refactor, and true optional scope creep. Reject only findings that do not hold up or are genuinely optional beyond the minimum needed to deliver the request safely. Write the updated plan back to ${PLAN_FILE_ABS}.
 
 The original request was: ${PROMPT}'" \
         --permission-mode acceptEdits \

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -873,16 +873,37 @@ create_state_file() {
   # (e.g., /path/to/worktree/.closedloop-ai/work)
   mkdir -p "$WORKDIR"
 
-  # Build the prompt - this is what gets passed to claude -p
-  local prompt="/code:code $WORKDIR"
+  # Build the prompt - this is what gets passed to claude -p.
+  # Quote values so paths with spaces survive slash-command argument parsing.
+  local workdir_arg="$WORKDIR"
+  workdir_arg="${workdir_arg//\\/\\\\}"
+  workdir_arg="${workdir_arg//\"/\\\"}"
+  workdir_arg="${workdir_arg//\$/\\\$}"
+  workdir_arg="${workdir_arg//\`/\\\`}"
+  local prompt="/code:code \"$workdir_arg\""
   if [[ -n "$PROMPT_NAME" ]]; then
-    prompt="$prompt --prompt $PROMPT_NAME"
+    local prompt_name_arg="$PROMPT_NAME"
+    prompt_name_arg="${prompt_name_arg//\\/\\\\}"
+    prompt_name_arg="${prompt_name_arg//\"/\\\"}"
+    prompt_name_arg="${prompt_name_arg//\$/\\\$}"
+    prompt_name_arg="${prompt_name_arg//\`/\\\`}"
+    prompt="$prompt --prompt \"$prompt_name_arg\""
   fi
   if [[ -n "$PRD_FILE" ]]; then
-    prompt="$prompt --prd $PRD_FILE"
+    local prd_arg="$PRD_FILE"
+    prd_arg="${prd_arg//\\/\\\\}"
+    prd_arg="${prd_arg//\"/\\\"}"
+    prd_arg="${prd_arg//\$/\\\$}"
+    prd_arg="${prd_arg//\`/\\\`}"
+    prompt="$prompt --prd \"$prd_arg\""
   fi
   for add_dir in "${ADD_DIRS[@]+"${ADD_DIRS[@]}"}"; do
-    prompt="$prompt --add-dir \"$add_dir\""
+    local add_dir_arg="$add_dir"
+    add_dir_arg="${add_dir_arg//\\/\\\\}"
+    add_dir_arg="${add_dir_arg//\"/\\\"}"
+    add_dir_arg="${add_dir_arg//\$/\\\$}"
+    add_dir_arg="${add_dir_arg//\`/\\\`}"
+    prompt="$prompt --add-dir \"$add_dir_arg\""
   done
 
   cat > "$STATE_FILE" <<EOF

--- a/plugins/code/scripts/setup-closedloop.sh
+++ b/plugins/code/scripts/setup-closedloop.sh
@@ -14,13 +14,38 @@ echo "$(date): Setup started, PID=$$, PPID=$PPID, args: $*" >> "$DEBUG_LOG"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
 
-# Parse arguments — collect positional args into an array for classification after parsing
+# Parse arguments
+# Be tolerant of unquoted paths containing spaces. Some invocations pass
+# slash-command arguments through a raw string where paths can be split.
 PRD_FILE=""
 PLAN_FILE=""
 MAX_ITERATIONS=10
 PROMPT_NAME=""
-POSITIONAL_ARGS=()
+WORKDIR=""
 ADD_DIRS=()
+ARGS=("$@")
+ARG_INDEX=0
+ARG_COUNT=${#ARGS[@]}
+CONSUMED_PATH_VALUE=""
+
+consume_joined_path_value() {
+    CONSUMED_PATH_VALUE=""
+
+    while [[ $ARG_INDEX -lt $ARG_COUNT ]]; do
+        local token="${ARGS[$ARG_INDEX]}"
+        if [[ "$token" == --* ]]; then
+            break
+        fi
+
+        if [[ -z "$CONSUMED_PATH_VALUE" ]]; then
+            CONSUMED_PATH_VALUE="$token"
+        else
+            CONSUMED_PATH_VALUE="$CONSUMED_PATH_VALUE $token"
+        fi
+
+        ARG_INDEX=$((ARG_INDEX + 1))
+    done
+}
 
 array_contains() {
     local needle="$1"
@@ -90,57 +115,82 @@ resolve_directory_path() {
     echo "$resolved_path"
 }
 
-while [[ $# -gt 0 ]]; do
-    case $1 in
+if [[ $ARG_INDEX -lt $ARG_COUNT ]] && [[ "${ARGS[$ARG_INDEX]}" != --* ]]; then
+    consume_joined_path_value
+    WORKDIR="$CONSUMED_PATH_VALUE"
+fi
+
+while [[ $ARG_INDEX -lt $ARG_COUNT ]]; do
+    token="${ARGS[$ARG_INDEX]}"
+    case "$token" in
         --prd)
-            PRD_FILE="$2"
-            shift 2
+            ARG_INDEX=$((ARG_INDEX + 1))
+            consume_joined_path_value
+            PRD_FILE="$CONSUMED_PATH_VALUE"
+            if [[ -z "$PRD_FILE" ]]; then
+                echo "Error: --prd requires a file path" >&2
+                exit 1
+            fi
             ;;
         --plan)
-            PLAN_FILE="$2"
-            shift 2
+            ARG_INDEX=$((ARG_INDEX + 1))
+            consume_joined_path_value
+            PLAN_FILE="$CONSUMED_PATH_VALUE"
+            if [[ -z "$PLAN_FILE" ]]; then
+                echo "Error: --plan requires a file path" >&2
+                exit 1
+            fi
             ;;
         --max-iterations)
-            MAX_ITERATIONS="$2"
-            shift 2
+            ARG_INDEX=$((ARG_INDEX + 1))
+            if [[ $ARG_INDEX -ge $ARG_COUNT ]]; then
+                echo "Error: --max-iterations requires a value" >&2
+                exit 1
+            fi
+            MAX_ITERATIONS="${ARGS[$ARG_INDEX]}"
+            ARG_INDEX=$((ARG_INDEX + 1))
             ;;
         --prompt)
-            if [[ -z "${2:-}" ]]; then
+            ARG_INDEX=$((ARG_INDEX + 1))
+            if [[ $ARG_INDEX -ge $ARG_COUNT ]]; then
                 echo "Error: --prompt requires a prompt name" >&2
                 exit 1
             fi
-            PROMPT_NAME="$2"
-            shift 2
+            PROMPT_NAME="${ARGS[$ARG_INDEX]}"
+            ARG_INDEX=$((ARG_INDEX + 1))
             ;;
         --add-dir)
-            if [[ -z "${2:-}" ]]; then
+            ARG_INDEX=$((ARG_INDEX + 1))
+            consume_joined_path_value
+            add_dir_value="$CONSUMED_PATH_VALUE"
+            if [[ -z "$add_dir_value" ]]; then
                 echo "Error: --add-dir requires a directory path" >&2
                 exit 1
             fi
-            ADD_DIRS+=("$2")
-            shift 2
+            ADD_DIRS+=("$add_dir_value")
             ;;
         -*)
-            echo "Unknown option: $1" >&2
-            shift
+            echo "Unknown option: $token" >&2
+            ARG_INDEX=$((ARG_INDEX + 1))
             ;;
         *)
-            POSITIONAL_ARGS+=("$1")
-            shift
+            # Preserve unexpected trailing positional tokens by appending to
+            # workdir. This keeps compatibility with raw split-path invocations.
+            if [[ -z "$WORKDIR" ]]; then
+                WORKDIR="$token"
+            else
+                WORKDIR="$WORKDIR $token"
+            fi
+            ARG_INDEX=$((ARG_INDEX + 1))
             ;;
     esac
 done
 
-# First positional arg is workdir
-WORKDIR=""
-if [[ ${#POSITIONAL_ARGS[@]} -gt 0 ]]; then
-    WORKDIR="${POSITIONAL_ARGS[0]}"
-fi
-
-WORKDIR="${WORKDIR:-.}"
+RAW_WORKDIR="${WORKDIR:-.}"
+WORKDIR="$RAW_WORKDIR"
 # Resolve to a canonical absolute path so primary-vs-secondary comparisons are reliable.
 if ! WORKDIR="$(resolve_directory_path "$WORKDIR")"; then
-    echo "Error: workdir path does not exist or is not a directory: ${POSITIONAL_ARGS[0]:-.}" >&2
+    echo "Error: workdir path does not exist or is not a directory: $RAW_WORKDIR" >&2
     exit 1
 fi
 

--- a/plugins/code/skills/codex-review/SKILL.md
+++ b/plugins/code/skills/codex-review/SKILL.md
@@ -24,6 +24,7 @@ The `scripts/` directory is relative to this skill's base directory (shown above
 bash <base_directory>/scripts/run_codex_review.sh \
   --plan-file <path> \
   --feedback-file <path> \
+  --request-file <path> \
   --revisions-file <path> \
   --round <N> \
   --codex-model <model> \
@@ -35,8 +36,9 @@ bash <base_directory>/scripts/run_codex_review.sh \
 |----------|----------|---------|-------------|
 | `--plan-file` | Yes | -- | Absolute path to the implementation plan (plan.json or plan.md) that Codex will review. The script injects this path into the review prompt so Codex can read and analyze the plan's contents. |
 | `--feedback-file` | Yes | -- | Absolute path where the script writes Codex's full feedback text (parsed from the JSON stream). The orchestrator reads this file after the script completes to get the detailed findings. This file is overwritten each round. |
-| `--revisions-file` | No | -- | Absolute path to Claude's revision summary from the previous round, listing which findings were accepted and which were rejected with evidence. Only meaningful when round > 1 AND the file exists with actual content (the script checks `-s` for non-empty). The script injects this path into Codex's prompt so it can read the revisions before re-reviewing, preventing it from re-raising findings that Claude already refuted with valid evidence. **Omit entirely on round 1 or when no revisions file has been written yet** -- do not pass `/dev/null` or an empty file. |
-| `--round` | No | 1 | The current debate round number (1-indexed). Controls the review prompt tone: round 1 says "Review this new plan", rounds 2+ say "Claude addressed your feedback, re-review for remaining issues." Also gates whether the revisions file is included in the prompt. |
+| `--request-file` | No | -- | Absolute path to the original user request sidecar. When present and non-empty, the script tells Codex to read it before reviewing the plan so it can judge whether the plan chose the right overall approach for the request, not just whether the plan is internally consistent. If the file begins with `[synthesized]`, Codex is told to treat it as a weak hint rather than authoritative user intent. |
+| `--revisions-file` | No | -- | Absolute path to Claude's revision summary from the previous round, listing which findings were accepted and which were rejected with evidence. Only meaningful when round > 1 AND the file exists with actual content (the script checks `-s` for non-empty). The script injects this path into Codex's prompt so it can read the revisions before re-reviewing, but it explicitly tells Codex to verify Claude's rebuttals against the updated plan and codebase rather than trusting the summary blindly. **Omit entirely on round 1 or when no revisions file has been written yet** -- do not pass `/dev/null` or an empty file. |
+| `--round` | No | 1 | The current debate round number (1-indexed). Controls the review prompt phase: round 1 runs a broad but material audit, rounds 2-4 run a delta review that first checks whether prior findings were resolved, and rounds 5+ run a blocker-only convergence review. Also gates whether the revisions file is included in the prompt. |
 | `--codex-model` | No | gpt-5.3-codex | The OpenAI model ID passed to `codex -m`. Controls which model performs the review. |
 | `--session-id` | No | -- | Codex thread ID returned as `CODEX_SESSION` from a previous round. When provided, the script attempts `codex exec resume <session_id>` to continue the conversation with full prior context. If resume fails, it falls back to a fresh session automatically. Omit on round 1. |
 | `--log-id` | No | auto-generated UUID | Identifier for the persistent JSONL log file at `~/.closedloop-ai/plan-with-codex/<log-id>.jsonl`. The raw Codex JSON stream is appended here each round. Pass the same ID across all rounds of a debate to keep the full conversation history in one file. If omitted, a new UUID is generated. |
@@ -89,7 +91,7 @@ LOG_ID:550e8400-e29b-41d4-a716-446655440000
 
 ## How It Works
 
-1. Builds a review prompt asking Codex to analyze the plan for technical soundness, missing steps, architectural issues, security/performance risks, and unclear descriptions
+1. Builds a round-aware review prompt: round 1 performs a broad but material audit of both the chosen approach and the task details; rounds 2-4 verify prior findings and look only for net-new material issues; rounds 5+ only flag blocker-level issues that would likely lead to wrong behavior
 2. If `--session-id` is provided, attempts `codex exec resume` for context continuity; falls back to a fresh session if resume fails
 3. Parses the Codex JSON stream for `thread.started` (thread ID) and `item.completed`/`agent_message` (feedback text)
 4. If session resume succeeds but no new `thread.started` event appears, the input session ID is preserved and re-emitted (prevents losing session continuity)

--- a/plugins/code/skills/codex-review/scripts/run_codex_review.sh
+++ b/plugins/code/skills/codex-review/scripts/run_codex_review.sh
@@ -2,7 +2,8 @@
 # run_codex_review.sh - Call Codex to review a plan file and return structured results.
 #
 # Usage:
-#   run_codex_review.sh --plan-file <path> --feedback-file <path> --round <N> \
+#   run_codex_review.sh --plan-file <path> --feedback-file <path> \
+#                       [--request-file <path>] --round <N> \
 #                       --codex-model <model> [--session-id <thread_id>] \
 #                       [--log-id <uuid>]
 #
@@ -27,6 +28,7 @@ CLOSEDLOOP_STATE_DIR=".closedloop-ai"
 
 PLAN_FILE=""
 FEEDBACK_FILE=""
+REQUEST_FILE=""
 REVISIONS_FILE=""
 ROUND=1
 CODEX_MODEL="gpt-5.3-codex"
@@ -37,6 +39,7 @@ while [[ $# -gt 0 ]]; do
   case $1 in
     --plan-file)      PLAN_FILE="$2"; shift 2 ;;
     --feedback-file)  FEEDBACK_FILE="$2"; shift 2 ;;
+    --request-file)   REQUEST_FILE="$2"; shift 2 ;;
     --revisions-file) REVISIONS_FILE="$2"; shift 2 ;;
     --round)          ROUND="$2"; shift 2 ;;
     --codex-model)    CODEX_MODEL="$2"; shift 2 ;;
@@ -85,68 +88,117 @@ prompt_file="$tmp_dir/prompt.txt"
 
 # ── Build the review prompt ──────────────────────────────────────────────────
 
+REQUEST_BLOCK=""
 REVISIONS_BLOCK=""
-SEVERITY_GATE=""
+ROUND_GUIDANCE=""
+REVIEW_AREAS=""
+if [[ -n "$REQUEST_FILE" ]] && [[ -s "$REQUEST_FILE" ]]; then
+  REQUEST_BLOCK="
+
+Original user request is at: ${REQUEST_FILE}
+Read it before reviewing the plan. Judge the plan against that request, not just against the plan's own framing. If the request file begins with [synthesized], treat it as a weak hint rather than authoritative user intent."
+fi
+
 if [[ "$ROUND" -eq 1 ]]; then
-  REVIEW_INTRO="Claude has created an implementation plan. Review it and provide feedback."
+  REVIEW_INTRO="Claude has created an implementation plan. This is the first review pass."
+  ROUND_GUIDANCE="
+Do a broad but material review. Flag issues only if they would likely cause wrong behavior, miss the stated objective, choose the wrong implementation approach, leave important implementation gaps, or add clearly unnecessary complexity or scope. Do not nitpick style, naming, or minor wording improvements."
+  REVIEW_AREAS="
+Analyze for:
+1. Goal alignment against the original request when available, otherwise against the plan's stated context, title, and explicit objectives. If the original request is not stated clearly in the plan, do not invent extra requirements.
+2. Approach choice and pragmatism -- is the plan solving the problem in the right layer, with the right abstraction, and with a materially simpler or more local approach where appropriate? Flag plans whose overall approach is wrong, heavier than necessary, or less pragmatic than an obvious simpler alternative.
+3. Over-engineering that materially increases complexity without clear benefit.
+4. Scope creep that adds work beyond the stated objective. Do not treat a localized enabling refactor as scope creep if it is needed to implement the request safely, clearly, or without making an already bloated file worse.
+5. Reinventing existing code when the plan should reuse an existing implementation or pattern.
+6. Technical soundness and feasibility.
+7. Missing steps, missing callsites, or edge cases that would likely matter in real execution.
+8. Security or performance risks that are concrete and relevant.
+9. Test coverage and test fidelity for the real behavior boundary being changed.
+10. Unclear, ambiguous, or easy-to-misimplement task descriptions.
+11. Canonical state and invariant preservation.
+12. Task specificity and omission resistance.
+13. Behavioral precision and algorithmic ambiguity.
+14. Order-of-operations and sequencing constraints.
+15. Lifecycle symmetry and cleanup completeness.
+16. File-shape pragmatism -- if the touched file is already bloated, fragile, or overly coupled, check whether the plan's approach makes that worse. A small restructuring or extraction can be warranted when it is the most practical way to implement the requested change safely and keep the result maintainable."
 elif [[ "$ROUND" -le 4 ]]; then
-  REVIEW_INTRO="Claude has addressed your previous feedback and updated the plan. Re-review the plan for remaining issues."
+  REVIEW_INTRO="Claude has addressed your previous feedback and updated the plan. This is round ${ROUND}."
   if [[ -n "$REVISIONS_FILE" ]] && [[ -s "$REVISIONS_FILE" ]]; then
     REVISIONS_BLOCK="
 
 Claude's revision summary (including any findings that were rejected with evidence) is at: ${REVISIONS_FILE}
-Read it before reviewing the plan -- if Claude rejected a finding with valid evidence, do not re-raise it."
+Read it before reviewing the plan, but treat it as a claim to verify against the updated plan and the current codebase. Do not automatically trust or reject it."
   fi
+  ROUND_GUIDANCE="
+This is a delta review, not a fresh blank-slate audit.
+1. First check whether prior findings are actually resolved in the updated plan.
+2. Verify Claude's rebuttals and claimed fixes against the updated plan and the codebase before accepting them.
+3. Only raise net-new findings if they are clearly material, high-confidence, and not just rephrasings of earlier points.
+4. Do not churn on explicit design choices already spelled out in the plan unless they remain incorrect, incomplete, or dangerous.
+5. Do not accept an 'out of scope' rebuttal unless the work is truly optional. Required work and localized enabling refactors are in scope if they are the most pragmatic way to deliver the request safely."
+  REVIEW_AREAS="
+Analyze for:
+1. Previously raised issues that are still unresolved or only partially fixed.
+2. Remaining goal-alignment gaps that would cause the plan to miss its stated objective.
+3. Material missing steps, missing callsites, or missing cleanup paths.
+4. Canonical state, migration, fallback, caching, or invariant problems that could leave the system in the wrong state.
+5. Ambiguous algorithms, overwrite semantics, sequencing, or lifecycle rules where two reasonable engineers could implement opposite behaviors.
+6. Test gaps only when they would allow a real behavioral regression or incorrect implementation to ship unnoticed.
+7. Over-engineering, wrong-layer approach, or scope creep only if it is substantial enough to distort delivery or conflict with the stated plan.
+8. Cases where Claude dismissed a necessary or strongly justified enabling refactor as out of scope, even though the codebase shape makes the narrower plan materially less pragmatic or more error-prone."
 else
-  # Round 5+: raise the bar -- only flag things that would cause wrong behavior
-  REVIEW_INTRO="Claude has addressed your previous feedback and updated the plan. This is round ${ROUND}. Re-review for any remaining critical issues."
+  REVIEW_INTRO="Claude has addressed your previous feedback and updated the plan. This is round ${ROUND}."
   if [[ -n "$REVISIONS_FILE" ]] && [[ -s "$REVISIONS_FILE" ]]; then
     REVISIONS_BLOCK="
 
 Claude's revision summary (including any findings that were rejected with evidence) is at: ${REVISIONS_FILE}
-Read it before reviewing the plan -- if Claude rejected a finding with valid evidence, do not re-raise it."
+Read it before reviewing the plan, but treat it as a claim to verify against the updated plan and the current codebase. Do not automatically trust or reject it."
   fi
-  SEVERITY_GATE="
-IMPORTANT -- Severity threshold for round ${ROUND}:
-At this stage of the debate, only flag findings where a competent engineer following the plan would produce functionally wrong behavior -- incorrect output, data loss, crashes, security holes, or silently broken features. Do NOT flag:
-- Wording ambiguities that a reasonable implementer would resolve correctly
-- Missing prose for behavior that is already obvious from context
-- Hypothetical misimplementations that require actively misreading the plan
-- Test coverage gaps for edge cases that are unlikely in practice
-- Style or naming suggestions
+  ROUND_GUIDANCE="
+This is a blocker-only convergence review.
+First check whether any previously raised findings are still unresolved. Only flag issues where a competent engineer following the plan would still likely:
+- produce functionally wrong behavior
+- violate invariants or create split-brain state
+- miss required scope, required callsites, or required cleanup paths
+- ship tests that would allow broken behavior to pass unnoticed
 
-If you find no issues meeting this bar, respond with VERDICT: APPROVED."
+Do NOT flag:
+- Style, naming, or wording improvements
+- Minor ambiguity that a reasonable implementer would resolve correctly
+- Hypothetical misimplementations that require actively misreading the plan
+- Optional refactors, polish, or generic architecture preferences
+- Generic test wishlist items not tied to a concrete correctness risk
+
+If you find no blocker-level issues meeting this bar, respond with VERDICT: APPROVED."
+  REVIEW_AREAS="
+Analyze only for:
+1. Remaining unresolved prior findings that still imply broken behavior.
+2. Incorrect or missing algorithms, overwrite semantics, or sequencing that would change behavior.
+3. Missing required callsites, migrations, state transitions, teardown paths, or cleanup paths.
+4. Canonical-state or invariant violations that could leave mixed or contradictory state.
+5. Missing tests only when the absence of those tests would plausibly allow a broken implementation to ship."
 fi
 
 cat > "$prompt_file" <<PROMPT_EOF
 ${REVIEW_INTRO}
 ${REVISIONS_BLOCK}
+${REQUEST_BLOCK}
 
 Read the plan at: ${PLAN_FILE}
 
 Review for implementability, not just conceptual correctness. Ask: if a different engineer executed this plan literally, could they still produce behavior that contradicts the plan's intent while believing they followed it? If yes, flag the plan as underspecified and propose exact wording that removes the ambiguity.
 
+Do not only check whether the plan is internally consistent. Also challenge whether it has chosen the right overall approach for the request. If a materially simpler, more local, or more pragmatic solution would satisfy the request with less risk or complexity, flag that and propose the better direction.
+
+A localized refactor within an already bloated, fragile, or overly coupled file can be warranted when it is the most practical way to implement the requested change safely, clearly, or testably. Do not treat every refactor as scope creep; distinguish required enabling refactors from optional cleanup.
+
 Before raising or dismissing any finding, verify the plan's claims against the current codebase by reading the referenced files and searching for adjacent callsites or related logic. Do not rely on plan text alone.
 
-For large or multi-area plans, use subagents in parallel to audit separate file clusters or subsystems, then synthesize their results into a single review.
+${ROUND_GUIDANCE}
 
-Analyze for:
-1. Goal alignment -- does the plan actually accomplish what was requested? Would executing it fully deliver the feature, fix the bug, or achieve the stated objective? Flag if the plan misses the core intent or only partially addresses it.
-2. Over-engineering -- is the plan more complex than necessary? Flag unnecessary abstractions, helper utilities, configuration layers, or indirection that a simpler approach would avoid.
-3. Scope creep -- does the plan add work that was not requested? Flag "while we're at it" improvements, refactors, or features beyond what the original request requires.
-4. Reinventing existing code -- does the plan propose creating something that likely already exists in the codebase? Flag new utilities, helpers, or patterns when existing implementations should be reused instead.
-5. Technical soundness and feasibility
-6. Missing steps or edge cases not addressed
-7. Architectural concerns or flawed assumptions
-8. Security or performance risks
-9. Test coverage -- does the plan include unit and/or integration tests for the changes? Flag if new logic, endpoints, or behaviors lack corresponding test tasks.
-10. Unclear, ambiguous, or easy-to-misimplement task descriptions -- flag tasks that are technically correct in intent but leave room for materially wrong implementations. Focus on missing algorithms, missing ordering constraints, unspecified overwrite behavior, unspecified canonical-write targets, and vague "apply this pattern everywhere" instructions.
-11. Canonical state and invariant preservation -- for any plan that migrates, renames, caches, mirrors, or falls back between multiple representations/locations, verify that it explicitly defines: the canonical source of truth after the change; read behavior when old and new state both exist; write behavior when old and new state both exist; whether legacy state must be migrated, ignored, or cleaned up. Flag plans that permit split-brain state, continued mutation of legacy state, or mixed-state behavior that never converges.
-12. Task specificity and omission resistance -- check whether each task is concrete enough that an implementer cannot accidentally skip part of it. Flag tasks that rely on shorthand like "apply the same pattern," "update all handlers," or "mirror the above change" without naming exact functions, branches, side effects, and cleanup paths. Prefer plans that enumerate the concrete callsites or require a verification sweep proving none were missed.
-13. Behavioral precision and algorithmic ambiguity -- check whether key behavioral words are operationalized into exact steps. Flag terms like "merge," "prefer," "preserve," "reuse," "best effort," "safe," "destination-precedence," "fallback," or "migrate" when the plan does not specify the exact algorithm, overwrite semantics, and non-goals. If two reasonable engineers could implement the sentence in opposite ways, the task is too ambiguous.
-14. Order-of-operations and sequencing constraints -- check whether the plan specifies the required order between validation, reads, migration, locking, PID checks, writes, cleanup, and response generation. Flag tasks where doing the right steps in the wrong order would change behavior, create races, or violate invariants. Require explicit sequencing whenever earlier steps affect what later steps are allowed to read or write.
-15. Lifecycle symmetry and cleanup completeness -- for every create/read/write/start path in the plan, verify the corresponding stop/delete/reset/cleanup path is also updated. Flag one-sided migrations where the plan updates creation or reads but not teardown, cancellation, cleanup, backfill, or legacy-path removal. This includes "clear both locations," "stop both process types," and "remove stale artifacts from all relevant stores."
-16. Test fidelity to real execution paths -- evaluate not just whether tests exist, but whether they exercise the real behavior boundary that enforces the contract. Flag test tasks that: reimplement production logic inside mocks; only test helpers when the risk lives in route/handler orchestration; mock away ordering, filesystem, or state-transition behavior that is the actual source of risk; do not cover mixed-state, partial-migration, or contradiction scenarios. Require the plan to specify the test level where needed: unit, integration, route/handler, or end-to-end.
+If the plan spans clearly separable subsystems, you may use subagents in parallel to audit distinct file clusters or subsystems, then synthesize the results into a single review. Otherwise, review directly.
+
+${REVIEW_AREAS}
 
 Format each finding as:
 
@@ -159,7 +211,7 @@ Format each finding as:
 ---
 
 Be direct and specific. Only flag genuine, significant issues. Propose solutions, not just problems.
-${SEVERITY_GATE}
+If you find no issues worth flagging for this round, write no findings and end with VERDICT: APPROVED.
 
 The LAST line of your response MUST be exactly one of these two lines (nothing after it):
 VERDICT: APPROVED

--- a/plugins/code/tools/python/test_self_learning_flag.py
+++ b/plugins/code/tools/python/test_self_learning_flag.py
@@ -126,6 +126,43 @@ class TestCreateStateFilePersistsSelfLearning:
         assert "CLOSEDLOOP_WORKDIR=/tmp/test" in content
 
 
+class TestCreateStateFilePromptQuoting:
+    """Verify create_state_file emits quoted slash-command arguments."""
+
+    def test_prompt_quotes_workdir_prd_and_add_dir_with_spaces(
+        self, tmp_path: Path
+    ) -> None:
+        """State prompt should preserve argument boundaries for paths with spaces."""
+        project_root = tmp_path / "AI Platform"
+        workdir = project_root / "workdir"
+        workdir.mkdir(parents=True)
+        prd_file = workdir / "docs" / "prd file.md"
+        prd_file.parent.mkdir(parents=True)
+        add_dir = tmp_path / "peer repo"
+        add_dir.mkdir()
+
+        awk = _awk_extract_script()
+        script = (
+            _base_env(workdir, self_learning="false")
+            + f'PRD_FILE="{prd_file}"\n'
+            + 'PROMPT_NAME="prompt"\n'
+            + f'ADD_DIRS=("{add_dir}")\n'
+            + f'eval "$(awk \'{awk}\' "{RUN_LOOP_SH}")"\n'
+            + "create_state_file\n"
+        )
+
+        result = _run_script(script, cwd=str(workdir))
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        state_file = workdir / CLOSEDLOOP_STATE_DIR / "state.local.md"
+        prompt_line = state_file.read_text().splitlines()[-1]
+        expected = (
+            f'/code:code "{workdir}" --prompt "prompt" --prd "{prd_file}" '
+            f'--add-dir "{add_dir}"'
+        )
+        assert prompt_line == expected
+
+
 class TestBootstrapLearningsGuard:
     """Verify bootstrap_learnings skips when self-learning is off."""
 

--- a/plugins/code/tools/python/test_setup_closedloop.py
+++ b/plugins/code/tools/python/test_setup_closedloop.py
@@ -117,14 +117,20 @@ def test_writes_session_mapping_from_closedloop_pid_file(tmp_workdir: Path) -> N
     session_dir = tmp_workdir / CLOSEDLOOP_STATE_DIR
     session_dir.mkdir(parents=True)
     session_id = "session-from-closedloop"
-    (session_dir / f"pid-{os.getpid()}.session").write_text(session_id)
-
-    result = _run_setup_in_workdir(tmp_workdir)
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'echo "{session_id}" > "{session_dir}/pid-$$.session"; '
+            f'exec bash "{SETUP_SCRIPT}" "{tmp_workdir}"',
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_workdir),
+    )
 
     assert result.returncode == 0
-    assert (session_dir / f"session-{session_id}.workdir").read_text().strip() == str(
-        tmp_workdir
-    )
+    assert (session_dir / f"session-{session_id}.workdir").read_text().strip() == str(tmp_workdir.resolve())
 
 
 def test_ignores_legacy_pid_mapping(tmp_workdir: Path) -> None:
@@ -405,3 +411,55 @@ def test_no_add_dir_config_env_has_empty_add_dirs(tmp_workdir: Path) -> None:
     assert 'CLOSEDLOOP_ADD_DIRS=""' in config
     assert 'CLOSEDLOOP_ADD_DIR_NAMES=""' in config
     assert 'CLOSEDLOOP_REPO_MAP=""' in config
+
+
+def test_reconstructs_split_workdir_and_prd_paths_with_spaces(tmp_path: Path) -> None:
+    """Handles unquoted split tokens for workdir/--prd paths that contain spaces."""
+    project_root = tmp_path / "AI Platform" / "ai-matching-platform-loop-pln-2"
+    workdir = project_root / CLOSEDLOOP_STATE_DIR / "work"
+    workdir.mkdir(parents=True)
+    prd = workdir / "prd.md"
+    prd.write_text("# PRD\n\nRequirements here\n")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(SETUP_SCRIPT),
+            *str(workdir).split(" "),
+            "--prd",
+            *str(prd).split(" "),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(project_root),
+    )
+
+    assert result.returncode == 0, result.stderr
+    config = _config_env(workdir)
+    assert _config_value(config, "CLOSEDLOOP_WORKDIR") == str(workdir.resolve())
+    assert _config_value(config, "CLOSEDLOOP_PRD_FILE") == str(prd.resolve())
+
+
+def test_reconstructs_split_add_dir_path_with_spaces(
+    tmp_workdir: Path, tmp_path: Path
+) -> None:
+    """Handles unquoted split tokens for --add-dir paths that contain spaces."""
+    extra_repo = tmp_path / "peer repo"
+    extra_repo.mkdir()
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(SETUP_SCRIPT),
+            str(tmp_workdir),
+            "--add-dir",
+            *str(extra_repo).split(" "),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_workdir),
+    )
+
+    assert result.returncode == 0, result.stderr
+    config = _config_env(tmp_workdir)
+    assert _config_value(config, "CLOSEDLOOP_ADD_DIRS") == str(extra_repo.resolve())

--- a/plugins/platform/.claude-plugin/plugin.json
+++ b/plugins/platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platform",
   "description": "ClosedLoop Platform plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/platform/README.md
+++ b/plugins/platform/README.md
@@ -146,7 +146,7 @@ A comprehensive guide for creating Mermaid diagrams embedded in markdown. Covers
 
 A two-mode workflow for uploading file content to the ClosedLoop platform as a typed artifact:
 
-**Script mode** (preferred when `CLOSEDLOOP_API_KEY` is available in `.env.local`): Runs `skills/upload-artifact/scripts/upload_artifact.py` via `uv`, which connects directly to the MCP server over Streamable HTTP without loading file content into the conversation context. Supports creating new artifacts and new versions of existing artifacts.
+**Script mode** (preferred when `CLOSEDLOOP_API_KEY` is available in the shell environment): Runs `skills/upload-artifact/scripts/upload_artifact.py` via `uv`, which connects directly to the MCP server over Streamable HTTP without loading file content into the conversation context. Supports creating new artifacts and new versions of existing artifacts.
 
 **MCP fallback** (when no API key is configured): Uses Claude Code's existing MCP authentication to call `mcp__closedloop__create-artifact` or `mcp__closedloop__create-artifact-version` directly. File content is loaded into conversation context in this mode.
 
@@ -229,4 +229,4 @@ The skill activates on explicit upload requests. Example triggers:
 - "Save this implementation plan as an artifact."
 - "Create a new version of artifact `art_abc123` from `plan-v2.md`."
 
-For script mode, ensure `CLOSEDLOOP_API_KEY` and `NEXT_PUBLIC_MCP_SERVER_URL` are set in `.env.local`. For MCP fallback, ensure the ClosedLoop MCP server is configured in Claude Code's MCP settings.
+For script mode, ensure `CLOSEDLOOP_API_KEY` and `NEXT_PUBLIC_MCP_SERVER_URL` are set in the shell environment. For MCP fallback, ensure the ClosedLoop MCP server is configured in Claude Code's MCP settings.

--- a/plugins/platform/skills/upload-artifact/SKILL.md
+++ b/plugins/platform/skills/upload-artifact/SKILL.md
@@ -17,10 +17,13 @@ Upload file content as a ClosedLoop MCP artifact. Two modes:
 
 1. **Script mode** (preferred) — uses a standalone Python script that reads the
    file and calls MCP directly over Streamable HTTP. No conversation context
-   consumed for file content. Requires a `CLOSEDLOOP_API_KEY` in `.env.local`.
+   consumed for file content. Requires `CLOSEDLOOP_API_KEY` and
+   `NEXT_PUBLIC_MCP_SERVER_URL` to already be present in the current shell
+   environment.
 
 2. **MCP fallback** — reads the file into context and calls `mcp__closedloop__create-artifact`
-   directly. Uses Claude Code's existing MCP auth. Used when no API key is available.
+   directly. Uses Claude Code's existing MCP auth. Used when the required
+   script-mode environment variables are not available.
 
 ## Workflow
 
@@ -28,16 +31,17 @@ Follow these steps in order:
 
 ### Step 1: Resolve Credentials and Choose Mode
 
-Read `.env.local` and look for:
+Read these values from the current shell environment. Do not read, source, or
+otherwise rely on a `.env.local` file in the current working directory:
 - `CLOSEDLOOP_API_KEY` — the API key (starts with `sk_live_`)
 - `NEXT_PUBLIC_MCP_SERVER_URL` — the MCP server URL
 
 **If both exist** → use **script mode** (Steps 2a–5a).
-**If API key is missing** → use **MCP fallback** (Steps 2b–5b).
+**If either variable is missing** → use **MCP fallback** (Steps 2b–5b).
 
 ---
 
-## Script Mode (API key available)
+## Script Mode (required env vars available)
 
 ### Step 2a: List Projects
 
@@ -45,8 +49,8 @@ Run the script with `--list-projects`:
 
 ```bash
 uv run --with 'mcp[cli]' <base_directory>/scripts/upload_artifact.py \
-  --url <MCP_URL> \
-  --api-key <API_KEY> \
+  --url "$NEXT_PUBLIC_MCP_SERVER_URL" \
+  --api-key "$CLOSEDLOOP_API_KEY" \
   --list-projects
 ```
 
@@ -73,8 +77,8 @@ type — only ask for the title.
 
 ```bash
 uv run --with 'mcp[cli]' <base_directory>/scripts/upload_artifact.py \
-  --url <MCP_URL> \
-  --api-key <API_KEY> \
+  --url "$NEXT_PUBLIC_MCP_SERVER_URL" \
+  --api-key "$CLOSEDLOOP_API_KEY" \
   --file <FILE_PATH> \
   --title "<TITLE>" \
   --type <TYPE> \
@@ -96,7 +100,7 @@ Parse the JSON output and report to the user:
 
 ---
 
-## MCP Fallback (no API key)
+## MCP Fallback (required env vars missing)
 
 ### Step 2b: List Projects
 

--- a/plugins/platform/skills/upload-artifact/scripts/upload_artifact.py
+++ b/plugins/platform/skills/upload-artifact/scripts/upload_artifact.py
@@ -4,17 +4,20 @@
 Connects directly to the MCP server, authenticates with an API key,
 and calls create-artifact or create-artifact-version.
 
+Reads `CLOSEDLOOP_API_KEY` and `NEXT_PUBLIC_MCP_SERVER_URL` from the current
+process environment by default. `--api-key` and `--url` can still be provided
+explicitly to override those values.
+
 Usage:
+    export CLOSEDLOOP_API_KEY=sk_live_...
+    export NEXT_PUBLIC_MCP_SERVER_URL=https://example.com/mcp
+
     # List available projects:
     uv run --with 'mcp[cli]' scripts/upload_artifact.py \\
-        --url http://localhost:3010/mcp \\
-        --api-key sk_live_... \\
         --list-projects
 
     # Create artifact:
     uv run --with 'mcp[cli]' scripts/upload_artifact.py \\
-        --url http://localhost:3010/mcp \\
-        --api-key sk_live_... \\
         --file /path/to/content.md \\
         --title "My PRD" \\
         --type PRD \\
@@ -22,15 +25,11 @@ Usage:
 
     # New version of existing artifact:
     uv run --with 'mcp[cli]' scripts/upload_artifact.py \\
-        --url http://localhost:3010/mcp \\
-        --api-key sk_live_... \\
         --file /path/to/content.md \\
         --artifact-id <ARTIFACT_ID>
 
     # Create + verify round-trip:
     uv run --with 'mcp[cli]' scripts/upload_artifact.py \\
-        --url http://localhost:3010/mcp \\
-        --api-key sk_live_... \\
         --file /path/to/content.md \\
         --title "My PRD" \\
         --type PRD \\
@@ -42,6 +41,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -63,6 +63,10 @@ class _Args(argparse.Namespace):
     workstream_id: str | None
     artifact_id: str | None
     verify: bool
+
+
+_API_KEY_ENV_VAR = "CLOSEDLOOP_API_KEY"
+_MCP_URL_ENV_VAR = "NEXT_PUBLIC_MCP_SERVER_URL"
 
 
 def _build_http_client(api_key: str) -> httpx.AsyncClient:
@@ -252,17 +256,41 @@ def _format_exception(exc: Exception | ExceptionGroup) -> dict:  # type: ignore[
     return {"error": str(exc), "traceback": traceback.format_exc()}
 
 
+def _require_arg_or_env(
+    parser: argparse.ArgumentParser,
+    *,
+    value: str | None,
+    flag: str,
+    env_var: str,
+) -> str:
+    """Return a CLI/env value or exit with a clear parser error."""
+    if value:
+        return value
+    parser.error(
+        f"{flag} is required. Set {env_var} in the current environment "
+        f"or pass {flag} explicitly."
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Upload file content as a ClosedLoop MCP artifact."
     )
     parser.add_argument(
         "--url",
-        default="http://localhost:3010/mcp",
-        help="MCP server URL (default: http://localhost:3010/mcp)",
+        default=os.environ.get(_MCP_URL_ENV_VAR),
+        help=(
+            "MCP server URL. Defaults to the "
+            f"{_MCP_URL_ENV_VAR} environment variable."
+        ),
     )
     parser.add_argument(
-        "--api-key", required=True, help="ClosedLoop API key (sk_live_...)"
+        "--api-key",
+        default=os.environ.get(_API_KEY_ENV_VAR),
+        help=(
+            "ClosedLoop API key (sk_live_...). Defaults to the "
+            f"{_API_KEY_ENV_VAR} environment variable."
+        ),
     )
     parser.add_argument(
         "--list-projects",
@@ -287,6 +315,18 @@ def main() -> None:
         help="After upload, fetch the artifact back and verify content length.",
     )
     args = parser.parse_args(namespace=_Args())
+    args.url = _require_arg_or_env(
+        parser,
+        value=args.url,
+        flag="--url",
+        env_var=_MCP_URL_ENV_VAR,
+    )
+    args.api_key = _require_arg_or_env(
+        parser,
+        value=args.api_key,
+        flag="--api-key",
+        env_var=_API_KEY_ENV_VAR,
+    )
 
     if args.list_projects:
         result = asyncio.run(list_projects(args))


### PR DESCRIPTION
- Quote workdir, prompt, prd, and add-dir when run-loop persists /code:code so spaces and shell metacharacters keep boundaries
- Invoke setup-closedloop.sh via bash in /code for portability
- Make setup-closedloop.sh tolerant of split path tokens for positional workdir, --prd, --plan, and --add-dir
- Add regression coverage for prompt quoting and split-path parsing
- Document AGENTS.md guidance to follow the .gitmessage template

Testing: Ran python -m pytest plugins/code/tools/python/test_self_learning_flag.py plugins/code/tools/python/test_setup_closedloop.py (31 passed); manually verified a /tmp harness with spaces, $, and backticks through generated /code:code args into setup-closedloop.sh

Risks: Low; changes are limited to argument construction/parsing and covered by targeted tests