### PR TITLE
Consume CLAUDE_BIN env var in loop scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code v1.9.2
+
+#### Changed
+- `run-loop.sh` and `debate-loop.sh` now consume the `CLAUDE_BIN` environment variable when set, falling back to bare `claude` otherwise. Complements closedloop-electron PR #111 so the Electron desktop app's pre-validated claude binary path is actually used by every subprocess invocation — fixes silent failures for users whose `claude` is installed outside `/opt/homebrew/bin` (non-Homebrew macOS setups, manual symlinks, etc.)
+- `debate-loop.sh` dependency check verifies the resolved `$CLAUDE` path rather than a bare `claude` lookup, so custom binary locations are correctly validated at startup
+
 ### code v1.9.1
 
 #### Added
@@ -28,6 +34,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 #### Changed
 - `upload-artifact` skill now reads `CLOSEDLOOP_API_KEY` and `NEXT_PUBLIC_MCP_SERVER_URL` from the current shell environment instead of `.env.local`, and falls back to MCP mode when either variable is missing
 - `upload_artifact.py` defaults `--api-key` and `--url` to the `CLOSEDLOOP_API_KEY` and `NEXT_PUBLIC_MCP_SERVER_URL` environment variables, exiting with a clear parser error when neither the flag nor the env var is set
+
+### self-learning v1.1.2
+
+#### Changed
+- `process-chat-learnings.sh` now consumes the `CLAUDE_BIN` environment variable when set, falling back to bare `claude` otherwise — matches the `code` plugin pattern so desktop-spawned learning runs use the pre-validated binary
 
 ### bootstrap v1.2.0
 

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/scripts/debate-loop.sh
+++ b/plugins/code/scripts/debate-loop.sh
@@ -19,6 +19,12 @@
 
 set -euo pipefail
 
+# Claude binary path. When spawned by the closedloop-electron desktop app,
+# CLAUDE_BIN is set to the absolute path that the desktop validated in its
+# pre-flight check. Falls back to bare `claude` for manual/interactive runs
+# where PATH is trusted. See run-loop.sh for the same pattern.
+CLAUDE="${CLAUDE_BIN:-claude}"
+
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FORMATTER="$SCRIPTS_DIR/../tools/python/stream_formatter.py"
 
@@ -78,14 +84,14 @@ run_claude() {
     local claude_exit_file
     claude_exit_file=$(mktemp)
     TMPFILES+=("$claude_exit_file")
-    { claude "${claude_args[@]}" --output-format stream-json --verbose 2>"$CLAUDE_STDERR"; echo $? > "$claude_exit_file"; } \
+    { "$CLAUDE" "${claude_args[@]}" --output-format stream-json --verbose 2>"$CLAUDE_STDERR"; echo $? > "$claude_exit_file"; } \
       | python3 "$FORMATTER" &
     CURRENT_CHILD_PID=$!
     wait $CURRENT_CHILD_PID || true
     CURRENT_CHILD_PID=0
     exit_code=$(cat "$claude_exit_file" 2>/dev/null || echo "1")
   else
-    claude "${claude_args[@]}" --output-format text > /dev/null 2>"$CLAUDE_STDERR" &
+    "$CLAUDE" "${claude_args[@]}" --output-format text > /dev/null 2>"$CLAUDE_STDERR" &
     CURRENT_CHILD_PID=$!
     wait $CURRENT_CHILD_PID && exit_code=0 || exit_code=$?
     CURRENT_CHILD_PID=0
@@ -303,7 +309,7 @@ if [[ ${#ADD_DIRS[@]} -gt 0 ]]; then
 fi
 
 # Check dependencies
-for cmd in claude codex; do
+for cmd in "$CLAUDE" codex; do
   if ! command -v "$cmd" &> /dev/null; then
     echo -e "${RED}Error: $cmd is required but not found${NC}" >&2
     exit 1
@@ -452,7 +458,7 @@ if [[ "$PHASE" == "user_review" ]]; then
     if [[ ${#ADD_DIR_ARGS[@]} -gt 0 ]]; then
       local_claude_args+=("${ADD_DIR_ARGS[@]}")
     fi
-    claude "${local_claude_args[@]}" 2>/dev/null
+    "$CLAUDE" "${local_claude_args[@]}" 2>/dev/null
     INTERACTIVE_EXIT=$?
 
     echo ""

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -7,6 +7,13 @@
 
 set -euo pipefail
 
+# Claude binary path. When spawned by the closedloop-electron desktop app,
+# CLAUDE_BIN is set to the absolute path that the desktop validated in its
+# pre-flight check. This avoids PATH mismatches between Electron's spawn env
+# and the user's login shell (e.g. non-Homebrew installs, symlinked binaries).
+# Falls back to bare `claude` for manual/interactive runs where PATH is trusted.
+CLAUDE="${CLAUDE_BIN:-claude}"
+
 # Single source of truth for the state directory name
 CLOSEDLOOP_STATE_DIR=".closedloop-ai"
 
@@ -344,7 +351,7 @@ post_iteration_processing() {
       echo -e "${BLUE}[8/10] Processing pending learnings...${NC}"
       log_progress "Step 8: Running process-learnings"
       if run_timed_step 8 "process_learnings" bash -c "
-        claude -p 'Run /self-learning:process-learnings $workdir' \
+        \"$CLAUDE\" -p 'Run /self-learning:process-learnings $workdir' \
             --allowed-tools=Bash,Grep,Glob,Read,Write \
             --max-turns 100 2>&1 | tee -a '$PROGRESS_LOG'
       "; then
@@ -396,7 +403,7 @@ post_iteration_processing() {
       echo -e "${BLUE}[10/10] Exporting closedloop learnings...${NC}"
       log_progress "Step 10: Running export-closedloop-learnings"
       if run_timed_step 10 "export_closedloop_learnings" bash -c "
-        claude -p '/self-learning:export-closedloop-learnings $workdir' \
+        \"$CLAUDE\" -p '/self-learning:export-closedloop-learnings $workdir' \
             --allowed-tools=Bash,Grep,Glob,Read,Write \
             --max-turns 20 2>&1 | tee -a '$PROGRESS_LOG'
       "; then
@@ -488,7 +495,7 @@ run_post_loop_review() {
 
     set +e
     (
-      claude \
+      "$CLAUDE" \
         --allowed-tools=Bash,Grep,Glob,Read,Write,Edit,Task,TodoWrite \
         --output-format stream-json \
         --verbose \
@@ -565,7 +572,7 @@ run_post_loop_review() {
 
     set +e
     (
-      claude \
+      "$CLAUDE" \
         --allowed-tools=Bash,Grep,Glob,Read,Write,Edit,Task,TodoWrite \
         --output-format stream-json \
         --verbose \
@@ -1127,7 +1134,7 @@ main() {
     exit_code_file=$(mktemp)
     set +e
     (
-      claude \
+      "$CLAUDE" \
           --allowed-tools=Bash,Grep,Glob,Read,Edit,Write,Task,TodoWrite,Skill,WebSearch,WebFetch,mcp__playwright__browser_navigate,mcp__playwright__browser_snapshot,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_click,mcp__playwright__browser_type,mcp__playwright__browser_evaluate \
           --output-format stream-json \
           --verbose \

--- a/plugins/self-learning/.claude-plugin/plugin.json
+++ b/plugins/self-learning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "self-learning",
   "description": "Self-learning plugin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/self-learning/scripts/process-chat-learnings.sh
+++ b/plugins/self-learning/scripts/process-chat-learnings.sh
@@ -9,6 +9,11 @@
 
 set -euo pipefail
 
+# Claude binary path. When spawned by the closedloop-electron desktop app,
+# CLAUDE_BIN is set to the absolute path that the desktop validated in its
+# pre-flight check. Falls back to bare `claude` for manual runs.
+CLAUDE="${CLAUDE_BIN:-claude}"
+
 WORKDIR="${1:?Usage: process-chat-learnings.sh <workdir>}"
 
 PENDING_DIR="$WORKDIR/.learnings/pending"
@@ -41,7 +46,7 @@ write_status "processing" "Running process-learnings"
 
 # Run the process-learnings command via Claude
 CLAUDE_OK=false
-if claude -p "Run /self-learning:process-learnings $WORKDIR" \
+if "$CLAUDE" -p "Run /self-learning:process-learnings $WORKDIR" \
     --allowed-tools=Bash,Grep,Glob,Read,Write \
     --max-turns 100 2>/dev/null; then
   CLAUDE_OK=true


### PR DESCRIPTION
## Summary

Companion PR to [closedloop-electron#111](https://github.com/closedloop-ai/closedloop-electron/pull/111) — makes the loop scripts actually consume the `CLAUDE_BIN` env var that the desktop app now sets.

The desktop app pre-flight-validates the `claude` binary absolute path and injects it into the spawn env as `CLAUDE_BIN`. But every script in this repo currently invokes `claude` as a bare command, so the env var lands and does nothing. Users without Homebrew or with a non-standard `claude` install hit this — the desktop's pre-flight check passes, but the loop subprocess can't resolve `claude` via its own subshell PATH. Result: silent failure, ghost-loop abort after 3 empty iterations with `tokenUsage: 0/0`.

Observed in production.

## Changes

### `code` plugin (v1.9.1 → v1.9.2)

- `plugins/code/scripts/run-loop.sh` — adds `CLAUDE="${CLAUDE_BIN:-claude}"` near the top; replaces bare `claude` at 5 invocation sites (2 inside `bash -c` heredocs, 3 direct) with `"$CLAUDE"`
- `plugins/code/scripts/debate-loop.sh` — same pattern; replaces bare `claude` at 3 invocation sites
- `debate-loop.sh` dependency check (`for cmd in claude codex`) now verifies the resolved `$CLAUDE` binary rather than a bare `claude` lookup — matters when the user has a custom path

### `self-learning` plugin (v1.1.1 → v1.1.2)

- `plugins/self-learning/scripts/process-chat-learnings.sh` — same pattern; 1 invocation

### Plus

- Plugin version bumps in both `plugin.json` manifests
- `CHANGELOG.md` entries under `[Unreleased]`

## Scripts NOT changed (intentional)

- `install.sh` — user-facing installer run manually before the desktop app exists. Not in the desktop-spawned failure path.
- `pretooluse-hook.sh`, `ensure_agents_snapshot.sh` — no `claude` binary invocations (only references in path strings).

## Test plan

- [x] `bash -n` passes on all three modified scripts
- [x] `grep` confirms no remaining bare `claude` invocations in the affected scripts
- [ ] End-to-end with a non-Homebrew, symlinked-`claude` setup — pending merge of closedloop-electron#111 and a new desktop build
- [ ] Smoke test locally with `CLAUDE_BIN=/custom/path/claude` to confirm the value propagates through bash -c heredocs and direct invocations

## Risks

Low. Fallback to bare `claude` preserves existing behavior when `CLAUDE_BIN` is unset (manual/interactive runs). Only changes desktop-spawned behavior, and only when `CLAUDE_BIN` is set. Paths with spaces handled via double-quoting through both bash -c heredoc and direct spawn paths.
