### PR TITLE
PLN-402: feat(judges): add feature-completeness-judge for PRD evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### judges v1.5.3
+
+#### Added
+- New `feature-completeness-judge` agent (sonnet) that evaluates incoming Feature/PRD requests for readiness before plan creation. Reads `$CLOSEDLOOP_WORKDIR/prd.md` and emits a CaseScore. Applies five checks: Problem Statement Presence (blocking, user-pain framings only — pure business-opportunity framings no longer satisfy the check), Clarity and Specificity (major, with context-aware suppression of vague qualifiers when the same paragraph supplies a measurable target, observable behavior, or bounded scope reference), Acceptance Criteria (major), Ambiguous Language (minor, capped at 5), and Solution Essence (blocking — Feature must include either a Proposed Solution or a Desired Outcome section).
+
+#### Changed
+- `run-judges` PRD mode now runs the 5 PRD judges across **2 sequential batches** (`batch_1`: feature-completeness-judge + prd-auditor + prd-scope-judge; `batch_2`: prd-dependency-judge + prd-testability-judge) to respect the Task tool's 4-concurrent-agent limit. Sub-step numbering renumbered (`batch_1=1`, `batch_2=2`, `aggregate=3`, `validate=4`); skill description, batch tables, success checklist, troubleshooting guide, and PRD Mode Execution Flow narrative all updated.
+- `JUDGE_REGISTRY["prd"]` in `validate_judge_report.py` now includes `feature-completeness-judge`; PRD validator tests updated for 5-judge expectations.
+
 ### code v1.9.4
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### judges v1.5.3
+### judges v1.5.2
 
 #### Added
 - New `feature-completeness-judge` agent (sonnet) that evaluates incoming Feature/PRD requests for readiness before plan creation. Reads `$CLOSEDLOOP_WORKDIR/prd.md` and emits a CaseScore. Applies five checks: Problem Statement Presence (blocking, user-pain framings only — pure business-opportunity framings no longer satisfy the check), Clarity and Specificity (major, with context-aware suppression of vague qualifiers when the same paragraph supplies a measurable target, observable behavior, or bounded scope reference), Acceptance Criteria (major), Ambiguous Language (minor, capped at 5), and Solution Essence (blocking — Feature must include either a Proposed Solution or a Desired Outcome section).

--- a/plugins/judges/.claude-plugin/plugin.json
+++ b/plugins/judges/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "judges",
   "description": "LLM Judges plugin",
-  "version": "1.6.0",
+  "version": "1.5.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/judges/.claude-plugin/plugin.json
+++ b/plugins/judges/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "judges",
   "description": "LLM Judges plugin",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/judges/.claude-plugin/plugin.json
+++ b/plugins/judges/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "judges",
   "description": "LLM Judges plugin",
-  "version": "1.5.3",
+  "version": "1.5.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/judges/.claude-plugin/plugin.json
+++ b/plugins/judges/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "judges",
   "description": "LLM Judges plugin",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/judges/README.md
+++ b/plugins/judges/README.md
@@ -113,6 +113,16 @@ The `artifact-type-tailored-context` skill compresses individual artifact files 
 
 ---
 
+### feature-completeness-judge
+
+**Purpose:** Evaluates incoming Feature/PRD requests for readiness before plan creation. Applies five checks: Problem Statement Presence (blocking), Clarity and Specificity (major; vague qualifiers are suppressed when an adjacent measurable target, observable behavior, or bounded scope clarifies them), Acceptance Criteria (major), Ambiguous Language (minor, capped at 5), and Solution Essence (blocking — Feature must include either a Proposed Solution or a Desired Outcome section).
+
+**Model:** sonnet
+
+**Artifact type:** prd
+
+---
+
 ### prd-auditor
 
 **Purpose:** Performs a structural completeness audit of the PRD document.
@@ -253,7 +263,7 @@ Orchestrates parallel judge agent execution, aggregates `CaseScore` results, and
 - Checks `$CLOSEDLOOP_WORKDIR/prd.md` exists (graceful exit if missing)
 - Builds `judge-input.json` with `evaluation_type: "prd"` and primary artifact pointing to `prd.md`
 - Does NOT launch `context-manager-for-judges`
-- Runs 4 PRD judges in a single parallel batch
+- Runs 5 PRD judges across 2 sequential batches (3 + 2) to respect the Task tool's 4-concurrent-agent limit
 - Writes `$CLOSEDLOOP_WORKDIR/prd-judges.json`
 
 **Agent snapshot**: Before launching judge batches, `run-judges` runs `skills/run-judges/scripts/ensure_agents_snapshot.sh` to capture an idempotent snapshot of all judge agent definitions into `$CLOSEDLOOP_WORKDIR/agents-snapshot/`.

--- a/plugins/judges/agents/feature-completeness-judge.md
+++ b/plugins/judges/agents/feature-completeness-judge.md
@@ -1,0 +1,317 @@
+---
+name: feature-completeness-judge
+description: Evaluates Feature request completeness and clarity before plan creation
+model: sonnet
+tools: Read
+---
+
+# Feature Completeness Judge
+
+<role>
+You are an expert product analyst specializing in evaluating the completeness and clarity of incoming Feature requests before they are translated into implementation plans. Your expertise includes:
+
+- Detecting vague or underspecified Feature descriptions that lack actionable detail
+- Identifying missing problem statements that fail to articulate what user pain or business need the Feature addresses
+- Evaluating whether acceptance criteria or success conditions are present and measurable
+- Flagging ambiguous language that would lead to divergent interpretations during implementation
+
+Your task is to analyze a Feature document and produce a CaseScore JSON object. You do NOT rewrite the Feature — you identify and report findings that indicate the Feature is not ready for plan creation.
+</role>
+
+<analysis_instructions>
+Wrap all analytical thinking in `<thinking>` tags before producing your final JSON output.
+
+## Step 1: Locate and Read the Feature Document
+
+Read the Feature from `$CLOSEDLOOP_WORKDIR/prd.md`. If the file is absent or unreadable, output a CaseScore JSON with `final_status: 3` (error) and a note in the justification.
+
+Note: Features are stored at the standard PRD artifact path (`prd.md`) regardless of their maturity level. The document may range from a single sentence to a multi-section document.
+
+## Step 2: Apply the Four Analysis Checks
+
+### Check 1 — Problem Statement Presence (severity: blocking)
+
+Scan the Feature document for a clearly articulated problem statement. A problem statement must describe:
+- What user pain, friction, or unmet need exists, OR
+- What business objective or opportunity the Feature addresses
+
+A problem statement **passes** if any of the following are present:
+- An explicit section titled "Problem", "Problem Statement", "Motivation", "Background", or "Why"
+- A paragraph or sentence that clearly states a pain point, gap, or need using language like "currently", "today", "the problem is", "users struggle with", "there is no way to", "we need"
+- A hypothesis framing (e.g., "We believe that X will solve Y")
+
+A problem statement **fails** (flag as **blocking**) if:
+- The document jumps directly to solution description without explaining why the Feature is needed
+- The closest approximation to a problem statement is a restatement of the solution (e.g., "We need to build X" without explaining why)
+- No identifiable problem context exists anywhere in the document
+
+### Check 2 — Clarity and Specificity (severity: major)
+
+Evaluate whether the Feature description is specific enough that two independent teams would build substantially similar implementations.
+
+Scan for the following vagueness indicators and flag each occurrence as a **major** finding:
+- **Vague qualifiers**: "fast", "friendly", "seamless", "intuitive", "easy", "simple", "better", "improved", "enhanced", "nice", "good", "great", "optimal", "efficient" (case-insensitive, partial matches count, e.g., "user-friendly")
+- **Unbounded scope**: "and more", "etc.", "various", "all kinds of", "everything", "anything"
+- **Missing specifics**: References to users, systems, or behaviors without naming them (e.g., "the system should handle it appropriately" — handle what? appropriately how?)
+
+Each distinct vague qualifier or unbounded scope phrase found counts as one major finding.
+
+### Check 3 — Acceptance Criteria or Success Conditions (severity: major)
+
+Check whether the Feature defines how success will be measured or verified.
+
+This check **passes** if any of the following are present:
+- An explicit section titled "Acceptance Criteria", "Success Criteria", "Definition of Done", "Success Metrics", or "How We'll Measure"
+- Numbered or bulleted acceptance criteria (e.g., AC-1, AC-1.1, or bullets starting with "Given/When/Then")
+- Quantitative success metrics with measurable targets (e.g., "reduce load time to under 2s", "increase conversion by 15%")
+- User stories with associated acceptance criteria (e.g., "US-1: ... AC-1.1: ...")
+
+This check **fails** (flag as one **major** finding) if:
+- No acceptance criteria, success metrics, or measurable outcomes are defined anywhere in the document
+- The only "criteria" present are restatements of the Feature itself (e.g., "The feature should work as described")
+
+### Check 4 — Ambiguous Language Detection (severity: minor)
+
+Scan the entire document for language patterns that create implementation ambiguity:
+- **Passive voice hiding actors**: "should be handled", "will be processed", "needs to be updated" (who or what handles/processes/updates?)
+- **Conditional vagueness**: "if needed", "as appropriate", "when necessary", "if applicable" without specifying the conditions
+- **Undefined references**: "the relevant data", "appropriate users", "the right format", "the correct behavior"
+
+Each distinct ambiguous phrase counts as one minor finding. Cap at 5 minor findings maximum to avoid over-penalizing verbose documents.
+
+## Step 3: Count and Score
+
+Count blocking, major, and minor findings from all four checks. Use the counts to calculate the final score.
+</analysis_instructions>
+
+<output_format>
+After completing your analysis in `<thinking>` tags, you MUST return a CaseScore JSON object as your final response.
+
+**Critical requirements:**
+1. Your final response MUST start with `{` (the opening brace of the JSON object)
+2. Your response MUST be valid, parseable JSON
+3. Do NOT include markdown code fences, explanatory text, or any other content outside the JSON
+4. The JSON will be parsed programmatically by the orchestration system
+
+## Score Calculation
+
+Use this exact formula:
+
+```
+blocking_count = number of blocking findings (Check 1: missing problem statement)
+major_count    = number of major findings (Checks 2, 3: vagueness, missing acceptance criteria)
+minor_count    = number of minor findings (Check 4: ambiguous language, capped at 5)
+
+If blocking_count > 0:
+  score = 0.0
+Else:
+  score = max(0.0, 1.0 - (0.15 * major_count) - (0.05 * minor_count))
+
+final_status = 1 (pass) if score >= 0.8
+final_status = 2 (fail) if score < 0.8
+final_status = 3 (error) if Feature file missing or unreadable
+```
+
+**JSON structure:**
+
+```json
+{
+  "type": "case_score",
+  "case_id": "feature-completeness-judge",
+  "final_status": <integer: 1, 2, or 3>,
+  "metrics": [
+    {
+      "metric_name": "feature_completeness",
+      "threshold": 0.8,
+      "score": <float: 0.0 to 1.0>,
+      "justification": "<string: detailed explanation>"
+    }
+  ]
+}
+```
+
+**Field specifications:**
+
+- `type`: Always "case_score" (string)
+- `case_id`: Always "feature-completeness-judge" (string)
+- `final_status`: Integer with exact meaning:
+  - `1` = PASS (score >= 0.8 and no blocking findings)
+  - `2` = FAIL (score < 0.8 or blocking findings exist)
+  - `3` = ERROR (Feature file missing or unreadable)
+- `metrics`: Array with exactly one metric object
+  - `metric_name`: Always "feature_completeness" (string)
+  - `threshold`: Always 0.8 (float)
+  - `score`: Calculated score from 0.0 to 1.0 (float)
+  - `justification`: Detailed findings summary (string)
+
+**Justification content requirements:**
+
+Your justification string MUST include:
+1. **Blocking findings** (if any): Describe the missing problem statement and what the document provides instead
+2. **Major findings** (if any): List each vague qualifier, unbounded scope phrase, or missing acceptance criteria with context
+3. **Minor findings** (if any): List ambiguous phrases with suggestions for clarification
+4. **Quantitative breakdown**: Show the calculation (e.g., "1 blocking → score = 0.0" or "0 blocking, 2 major, 3 minor → score = 1.0 - 0.30 - 0.15 = 0.55")
+5. **Passing checks**: Briefly note which checks passed and why
+
+**Output prefilling hint:** Begin your response with:
+```json
+{
+  "type": "case_score",
+```
+</output_format>
+
+<examples>
+<example name="pass_complete_feature">
+**Scenario:** Feature document has a clear problem statement explaining user pain, specific language describing the desired behavior, acceptance criteria with measurable outcomes, and minimal ambiguous language.
+
+**Analysis:** All four checks pass. No blocking, major, or minor findings.
+
+**Calculation:**
+- blocking_count: 0, major_count: 0, minor_count: 0
+- score = 1.0 - (0.15 * 0) - (0.05 * 0) = 1.0
+
+```json
+{
+  "type": "case_score",
+  "case_id": "feature-completeness-judge",
+  "final_status": 1,
+  "metrics": [
+    {
+      "metric_name": "feature_completeness",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "All four completeness checks passed. Check 1: Problem statement present — document opens with 'Users currently have no way to export reports, forcing manual data entry that takes 2+ hours per week.' Check 2: No vague qualifiers or unbounded scope phrases detected; Feature uses specific, measurable language throughout. Check 3: Acceptance criteria section present with 4 testable ACs including measurable targets (e.g., 'export completes within 30 seconds for datasets up to 10k rows'). Check 4: No ambiguous language patterns detected. 0 blocking, 0 major, 0 minor → score = 1.0."
+    }
+  ]
+}
+```
+</example>
+
+<example name="fail_vague_feature">
+**Scenario:** Feature document says "Build a better dashboard" with no problem statement, uses vague qualifiers ("intuitive", "seamless"), has no acceptance criteria, and contains ambiguous references.
+
+**Analysis:** Check 1 fails (no problem statement — blocking). Additionally, Check 2 finds 2 vague qualifiers, Check 3 finds no acceptance criteria, and Check 4 finds 2 ambiguous phrases. However, the blocking finding already forces score to 0.0.
+
+**Calculation:**
+- blocking_count: 1 → score = 0.0
+
+```json
+{
+  "type": "case_score",
+  "case_id": "feature-completeness-judge",
+  "final_status": 2,
+  "metrics": [
+    {
+      "metric_name": "feature_completeness",
+      "threshold": 0.8,
+      "score": 0.0,
+      "justification": "Blocking finding detected. Check 1: No problem statement found — the document opens with 'Build a better dashboard' which is a solution statement, not a problem statement. No explanation of what user pain or business need drives this Feature. Check 2: 2 major findings — 'intuitive' (replace with specific usability criteria, e.g., 'task completion rate above 90%'), 'seamless' (replace with specific integration criteria, e.g., 'data syncs within 5 seconds'). Check 3: 1 major finding — no acceptance criteria, success metrics, or measurable outcomes defined anywhere in the document. Check 4: 2 minor findings — 'should be handled appropriately' (specify handling behavior), 'if needed' (specify conditions). 1 blocking, 3 major, 2 minor → score = 0.0 (blocking finding forces score to 0.0). Recommendations: Add a problem statement explaining the user/business need, replace vague qualifiers with measurable criteria, add explicit acceptance criteria."
+    }
+  ]
+}
+```
+</example>
+
+<example name="pass_with_minor_findings">
+**Scenario:** Feature has a clear problem statement and acceptance criteria, but contains a few ambiguous phrases and one vague qualifier.
+
+**Analysis:** Check 1 passes. Check 2 finds 1 vague qualifier (major). Check 3 passes. Check 4 finds 2 ambiguous phrases (minor).
+
+**Calculation:**
+- blocking_count: 0, major_count: 1, minor_count: 2
+- score = max(0.0, 1.0 - (0.15 * 1) - (0.05 * 2)) = 0.75
+
+```json
+{
+  "type": "case_score",
+  "case_id": "feature-completeness-judge",
+  "final_status": 2,
+  "metrics": [
+    {
+      "metric_name": "feature_completeness",
+      "threshold": 0.8,
+      "score": 0.75,
+      "justification": "Check 1 passed: Problem statement clearly describes user friction with current manual export workflow. Check 2: 1 major finding — 'efficient' used to describe processing speed without a measurable target (replace with specific latency requirement, e.g., 'processes 1000 records in under 10 seconds'). Check 3 passed: 3 acceptance criteria present with testable conditions. Check 4: 2 minor findings — 'will be processed' (specify which component processes the data), 'as appropriate' in error handling section (specify the conditions under which each error response applies). 0 blocking, 1 major, 2 minor → score = 1.0 - 0.15 - 0.10 = 0.75. Suggestion: Replace 'efficient' with a concrete performance target and clarify the 2 ambiguous phrases to reach passing threshold."
+    }
+  ]
+}
+```
+</example>
+
+<example name="error_missing_file">
+**Scenario:** The prd.md file does not exist at $CLOSEDLOOP_WORKDIR.
+
+**Analysis:** Cannot proceed with evaluation due to missing required input.
+
+```json
+{
+  "type": "case_score",
+  "case_id": "feature-completeness-judge",
+  "final_status": 3,
+  "metrics": [
+    {
+      "metric_name": "feature_completeness",
+      "threshold": 0.8,
+      "score": 0.0,
+      "justification": "Error: Unable to read prd.md from $CLOSEDLOOP_WORKDIR. File not found. Cannot evaluate Feature completeness without the Feature document."
+    }
+  ]
+}
+```
+</example>
+</examples>
+
+<thinking_guidance>
+When performing your analysis, structure your thinking as follows:
+
+```
+<thinking>
+## 1. File Reading
+- Read prd.md: [success/failure]
+- Error check: [any issues that would trigger final_status: 3]
+- Document length: [approximate word count or line count]
+- Document structure: [list of sections/headings found, if any]
+
+## 2. Check 1: Problem Statement Presence
+- Explicit problem section found?: [yes/no, section name if found]
+- Problem language detected?: [list phrases indicating problem context]
+- Assessment: [present/absent]
+- If absent: What does the document provide instead? (e.g., solution description, feature list)
+- Blocking findings: [list or "none"]
+
+## 3. Check 2: Clarity and Specificity
+- Vague qualifiers found: [list each with surrounding context]
+- Unbounded scope phrases found: [list each with surrounding context]
+- Missing specifics found: [list each with surrounding context]
+- Major findings: [count and list]
+
+## 4. Check 3: Acceptance Criteria or Success Conditions
+- AC section found?: [yes/no, section name if found]
+- Numbered/bulleted criteria found?: [yes/no, list identifiers]
+- Quantitative success metrics found?: [yes/no, list]
+- User stories with ACs found?: [yes/no, list]
+- Assessment: [present/absent]
+- Major findings: [0 or 1]
+
+## 5. Check 4: Ambiguous Language Detection
+- Passive voice hiding actors: [list phrases]
+- Conditional vagueness: [list phrases]
+- Undefined references: [list phrases]
+- Minor findings: [count, capped at 5]
+
+## 6. Score Calculation
+- blocking_count: [count]
+- major_count: [count] (Checks 2, 3)
+- minor_count: [count] (Check 4, capped at 5)
+- If blocking_count > 0: score = 0.0
+- Else: score = max(0.0, 1.0 - (0.15 * major_count) - (0.05 * minor_count)) = [calculation]
+- Final score: [value]
+- Final status: [1/2/3 with reasoning]
+
+## 7. Justification Content
+[Draft the justification string with all required elements]
+</thinking>
+```
+
+Follow this structure exactly to ensure comprehensive analysis and correct scoring.
+</thinking_guidance>

--- a/plugins/judges/agents/feature-completeness-judge.md
+++ b/plugins/judges/agents/feature-completeness-judge.md
@@ -11,9 +11,10 @@ tools: Read
 You are an expert product manager specializing in evaluating the completeness and clarity of incoming Feature requests before they are translated into implementation plans. Your expertise includes:
 
 - Detecting vague or underspecified Feature descriptions that lack actionable detail
-- Identifying missing problem statements that fail to articulate what user pain or business need the Feature addresses
+- Identifying missing problem statements that fail to articulate what user pain the Feature addresses
 - Evaluating whether acceptance criteria or success conditions are present and measurable
 - Flagging ambiguous language that would lead to divergent interpretations during implementation
+- Confirming the Feature describes either a Proposed Solution or a Desired Outcome so it is clear what is accomplished when the Feature is built
 
 Your task is to analyze a Feature document and produce a CaseScore JSON object. You do NOT rewrite the Feature — you identify and report findings that indicate the Feature is not ready for plan creation.
 </role>
@@ -27,34 +28,41 @@ Read the Feature from `$CLOSEDLOOP_WORKDIR/prd.md`. If the file is absent or unr
 
 Note: Features are stored at the standard PRD artifact path (`prd.md`) regardless of their maturity level. The document may range from a single sentence to a multi-section document.
 
-## Step 2: Apply the Four Analysis Checks
+## Step 2: Apply the Five Analysis Checks
 
 ### Check 1 — Problem Statement Presence (severity: blocking)
 
-Scan the Feature document for a clearly articulated problem statement. A problem statement must describe:
-- What user pain, friction, or unmet need exists, OR
-- What business objective or opportunity the Feature addresses
+Scan the Feature document for a clearly articulated problem statement. A problem statement must describe what user pain, friction, or unmet need exists. The problem statement must stand on its own — a pure business-opportunity framing without a real user/system problem does NOT satisfy this check (a business opportunity that doesn't solve an actual problem isn't a good opportunity).
 
-A problem statement **passes** if any of the following are present:
-- An explicit section titled "Problem", "Problem Statement", "Motivation", "Background", or "Why"
-- A paragraph or sentence that clearly states a pain point, gap, or need using language like "currently", "today", "the problem is", "users struggle with", "there is no way to", "we need"
-- A hypothesis framing (e.g., "We believe that X will solve Y")
+A problem statement **passes** if either of the following is present:
+- An explicit section titled "Problem", "Problem Statement", "Motivation", "Background", or "Why" that describes user pain, friction, or unmet need.
+- A paragraph or sentence that clearly states a pain point, gap, or need using language like "currently", "today", "the problem is", "users struggle with", "there is no way to", "we need".
 
 A problem statement **fails** (flag as **blocking**) if:
-- The document jumps directly to solution description without explaining why the Feature is needed
-- The closest approximation to a problem statement is a restatement of the solution (e.g., "We need to build X" without explaining why)
-- No identifiable problem context exists anywhere in the document
+- The document jumps directly to solution description without explaining why the Feature is needed.
+- The closest approximation to a problem statement is a restatement of the solution (e.g., "We need to build X" without explaining why).
+- The framing is purely a business opportunity / market motion with no underlying user problem articulated.
+- No identifiable problem context exists anywhere in the document.
+
+**Note on hypotheses:** A hypothesis framing (e.g., "We believe that X will solve Y") is NOT a substitute for a problem statement. It may appear as supporting material but does not on its own satisfy this check. Hypothesis content is evaluated under Check 5 (Solution Essence) when it carries a concrete outcome clause.
 
 ### Check 2 — Clarity and Specificity (severity: major)
 
 Evaluate whether the Feature description is specific enough that two independent teams would build substantially similar implementations.
 
-Scan for the following vagueness indicators and flag each occurrence as a **major** finding:
-- **Vague qualifiers**: "fast", "friendly", "seamless", "intuitive", "easy", "simple", "better", "improved", "enhanced", "nice", "good", "great", "optimal", "efficient" (case-insensitive, partial matches count, e.g., "user-friendly")
+Scan for the following vagueness indicators:
+- **Vague qualifiers**: "fast", "friendly", "seamless", "intuitive", "easy", "simple", "better", "improved", "enhanced", "nice", "good", "great", "optimal", "efficient", "slow" (case-insensitive, partial matches count, e.g., "user-friendly")
 - **Unbounded scope**: "and more", "etc.", "various", "all kinds of", "everything", "anything"
 - **Missing specifics**: References to users, systems, or behaviors without naming them (e.g., "the system should handle it appropriately" — handle what? appropriately how?)
 
-Each distinct vague qualifier or unbounded scope phrase found counts as one major finding.
+**Context-aware scoring (suppression rule):** A vague qualifier or unbounded-scope phrase does NOT count as a finding when the **same paragraph or an immediately adjacent sentence** supplies a concrete clarifier. Concrete clarifiers include:
+- A measurable target with units (e.g., "within milliseconds", "under 2s", "above 90%", "under 200ms p95", "1000 requests/sec").
+- An explicit observable behavior (e.g., "letters appear as I type them", "the export downloads automatically").
+- A bounded scope reference that names the actor, system, or state (e.g., "the export job", "the checkout cart on mobile").
+
+Example of a suppressed finding: *"The editor is really slow. Right now I type faster than the letters appear. Letters should show up within a matter of milliseconds of typing."* — "slow" is a vague qualifier, but the surrounding sentences supply both an observable behavior ("letters appear as I type") and a measurable target ("within milliseconds"), so it is a "qualified-vague" pass and does NOT generate a major finding. Note this in the justification.
+
+Each remaining distinct vague qualifier, unbounded-scope phrase, or missing-specifics reference (i.e., one without an adjacent clarifier) counts as one major finding.
 
 ### Check 3 — Acceptance Criteria or Success Conditions (severity: major)
 
@@ -79,9 +87,27 @@ Scan the entire document for language patterns that create implementation ambigu
 
 Each distinct ambiguous phrase counts as one minor finding. Cap at 5 minor findings maximum to avoid over-penalizing verbose documents.
 
+### Check 5 — Solution Essence (severity: blocking)
+
+A Feature must give some indication of what is accomplished when it is built. The document must include AT LEAST ONE of the following:
+
+- **Proposed Solution** — describes what the solution looks like when it is done. Example: *"We should put a button at the bottom of the page that says 'Save' to allow the user to save their edits."* Proposes a concrete shape for the implementation.
+- **Desired Outcome** — describes the impact of the solution on the user experience or system behavior, without prescribing the implementation. Example: *"The user must be able to leave a comment, revise a comment, and resolve a comment."* Describes what becomes true once the solution exists.
+
+It is fine for both to be present. It is NOT fine for neither to be present.
+
+This check **passes** if any of the following is found:
+- An explicit section titled "Proposed Solution", "Solution", "Approach", "Design", "Desired Outcome", "Outcome", "Goal", "Goals", "What Success Looks Like", or "Impact".
+- Unlabeled prose that clearly proposes a concrete solution shape OR describes the post-Feature user/system state.
+- A hypothesis framing ("We believe that X will produce Y") **only when the outcome clause Y is concrete and observable** (e.g., "users complete checkout in fewer steps"). A hypothesis with a vague outcome clause does NOT satisfy this check.
+
+This check **fails** (flag as **blocking**) if:
+- The document only describes the problem without giving any indication of what shape the solution takes or what changes for the user when it ships.
+- Neither a proposed solution nor a desired outcome can be identified anywhere in the document.
+
 ## Step 3: Count and Score
 
-Count blocking, major, and minor findings from all four checks. Use the counts to calculate the final score.
+Count blocking, major, and minor findings from all five checks. Use the counts to calculate the final score.
 </analysis_instructions>
 
 <output_format>
@@ -98,8 +124,8 @@ After completing your analysis in `<thinking>` tags, you MUST return a CaseScore
 Use this exact formula:
 
 ```
-blocking_count = number of blocking findings (Check 1: missing problem statement)
-major_count    = number of major findings (Checks 2, 3: vagueness, missing acceptance criteria)
+blocking_count = number of blocking findings (Check 1: missing problem statement; Check 5: missing solution essence)
+major_count    = number of major findings (Checks 2, 3: vagueness without clarifier, missing acceptance criteria)
 minor_count    = number of minor findings (Check 4: ambiguous language, capped at 5)
 
 If blocking_count > 0:
@@ -147,11 +173,12 @@ final_status = 3 (error) if Feature file missing or unreadable
 **Justification content requirements:**
 
 Your justification string MUST include:
-1. **Blocking findings** (if any): Describe the missing problem statement and what the document provides instead
-2. **Major findings** (if any): List each vague qualifier, unbounded scope phrase, or missing acceptance criteria with context
+1. **Blocking findings** (if any): Describe the missing problem statement (Check 1) and/or missing solution essence (Check 5) and what the document provides instead
+2. **Major findings** (if any): List each vague qualifier (without an adjacent clarifier), unbounded scope phrase, or missing acceptance criteria with context
 3. **Minor findings** (if any): List ambiguous phrases with suggestions for clarification
-4. **Quantitative breakdown**: Show the calculation (e.g., "1 blocking → score = 0.0" or "0 blocking, 2 major, 3 minor → score = 1.0 - 0.30 - 0.15 = 0.55")
-5. **Passing checks**: Briefly note which checks passed and why
+4. **Qualified-vague notes** (if any): For each vague qualifier suppressed by a concrete clarifier, briefly note the qualifier and the clarifier that justified suppression
+5. **Quantitative breakdown**: Show the calculation (e.g., "1 blocking → score = 0.0" or "0 blocking, 2 major, 3 minor → score = 1.0 - 0.30 - 0.15 = 0.55")
+6. **Passing checks**: Briefly note which checks passed and why
 
 **Output prefilling hint:** Begin your response with:
 ```json
@@ -162,9 +189,9 @@ Your justification string MUST include:
 
 <examples>
 <example name="pass_complete_feature">
-**Scenario:** Feature document has a clear problem statement explaining user pain, specific language describing the desired behavior, acceptance criteria with measurable outcomes, and minimal ambiguous language.
+**Scenario:** Feature document has a clear problem statement explaining user pain, specific language describing the desired behavior, acceptance criteria with measurable outcomes, a Desired Outcome section, and minimal ambiguous language.
 
-**Analysis:** All four checks pass. No blocking, major, or minor findings.
+**Analysis:** All five checks pass. No blocking, major, or minor findings.
 
 **Calculation:**
 - blocking_count: 0, major_count: 0, minor_count: 0
@@ -180,7 +207,7 @@ Your justification string MUST include:
       "metric_name": "feature_completeness",
       "threshold": 0.8,
       "score": 1.0,
-      "justification": "All four completeness checks passed. Check 1: Problem statement present — document opens with 'Users currently have no way to export reports, forcing manual data entry that takes 2+ hours per week.' Check 2: No vague qualifiers or unbounded scope phrases detected; Feature uses specific, measurable language throughout. Check 3: Acceptance criteria section present with 4 testable ACs including measurable targets (e.g., 'export completes within 30 seconds for datasets up to 10k rows'). Check 4: No ambiguous language patterns detected. 0 blocking, 0 major, 0 minor → score = 1.0."
+      "justification": "All five completeness checks passed. Check 1: Problem statement present — document opens with 'Users currently have no way to export reports, forcing manual data entry that takes 2+ hours per week.' Check 2: No vague qualifiers or unbounded scope phrases detected; Feature uses specific, measurable language throughout. Check 3: Acceptance criteria section present with 4 testable ACs including measurable targets (e.g., 'export completes within 30 seconds for datasets up to 10k rows'). Check 4: No ambiguous language patterns detected. Check 5: Desired Outcome section present — 'Analysts can export any report to CSV in one click and receive the file within 30 seconds.' 0 blocking, 0 major, 0 minor → score = 1.0."
     }
   ]
 }
@@ -188,12 +215,12 @@ Your justification string MUST include:
 </example>
 
 <example name="fail_vague_feature">
-**Scenario:** Feature document says "Build a better dashboard" with no problem statement, uses vague qualifiers ("intuitive", "seamless"), has no acceptance criteria, and contains ambiguous references.
+**Scenario:** Feature document says "Build a better dashboard" with no problem statement, uses vague qualifiers ("intuitive", "seamless"), has no acceptance criteria, contains ambiguous references, and offers no concrete proposed solution or desired outcome.
 
-**Analysis:** Check 1 fails (no problem statement — blocking). Additionally, Check 2 finds 2 vague qualifiers, Check 3 finds no acceptance criteria, and Check 4 finds 2 ambiguous phrases. However, the blocking finding already forces score to 0.0.
+**Analysis:** Check 1 fails (no problem statement — blocking). Check 5 also fails (no proposed solution or desired outcome — blocking). Additionally, Check 2 finds 2 vague qualifiers (no clarifiers nearby), Check 3 finds no acceptance criteria, and Check 4 finds 2 ambiguous phrases. The blocking findings force score to 0.0.
 
 **Calculation:**
-- blocking_count: 1 → score = 0.0
+- blocking_count: 2 → score = 0.0
 
 ```json
 {
@@ -205,7 +232,7 @@ Your justification string MUST include:
       "metric_name": "feature_completeness",
       "threshold": 0.8,
       "score": 0.0,
-      "justification": "Blocking finding detected. Check 1: No problem statement found — the document opens with 'Build a better dashboard' which is a solution statement, not a problem statement. No explanation of what user pain or business need drives this Feature. Check 2: 2 major findings — 'intuitive' (replace with specific usability criteria, e.g., 'task completion rate above 90%'), 'seamless' (replace with specific integration criteria, e.g., 'data syncs within 5 seconds'). Check 3: 1 major finding — no acceptance criteria, success metrics, or measurable outcomes defined anywhere in the document. Check 4: 2 minor findings — 'should be handled appropriately' (specify handling behavior), 'if needed' (specify conditions). 1 blocking, 3 major, 2 minor → score = 0.0 (blocking finding forces score to 0.0). Recommendations: Add a problem statement explaining the user/business need, replace vague qualifiers with measurable criteria, add explicit acceptance criteria."
+      "justification": "Blocking findings detected. Check 1: No problem statement found — the document opens with 'Build a better dashboard' which is a solution statement, not a problem statement. No explanation of what user pain drives this Feature. Check 5: No proposed solution or desired outcome — 'better dashboard' does not describe a concrete solution shape or what becomes true for the user. Check 2: 2 major findings — 'intuitive' with no nearby clarifier (replace with specific usability criteria, e.g., 'task completion rate above 90%'), 'seamless' with no nearby clarifier (replace with specific integration criteria, e.g., 'data syncs within 5 seconds'). Check 3: 1 major finding — no acceptance criteria, success metrics, or measurable outcomes defined anywhere in the document. Check 4: 2 minor findings — 'should be handled appropriately' (specify handling behavior), 'if needed' (specify conditions). 2 blocking, 3 major, 2 minor → score = 0.0 (blocking findings force score to 0.0). Recommendations: Add a problem statement explaining the user pain, add a Proposed Solution or Desired Outcome section, replace vague qualifiers with measurable criteria, add explicit acceptance criteria."
     }
   ]
 }
@@ -213,9 +240,9 @@ Your justification string MUST include:
 </example>
 
 <example name="pass_with_minor_findings">
-**Scenario:** Feature has a clear problem statement and acceptance criteria, but contains a few ambiguous phrases and one vague qualifier.
+**Scenario:** Feature has a clear problem statement, a Desired Outcome section, and acceptance criteria, but contains a few ambiguous phrases and one vague qualifier with no nearby clarifier.
 
-**Analysis:** Check 1 passes. Check 2 finds 1 vague qualifier (major). Check 3 passes. Check 4 finds 2 ambiguous phrases (minor).
+**Analysis:** Check 1 passes. Check 5 passes (Desired Outcome present). Check 2 finds 1 vague qualifier (major). Check 3 passes. Check 4 finds 2 ambiguous phrases (minor).
 
 **Calculation:**
 - blocking_count: 0, major_count: 1, minor_count: 2
@@ -231,7 +258,33 @@ Your justification string MUST include:
       "metric_name": "feature_completeness",
       "threshold": 0.8,
       "score": 0.75,
-      "justification": "Check 1 passed: Problem statement clearly describes user friction with current manual export workflow. Check 2: 1 major finding — 'efficient' used to describe processing speed without a measurable target (replace with specific latency requirement, e.g., 'processes 1000 records in under 10 seconds'). Check 3 passed: 3 acceptance criteria present with testable conditions. Check 4: 2 minor findings — 'will be processed' (specify which component processes the data), 'as appropriate' in error handling section (specify the conditions under which each error response applies). 0 blocking, 1 major, 2 minor → score = 1.0 - 0.15 - 0.10 = 0.75. Suggestion: Replace 'efficient' with a concrete performance target and clarify the 2 ambiguous phrases to reach passing threshold."
+      "justification": "Check 1 passed: Problem statement clearly describes user friction with current manual export workflow. Check 5 passed: Desired Outcome section present — 'Analysts can self-serve report exports without engineering tickets.' Check 2: 1 major finding — 'efficient' used to describe processing speed without a measurable target nor adjacent clarifier (replace with specific latency requirement, e.g., 'processes 1000 records in under 10 seconds'). Check 3 passed: 3 acceptance criteria present with testable conditions. Check 4: 2 minor findings — 'will be processed' (specify which component processes the data), 'as appropriate' in error handling section (specify the conditions under which each error response applies). 0 blocking, 1 major, 2 minor → score = 1.0 - 0.15 - 0.10 = 0.75. Suggestion: Replace 'efficient' with a concrete performance target and clarify the 2 ambiguous phrases to reach passing threshold."
+    }
+  ]
+}
+```
+</example>
+
+<example name="pass_qualified_vague">
+**Scenario:** Feature describes a slow editor: *"The editor is really slow today. I type faster than the letters appear, which makes drafting feel laggy. Letters should appear within milliseconds of each keystroke."* Document also contains a Problem Statement, a Proposed Solution describing input-event batching, and acceptance criteria.
+
+**Analysis:** Check 1 passes (problem articulated). Check 5 passes (Proposed Solution present). Check 2 contains the vague qualifier "slow" but the same paragraph supplies both an observable behavior ("letters appear as I type") and a measurable target ("within milliseconds"). Suppression rule applies — no major finding for "slow". Check 3 passes (ACs present). Check 4 finds 0 minor findings.
+
+**Calculation:**
+- blocking_count: 0, major_count: 0, minor_count: 0
+- score = 1.0 - 0 - 0 = 1.0
+
+```json
+{
+  "type": "case_score",
+  "case_id": "feature-completeness-judge",
+  "final_status": 1,
+  "metrics": [
+    {
+      "metric_name": "feature_completeness",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "All five checks passed. Check 1: Problem statement present (user pain from input lag). Check 2: 'slow' detected but suppressed by adjacent clarifier — observable behavior ('letters appear as I type') and measurable target ('within milliseconds'). Qualified-vague pass, 0 major findings from this phrase. Check 3 passed: acceptance criteria present. Check 4: no ambiguous phrases. Check 5 passed: Proposed Solution section describes input-event batching approach. 0 blocking, 0 major, 0 minor → score = 1.0."
     }
   ]
 }
@@ -281,9 +334,11 @@ When performing your analysis, structure your thinking as follows:
 
 ## 3. Check 2: Clarity and Specificity
 - Vague qualifiers found: [list each with surrounding context]
+- For each vague qualifier: adjacent clarifier present? (measurable target / observable behavior / bounded scope)
+- Suppressed (qualified-vague) qualifiers: [list with the clarifier that suppressed each]
 - Unbounded scope phrases found: [list each with surrounding context]
 - Missing specifics found: [list each with surrounding context]
-- Major findings: [count and list]
+- Major findings: [count and list — only those without an adjacent clarifier]
 
 ## 4. Check 3: Acceptance Criteria or Success Conditions
 - AC section found?: [yes/no, section name if found]
@@ -299,8 +354,16 @@ When performing your analysis, structure your thinking as follows:
 - Undefined references: [list phrases]
 - Minor findings: [count, capped at 5]
 
-## 6. Score Calculation
-- blocking_count: [count]
+## 6. Check 5: Solution Essence
+- Proposed Solution section found?: [yes/no, section name if found]
+- Desired Outcome section found?: [yes/no, section name if found]
+- Unlabeled prose proposing solution shape or post-Feature state?: [yes/no, brief quote]
+- Hypothesis with concrete outcome clause?: [yes/no, brief quote]
+- Assessment: [present/absent]
+- Blocking findings: [list or "none"]
+
+## 7. Score Calculation
+- blocking_count: [count] (Checks 1, 5)
 - major_count: [count] (Checks 2, 3)
 - minor_count: [count] (Check 4, capped at 5)
 - If blocking_count > 0: score = 0.0
@@ -308,7 +371,7 @@ When performing your analysis, structure your thinking as follows:
 - Final score: [value]
 - Final status: [1/2/3 with reasoning]
 
-## 7. Justification Content
+## 8. Justification Content
 [Draft the justification string with all required elements]
 </thinking>
 ```

--- a/plugins/judges/agents/feature-completeness-judge.md
+++ b/plugins/judges/agents/feature-completeness-judge.md
@@ -8,7 +8,7 @@ tools: Read
 # Feature Completeness Judge
 
 <role>
-You are an expert product analyst specializing in evaluating the completeness and clarity of incoming Feature requests before they are translated into implementation plans. Your expertise includes:
+You are an expert product manager specializing in evaluating the completeness and clarity of incoming Feature requests before they are translated into implementation plans. Your expertise includes:
 
 - Detecting vague or underspecified Feature descriptions that lack actionable detail
 - Identifying missing problem statements that fail to articulate what user pain or business need the Feature addresses

--- a/plugins/judges/agents/feature-completeness-judge.md
+++ b/plugins/judges/agents/feature-completeness-judge.md
@@ -97,7 +97,7 @@ A Feature must give some indication of what is accomplished when it is built. Th
 It is fine for both to be present. It is NOT fine for neither to be present.
 
 This check **passes** if any of the following is found:
-- An explicit section titled "Proposed Solution", "Solution", "Approach", "Design", "Desired Outcome", "Outcome", "Goal", "Goals", "What Success Looks Like", or "Impact".
+- An explicit section titled "Proposed Solution", "Solution", "Approach", "Design", "Desired Outcome", "Outcome", "Goals", or "Impact".
 - Unlabeled prose that clearly proposes a concrete solution shape OR describes the post-Feature user/system state.
 - A hypothesis framing ("We believe that X will produce Y") **only when the outcome clause Y is concrete and observable** (e.g., "users complete checkout in fewer steps"). A hypothesis with a vague outcome clause does NOT satisfy this check.
 

--- a/plugins/judges/skills/run-judges/SKILL.md
+++ b/plugins/judges/skills/run-judges/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-judges
-description: Orchestrate parallel judge agent execution, aggregate CaseScore results, write plan-judges.json, code-judges.json, or prd-judges.json, and validate output. Supports evaluating implementation plans (16 judges), code artifacts (11 judges), or PRD artifacts (5 judges) via --artifact-type parameter.
+description: Orchestrate parallel judge agent execution, aggregate CaseScore results, write plan-judges.json, code-judges.json, or prd-judges.json, and validate output. Supports evaluating implementation plans (16 judges, 4 batches), code artifacts (11 judges, 3 batches), or PRD artifacts (5 judges, 2 batches) via --artifact-type parameter.
 context: fork
 ---
 
@@ -8,7 +8,7 @@ context: fork
 
 ## Purpose
 
-Execute specialized judge agents in parallel to evaluate implementation plan quality (16 judges), code quality (11 judges), or PRD quality (5 judges). Aggregates results into `$CLOSEDLOOP_WORKDIR/plan-judges.json` (plan), `$CLOSEDLOOP_WORKDIR/code-judges.json` (code), or `$CLOSEDLOOP_WORKDIR/prd-judges.json` (prd) with validated output format.
+Execute specialized judge agents in parallel to evaluate implementation plan quality (16 judges, 4 batches), code quality (11 judges, 3 batches), or PRD quality (5 judges, 2 batches). All batches respect the Task tool's 4-concurrent-agent limit. Aggregates results into `$CLOSEDLOOP_WORKDIR/plan-judges.json` (plan), `$CLOSEDLOOP_WORKDIR/code-judges.json` (code), or `$CLOSEDLOOP_WORKDIR/prd-judges.json` (prd) with validated output format.
 
 ## Parameters
 
@@ -22,7 +22,7 @@ Execute specialized judge agents in parallel to evaluate implementation plan qua
 
 - **plan** (default): Evaluate implementation plan with 16 judges, 4 batches, output to plan-judges.json
 - **code**: Evaluate implemented code with 11 judges, 3 batches, output to code-judges.json
-- **prd**: Evaluate PRD document with 5 judges, single parallel batch, output to prd-judges.json
+- **prd**: Evaluate PRD document with 5 judges across 2 sequential batches (3 + 2, max 4 concurrent per batch), output to prd-judges.json
 
 ## Judge Input Contract (`judge-input.json`)
 
@@ -55,7 +55,7 @@ You are orchestrating quality evaluation for a ClosedLoop artifact (implementati
 **For PRD artifacts (--artifact-type prd):**
 1. Check `$CLOSEDLOOP_WORKDIR/prd.md` exists (graceful exit if missing)
 2. Build `judge-input.json` with evaluation_type: "prd" and primary_artifact pointing to prd.md
-3. Launch all 5 PRD judges in a single parallel batch
+3. Launch the 5 PRD judges in 2 sequential batches (3 + 2, max 4 concurrent per batch)
 4. Aggregate all 5 CaseScores into a valid EvaluationReport
 5. Write the report to `$CLOSEDLOOP_WORKDIR/prd-judges.json`
 6. Validate output structure and completeness
@@ -179,9 +179,9 @@ Use `sub_step` as numeric phase order and optional `sub_step_name` to capture th
 | code     | 4        | aggregate       |
 | code     | 5        | validate        |
 | prd      | 0        | context_prep (skipped — prd mode does not use context-manager-for-judges) |
-| prd      | 1        | prd_judges      |
-| prd      | 2        | aggregate       |
-| prd      | 3        | validate        |
+| prd      | 1–2      | batch_1, batch_2 |
+| prd      | 3        | aggregate       |
+| prd      | 4        | validate        |
 
 **Start of phase (run Bash once at the beginning of each phase):** Set the two sub-step variables at the top for the current phase, then run the block. It writes start time to a temp file so the end-of-phase Bash can compute duration. `CLOSEDLOOP_PARENT_STEP` and `CLOSEDLOOP_PARENT_STEP_NAME` are already in the environment (set by run-loop on the `claude` invocation).
 
@@ -410,7 +410,7 @@ fi
 **PRD context prep notes:**
 - Missing `prd.md` results in a WARNING and graceful exit (code 0), not an error
 - No context manager is launched; `judge-input.json` is built directly with `primary_artifact` pointing to `$CLOSEDLOOP_WORKDIR/prd.md`
-- Performance: emit sub_step=0 (context_prep, skipped=true) perf event immediately, then proceed to sub_step=1 (prd_judges)
+- Performance: emit sub_step=0 (context_prep, skipped=true) perf event immediately, then proceed to sub_step=1 (batch_1) and sub_step=2 (batch_2)
 
 **If required files are missing:**
 - Plan mode: Exit gracefully with code 0 (do not fail parent workflow)
@@ -455,8 +455,8 @@ The run-judges skill supports three artifact types with different judge configur
 - `judges:test-judge`
 
 ### PRD Artifacts (--artifact-type prd)
-- **Judges**: 5 total (parallel batch)
-- **Execution**: single parallel batch
+- **Judges**: 5 total
+- **Batches**: 2 sequential batches (max 4 concurrent per batch)
 - **Output**: `prd-judges.json`
 - **Report ID**: `{RUN_ID}-prd-judges`
 - **Validation**: `--category prd` (5 judges expected)
@@ -464,18 +464,20 @@ The run-judges skill supports three artifact types with different judge configur
 
 **PRD Execution:**
 
-**Batch 1: All PRD Judges (sub_step=1)**
+**Batch 1: Structure & Completeness (sub_step=1)**
 - `judges:feature-completeness-judge` — evaluates Feature request completeness and clarity
 - `judges:prd-auditor` — structural completeness audit of the PRD
+- `judges:prd-scope-judge` — evaluates scope definition and boundary clarity
+
+**Batch 2: Quality Gates (sub_step=2)**
 - `judges:prd-dependency-judge` — evaluates dependency clarity and completeness
 - `judges:prd-testability-judge` — evaluates requirement testability
-- `judges:prd-scope-judge` — evaluates scope definition and boundary clarity
 
 ---
 
 ### Step 1: Launch Judge Agents in Parallel
 
-**Performance:** For each batch/phase, run "start of phase" Bash before launching the batch and "end of phase" Bash after the batch completes. Plan: batch_1=sub_step 1, batch_2=sub_step 2, batch_3=sub_step 3, batch_4=sub_step 4. Code: batch_1=sub_step 1, batch_2=sub_step 2, batch_3=sub_step 3. PRD: prd_judges=sub_step 1.
+**Performance:** For each batch/phase, run "start of phase" Bash before launching the batch and "end of phase" Bash after the batch completes. Plan: batch_1=sub_step 1, batch_2=sub_step 2, batch_3=sub_step 3, batch_4=sub_step 4. Code: batch_1=sub_step 1, batch_2=sub_step 2, batch_3=sub_step 3. PRD: batch_1=sub_step 1, batch_2=sub_step 2.
 
 **Constraint:** The Task tool supports maximum 4 concurrent agents per batch.
 
@@ -521,17 +523,22 @@ The run-judges skill supports three artifact types with different judge configur
 | `judges:codebase-grounding-judge` | File-path/module-reference accuracy and existing-code awareness grounded in investigation findings |
 | `judges:convention-adherence-judge` | Alignment with established naming, structural, and tooling conventions in the codebase |
 
-### PRD Artifact Judge Batch (5 judges, single parallel batch)
+### PRD Artifact Judge Batches (5 judges, 2 batches)
 
-**Batch 1: All PRD Judges (sub_step=1)**
+**Batch 1: Structure & Completeness (sub_step=1)**
 
 | Agent Type | Evaluates |
 |------------|-----------|
 | `judges:feature-completeness-judge` | Feature request completeness and clarity |
 | `judges:prd-auditor` | Structural completeness, section coverage, clarity |
+| `judges:prd-scope-judge` | Scope definition and boundary clarity |
+
+**Batch 2: Quality Gates (sub_step=2)**
+
+| Agent Type | Evaluates |
+|------------|-----------|
 | `judges:prd-dependency-judge` | Dependency clarity and completeness |
 | `judges:prd-testability-judge` | Requirement testability and measurability |
-| `judges:prd-scope-judge` | Scope definition and boundary clarity |
 
 </judge_batches>
 
@@ -659,7 +666,7 @@ Each judge returns a **CaseScore** JSON object:
 
 ### Step 2: Aggregate Results into EvaluationReport
 
-**Performance:** Run "start of phase" with sub_step 5 (plan), 4 (code), or 2 (prd), sub_step_name=aggregate. Emit 'end of phase' after the aggregation step regardless of file write outcome.
+**Performance:** Run "start of phase" with sub_step 5 (plan), 4 (code), or 3 (prd), sub_step_name=aggregate. Emit 'end of phase' after the aggregation step regardless of file write outcome.
 
 **Task:** Collect all CaseScore outputs and structure them into an `EvaluationReport`.
 
@@ -755,7 +762,7 @@ output_path = $CLOSEDLOOP_WORKDIR / report_filename
 
 ### Step 3: Validate Output (MANDATORY)
 
-**Performance:** Run "start of phase" with sub_step 6 (plan), 5 (code), or 3 (prd), sub_step_name=validate. Emit 'end of phase' after each validation attempt regardless of exit code, then apply failure recovery logic.
+**Performance:** Run "start of phase" with sub_step 6 (plan), 5 (code), or 4 (prd), sub_step_name=validate. Emit 'end of phase' after each validation attempt regardless of exit code, then apply failure recovery logic.
 
 **CRITICAL:** You MUST run the validation script after writing the judge report. Do not consider the task complete until validation passes.
 
@@ -866,7 +873,7 @@ prd-testability-judge
 prd-scope-judge
 ```
 
-**Note:** All 5 PRD judges run in a single parallel batch.
+**Note:** PRD judges run in 2 sequential batches (3 + 2) to respect the Task tool's 4-concurrent-agent limit.
 
 </validation_checks>
 
@@ -968,11 +975,11 @@ Before marking this task complete, verify:
 - [ ] **prd.md existence check** - `$CLOSEDLOOP_WORKDIR/prd.md` found, or graceful exit with WARNING (code 0)
 - [ ] **No context manager** - context-manager-for-judges is NOT launched for prd mode
 - [ ] **Judge input contract** - `judge-input.json` written with `evaluation_type="prd"` and `primary_artifact=$CLOSEDLOOP_WORKDIR/prd.md`
-- [ ] **Parallel execution** - All 5 PRD judges launched in a single parallel batch (sub_step=1)
-- [ ] **Result aggregation** - Valid EvaluationReport with 5 CaseScore entries (sub_step=2)
+- [ ] **Parallel execution** - 5 PRD judges launched in 2 sequential batches: batch_1 (sub_step=1, 3 judges) and batch_2 (sub_step=2, 2 judges), max 4 concurrent per batch
+- [ ] **Result aggregation** - Valid EvaluationReport with 5 CaseScore entries (sub_step=3)
 - [ ] **File output** - `prd-judges.json` written to `$CLOSEDLOOP_WORKDIR`
 - [ ] **Report ID format** - report_id ends with '-prd-judges'
-- [ ] **Validation passed** - Script exits with code 0 using `--category prd` (sub_step=3)
+- [ ] **Validation passed** - Script exits with code 0 using `--category prd` (sub_step=4)
 
 </completion_criteria>
 
@@ -986,7 +993,7 @@ Before marking this task complete, verify:
 |---------------|------------|----------|
 | "Report file does not exist" | File not written to correct location | Verify `$CLOSEDLOOP_WORKDIR` is set; check write path matches artifact type (plan-judges.json, code-judges.json, or prd-judges.json) |
 | "Invalid JSON" | Syntax error in output file | Run `python3 -m json.tool "$CLOSEDLOOP_WORKDIR/{plan,code,prd}-judges.json"` to identify syntax error |
-| "Missing expected judges" | Incomplete batch execution | Verify all batches launched (4 for plan, 3 for code, 1 for prd); check error CaseScores for failures; plan expects 16 judges, code expects 11, prd expects 5 |
+| "Missing expected judges" | Incomplete batch execution | Verify all batches launched (4 for plan, 3 for code, 2 for prd); check error CaseScores for failures; plan expects 16 judges, code expects 11, prd expects 5 |
 | "final_status must be 1, 2, or 3" | Invalid status code | Use only: 1 (pass), 2 (fail), 3 (error) |
 | "report_id should end with '-plan-judges'" | Incorrect ID format for plan | Use pattern: `{RUN_ID}-plan-judges` for plan artifacts |
 | "report_id should end with '-code-judges'" | Incorrect ID format for code | Use pattern: `{RUN_ID}-code-judges` for code artifacts |
@@ -1058,8 +1065,8 @@ When `--artifact-type prd` is specified:
 - Check `$CLOSEDLOOP_WORKDIR/prd.md` exists; emit WARNING and exit gracefully (code 0) if missing
 - Do NOT launch context-manager-for-judges
 - Build `judge-input.json` with `evaluation_type="prd"` and `primary_artifact=$CLOSEDLOOP_WORKDIR/prd.md`
-- Launch all 5 PRD judges in a single parallel batch (sub_step=1)
-- Aggregate all 5 CaseScores (sub_step=2) and write to `prd-judges.json`
-- Validate with `--category prd` (sub_step=3)
+- Launch the 5 PRD judges in 2 sequential batches (sub_step=1: feature-completeness-judge + prd-auditor + prd-scope-judge; sub_step=2: prd-dependency-judge + prd-testability-judge) to respect the 4-concurrent-agent Task limit
+- Aggregate all 5 CaseScores (sub_step=3) and write to `prd-judges.json`
+- Validate with `--category prd` (sub_step=4)
 
 ---

--- a/plugins/judges/skills/run-judges/SKILL.md
+++ b/plugins/judges/skills/run-judges/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-judges
-description: Orchestrate parallel judge agent execution, aggregate CaseScore results, write plan-judges.json, code-judges.json, or prd-judges.json, and validate output. Supports evaluating implementation plans (16 judges), code artifacts (11 judges), or PRD artifacts (4 judges) via --artifact-type parameter.
+description: Orchestrate parallel judge agent execution, aggregate CaseScore results, write plan-judges.json, code-judges.json, or prd-judges.json, and validate output. Supports evaluating implementation plans (16 judges), code artifacts (11 judges), or PRD artifacts (5 judges) via --artifact-type parameter.
 context: fork
 ---
 
@@ -8,7 +8,7 @@ context: fork
 
 ## Purpose
 
-Execute specialized judge agents in parallel to evaluate implementation plan quality (16 judges), code quality (11 judges), or PRD quality (4 judges). Aggregates results into `$CLOSEDLOOP_WORKDIR/plan-judges.json` (plan), `$CLOSEDLOOP_WORKDIR/code-judges.json` (code), or `$CLOSEDLOOP_WORKDIR/prd-judges.json` (prd) with validated output format.
+Execute specialized judge agents in parallel to evaluate implementation plan quality (16 judges), code quality (11 judges), or PRD quality (5 judges). Aggregates results into `$CLOSEDLOOP_WORKDIR/plan-judges.json` (plan), `$CLOSEDLOOP_WORKDIR/code-judges.json` (code), or `$CLOSEDLOOP_WORKDIR/prd-judges.json` (prd) with validated output format.
 
 ## Parameters
 
@@ -22,7 +22,7 @@ Execute specialized judge agents in parallel to evaluate implementation plan qua
 
 - **plan** (default): Evaluate implementation plan with 16 judges, 4 batches, output to plan-judges.json
 - **code**: Evaluate implemented code with 11 judges, 3 batches, output to code-judges.json
-- **prd**: Evaluate PRD document with 4 judges, single parallel batch, output to prd-judges.json
+- **prd**: Evaluate PRD document with 5 judges, single parallel batch, output to prd-judges.json
 
 ## Judge Input Contract (`judge-input.json`)
 
@@ -55,8 +55,8 @@ You are orchestrating quality evaluation for a ClosedLoop artifact (implementati
 **For PRD artifacts (--artifact-type prd):**
 1. Check `$CLOSEDLOOP_WORKDIR/prd.md` exists (graceful exit if missing)
 2. Build `judge-input.json` with evaluation_type: "prd" and primary_artifact pointing to prd.md
-3. Launch all 4 PRD judges in a single parallel batch
-4. Aggregate all 4 CaseScores into a valid EvaluationReport
+3. Launch all 5 PRD judges in a single parallel batch
+4. Aggregate all 5 CaseScores into a valid EvaluationReport
 5. Write the report to `$CLOSEDLOOP_WORKDIR/prd-judges.json`
 6. Validate output structure and completeness
 
@@ -401,7 +401,7 @@ fi
 
 # Build prd-mode judge-input.json
 # - evaluation_type: "prd"
-# - task: PRD quality evaluation objective (prd-auditor + 3 critics)
+# - task: PRD quality evaluation objective (prd-auditor + 4 critics)
 # - primary_artifact: $CLOSEDLOOP_WORKDIR/prd.md
 # - supporting_artifacts: [] (none required)
 # - source_of_truth: ["prd"]
@@ -455,16 +455,17 @@ The run-judges skill supports three artifact types with different judge configur
 - `judges:test-judge`
 
 ### PRD Artifacts (--artifact-type prd)
-- **Judges**: 4 total (parallel batch)
+- **Judges**: 5 total (parallel batch)
 - **Execution**: single parallel batch
 - **Output**: `prd-judges.json`
 - **Report ID**: `{RUN_ID}-prd-judges`
-- **Validation**: `--category prd` (4 judges expected)
+- **Validation**: `--category prd` (5 judges expected)
 - **Canonical input**: `$CLOSEDLOOP_WORKDIR/prd.md`
 
 **PRD Execution:**
 
 **Batch 1: All PRD Judges (sub_step=1)**
+- `judges:feature-completeness-judge` — evaluates Feature request completeness and clarity
 - `judges:prd-auditor` — structural completeness audit of the PRD
 - `judges:prd-dependency-judge` — evaluates dependency clarity and completeness
 - `judges:prd-testability-judge` — evaluates requirement testability
@@ -520,12 +521,13 @@ The run-judges skill supports three artifact types with different judge configur
 | `judges:codebase-grounding-judge` | File-path/module-reference accuracy and existing-code awareness grounded in investigation findings |
 | `judges:convention-adherence-judge` | Alignment with established naming, structural, and tooling conventions in the codebase |
 
-### PRD Artifact Judge Batch (4 judges, single parallel batch)
+### PRD Artifact Judge Batch (5 judges, single parallel batch)
 
 **Batch 1: All PRD Judges (sub_step=1)**
 
 | Agent Type | Evaluates |
 |------------|-----------|
+| `judges:feature-completeness-judge` | Feature request completeness and clarity |
 | `judges:prd-auditor` | Structural completeness, section coverage, clarity |
 | `judges:prd-dependency-judge` | Dependency clarity and completeness |
 | `judges:prd-testability-judge` | Requirement testability and measurability |
@@ -648,7 +650,7 @@ Each judge returns a **CaseScore** JSON object:
 
 **Continue-on-failure semantics:**
 - Even if ALL judges fail, you MUST aggregate error CaseScores
-- Always produce a complete report with 16 CaseScore entries (plan), 11 CaseScore entries (code), or 4 CaseScore entries (prd)
+- Always produce a complete report with 16 CaseScore entries (plan), 11 CaseScore entries (code), or 5 CaseScore entries (prd)
 - Never abort the workflow due to judge failures
 
 </error_handling>
@@ -730,6 +732,7 @@ output_path = $CLOSEDLOOP_WORKDIR / report_filename
   "report_id": "{RUN_ID}-prd-judges",
   "timestamp": "2024-02-03T15:45:30Z",
   "stats": [
+    { /* CaseScore from feature-completeness-judge */ },
     { /* CaseScore from prd-auditor */ },
     { /* CaseScore from prd-dependency-judge */ },
     { /* CaseScore from prd-testability-judge */ },
@@ -744,7 +747,7 @@ output_path = $CLOSEDLOOP_WORKDIR / report_filename
 |-------|--------|---------------|
 | `report_id` | `{RUN_ID}-plan-judges`, `{RUN_ID}-code-judges`, or `{RUN_ID}-prd-judges` | Extract RUN_ID from `$CLOSEDLOOP_WORKDIR` directory name, append suffix based on artifact type |
 | `timestamp` | ISO 8601 | Generate with `date -u +%Y-%m-%dT%H:%M:%SZ` |
-| `stats` | Array[CaseScore] | 16 CaseScore objects for plan, 11 for code, 4 for prd (one per judge) |
+| `stats` | Array[CaseScore] | 16 CaseScore objects for plan, 11 for code, 5 for prd (one per judge) |
 
 </output_structure>
 
@@ -795,7 +798,7 @@ uv run "$SCRIPT_PATH" --workdir "$CLOSEDLOOP_WORKDIR" --category "$CATEGORY"
 
 **Argument requirements:**
 - `--workdir` must be the **absolute path** to `$CLOSEDLOOP_WORKDIR`
-- `--category` must be `plan` (16 judges), `code` (11 judges), or `prd` (4 judges)
+- `--category` must be `plan` (16 judges), `code` (11 judges), or `prd` (5 judges)
 - This is where `plan-judges.json`, `code-judges.json`, or `prd-judges.json` is located
 
 </validation_workflow>
@@ -812,7 +815,7 @@ The script validates using strict Pydantic models:
 |-------|-------------|
 | **JSON syntax** | Valid JSON format |
 | **Required fields** | report_id, timestamp, stats array |
-| **Judge coverage** | All expected judges present (16 for plan, 11 for code, 4 for prd) |
+| **Judge coverage** | All expected judges present (16 for plan, 11 for code, 5 for prd) |
 | **Status values** | final_status ∈ {1, 2, 3} |
 | **Metric completeness** | Each judge has ≥1 metric |
 | **Report ID format** | Ends with '-judges' (plan), '-code-judges' (code), or '-prd-judges' (prd) |
@@ -854,15 +857,16 @@ test-judge
 
 **Note:** Code artifacts exclude: goal-alignment-judge, verbosity-judge
 
-**Expected judge case_ids for PRD artifacts (4 total):**
+**Expected judge case_ids for PRD artifacts (5 total):**
 ```
+feature-completeness-judge
 prd-auditor
 prd-dependency-judge
 prd-testability-judge
 prd-scope-judge
 ```
 
-**Note:** All 4 PRD judges run in a single parallel batch.
+**Note:** All 5 PRD judges run in a single parallel batch.
 
 </validation_checks>
 
@@ -964,8 +968,8 @@ Before marking this task complete, verify:
 - [ ] **prd.md existence check** - `$CLOSEDLOOP_WORKDIR/prd.md` found, or graceful exit with WARNING (code 0)
 - [ ] **No context manager** - context-manager-for-judges is NOT launched for prd mode
 - [ ] **Judge input contract** - `judge-input.json` written with `evaluation_type="prd"` and `primary_artifact=$CLOSEDLOOP_WORKDIR/prd.md`
-- [ ] **Parallel execution** - All 4 PRD judges launched in a single parallel batch (sub_step=1)
-- [ ] **Result aggregation** - Valid EvaluationReport with 4 CaseScore entries (sub_step=2)
+- [ ] **Parallel execution** - All 5 PRD judges launched in a single parallel batch (sub_step=1)
+- [ ] **Result aggregation** - Valid EvaluationReport with 5 CaseScore entries (sub_step=2)
 - [ ] **File output** - `prd-judges.json` written to `$CLOSEDLOOP_WORKDIR`
 - [ ] **Report ID format** - report_id ends with '-prd-judges'
 - [ ] **Validation passed** - Script exits with code 0 using `--category prd` (sub_step=3)
@@ -982,7 +986,7 @@ Before marking this task complete, verify:
 |---------------|------------|----------|
 | "Report file does not exist" | File not written to correct location | Verify `$CLOSEDLOOP_WORKDIR` is set; check write path matches artifact type (plan-judges.json, code-judges.json, or prd-judges.json) |
 | "Invalid JSON" | Syntax error in output file | Run `python3 -m json.tool "$CLOSEDLOOP_WORKDIR/{plan,code,prd}-judges.json"` to identify syntax error |
-| "Missing expected judges" | Incomplete batch execution | Verify all batches launched (4 for plan, 3 for code, 1 for prd); check error CaseScores for failures; plan expects 16 judges, code expects 11, prd expects 4 |
+| "Missing expected judges" | Incomplete batch execution | Verify all batches launched (4 for plan, 3 for code, 1 for prd); check error CaseScores for failures; plan expects 16 judges, code expects 11, prd expects 5 |
 | "final_status must be 1, 2, or 3" | Invalid status code | Use only: 1 (pass), 2 (fail), 3 (error) |
 | "report_id should end with '-plan-judges'" | Incorrect ID format for plan | Use pattern: `{RUN_ID}-plan-judges` for plan artifacts |
 | "report_id should end with '-code-judges'" | Incorrect ID format for code | Use pattern: `{RUN_ID}-code-judges` for code artifacts |
@@ -1054,8 +1058,8 @@ When `--artifact-type prd` is specified:
 - Check `$CLOSEDLOOP_WORKDIR/prd.md` exists; emit WARNING and exit gracefully (code 0) if missing
 - Do NOT launch context-manager-for-judges
 - Build `judge-input.json` with `evaluation_type="prd"` and `primary_artifact=$CLOSEDLOOP_WORKDIR/prd.md`
-- Launch all 4 PRD judges in a single parallel batch (sub_step=1)
-- Aggregate all 4 CaseScores (sub_step=2) and write to `prd-judges.json`
+- Launch all 5 PRD judges in a single parallel batch (sub_step=1)
+- Aggregate all 5 CaseScores (sub_step=2) and write to `prd-judges.json`
 - Validate with `--category prd` (sub_step=3)
 
 ---

--- a/plugins/judges/skills/run-judges/scripts/test_validate_judge_report.py
+++ b/plugins/judges/skills/run-judges/scripts/test_validate_judge_report.py
@@ -105,7 +105,7 @@ class TestBackwardCompatibility:
 
     def test_default_category_plan(self, tmp_path: Path) -> None:
         """Verify omitting --category defaults to plan validation."""
-        # This is the same as test_no_category_flag_validates_15_judges but more explicit
+        # This is the same as test_no_category_flag_validates_16_judges but more explicit
         plan_judges = sorted(JUDGE_REGISTRY["plan"])
         report = create_evaluation_report("run-20250211-judges", plan_judges)
 
@@ -601,12 +601,12 @@ class TestIntegration:
 
 
 class TestCategoryPrdValidation:
-    """Tests for the new prd category with 4 judges."""
+    """Tests for the prd category with 5 judges."""
 
-    def test_accepts_valid_4_judge_report(self, tmp_path: Path) -> None:
-        """Valid 4-judge prd report passes validation."""
+    def test_accepts_valid_5_judge_report(self, tmp_path: Path) -> None:
+        """Valid 5-judge prd report passes validation."""
         prd_judges = sorted(JUDGE_REGISTRY["prd"])
-        assert len(prd_judges) == 4, "PRD judges count should be 4"
+        assert len(prd_judges) == 5, "PRD judges count should be 5"
 
         report = create_evaluation_report("run-20250211-prd-judges", prd_judges)
 
@@ -615,11 +615,12 @@ class TestCategoryPrdValidation:
 
         valid, message = validate_report(report_path, category="prd")
         assert valid is True, f"Expected valid prd report, got: {message}"
-        assert "4 judge results" in message
+        assert "5 judge results" in message
 
     def test_prd_registry_contains_expected_judges(self) -> None:
-        """Verify prd JUDGE_REGISTRY contains the 4 expected PRD judges."""
+        """Verify prd JUDGE_REGISTRY contains the 5 expected PRD judges."""
         expected = {
+            "feature-completeness-judge",
             "prd-auditor",
             "prd-dependency-judge",
             "prd-testability-judge",
@@ -689,7 +690,7 @@ class TestCategoryPrdValidation:
         partial_judges = [
             j for j in sorted(JUDGE_REGISTRY["prd"]) if j != "prd-scope-judge"
         ]
-        assert len(partial_judges) == 3
+        assert len(partial_judges) == 4
 
         report = create_evaluation_report("run-20250211-prd-judges", partial_judges)
 
@@ -716,7 +717,7 @@ class TestCategoryPrdValidation:
         assert "category 'prd'" in message
 
     def test_prd_report_extra_judge_passes(self, tmp_path: Path) -> None:
-        """PRD report with extra judges beyond the required 4 still passes."""
+        """PRD report with extra judges beyond the required 5 still passes."""
         prd_judges = sorted(JUDGE_REGISTRY["prd"])
         extra_judges = prd_judges + ["extra-custom-judge"]
 

--- a/plugins/judges/skills/run-judges/scripts/validate_judge_report.py
+++ b/plugins/judges/skills/run-judges/scripts/validate_judge_report.py
@@ -95,6 +95,7 @@ JUDGE_REGISTRY: dict[str, set[str]] = {
         "test-judge",
     },
     "prd": {
+        "feature-completeness-judge",
         "prd-auditor",
         "prd-dependency-judge",
         "prd-testability-judge",

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

Adds a new `feature-completeness-judge` to the `judges` plugin and wires it into the `run-judges` skill's PRD evaluation flow.

The new judge is an expert product analyst that evaluates incoming Feature/PRD requests for readiness *before* a plan is created. It detects:

- Vague or underspecified Feature descriptions lacking actionable detail
- Missing problem statements that fail to articulate user pain or business need
- Missing or non-measurable acceptance criteria
- Ambiguous language that would lead to divergent interpretations during implementation

## Changes

- **New agent**: `plugins/judges/agents/feature-completeness-judge.md` — sonnet-based judge that reads `$CLOSEDLOOP_WORKDIR/prd.md` and emits a CaseScore.
- **`run-judges` skill (`SKILL.md`)**: PRD artifact mode now runs **5 judges** (was 4) in a single parallel batch. All judge-count references, batch tables, output structure docs, error-handling guidance, and verification checklists updated from `4` → `5`.
- **Validator (`validate_judge_report.py`)**: `JUDGE_REGISTRY["prd"]` now includes `feature-completeness-judge`.
- **Validator tests (`test_validate_judge_report.py`)**: Test names, assertions, and partial-coverage counts updated to expect 5 PRD judges.
- **Plugin version**: `judges` bumped `1.5.1` → `1.6.0` (MINOR — new agent added).
- **`uv.lock`**: New lockfile committed.

## Test plan

- [x] `python3 -m json.tool plugins/judges/.claude-plugin/plugin.json` — valid JSON
- [ ] `pytest plugins/judges/skills/run-judges/scripts/test_validate_judge_report.py` — all PRD validator tests pass with 5 judges
- [ ] `ruff check plugins/judges/`
- [ ] `pyright plugins/judges/`
- [ ] End-to-end: run `run-judges --artifact-type prd` and confirm `prd-judges.json` contains 5 CaseScore entries

---
Loop ID: 019dd9dc-6d5b-76db-b53f-a24daa6f4b6a
Artifact: https://app.closedloop.ai/implementation-plans/PLN-402
