### PR TITLE
PLN-376: wire decision-table into pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code v1.10.0
+
+#### Added
+- New `decision-table` skill for generating code-grounded decision-table artifacts that map current vs. intended control-flow behavior, capturing recovery, retry, finalization, validation, and state-machine edge cases under `.closedloop-ai/decision-tables/`. Includes baseline/target table rules, behavioral edge-case expansion guidance (call-site inventory for shared surfaces, exception scope, serverless async side effects, testable invariants), post-implementation verification sections, contract-heavy review checklist, and a referenced artifact format template at `references/artifact-format.md`.
+- New `behavior-verifier` agent that activates the `decision-table` skill in verification-only mode (SKILL.md step 17), reads final code against the artifact's Intended Change rows, appends Verification Findings and Final Alignment Status, and emits a structured `ALIGNED` or `MISALIGNED` verdict with a typed `<drift_rows>` JSON block (`code_drift`, `test_drift`, `plan_ambiguity`) for orchestrator routing. Read-and-report only — never modifies code or tests.
+- Optional `decisionTable` property on the plan schema (`path` + `status` enum: `pending|aligned|aligned_with_clarifications|verification_failed`) so the orchestrator can persist artifact pointers and verification state across iterations.
+- Phase 5.5 Behavioral Verification loop in the orchestrator prompt with a 5-attempt cap, drift routing by kind (`code_drift` → `implementation-subagent`, `test_drift` → `test-engineer`, `plan_ambiguity` → haiku append), parse-failure circuit breaker, and per-run telemetry emit to `.closedloop-ai/decision-table-verifications.jsonl` (timestamp, final status, iteration count, drift counts, parse failures, phase duration).
+- `startSha` state-tracking field initialized once per run from `CLOSEDLOOP_START_SHA` in `config.env` and propagated on every `state.json` write so Phase 5.5 can scope the changed-file set without re-reading config.
+
+#### Changed
+- `plan-writer` Finalize Mode now generates the decision-table artifact via a snapshot/set-difference algorithm (mkdir → ls before → activate `decision-table` skill → comm -13 to compute new files) and writes `decisionTable.path` + `status: "pending"` into `plan.json`. Skips when `plan_was_imported=true` or `simple_mode=true`. Emits `DECISION_TABLE_ARTIFACT_COUNT_MISMATCH` and withholds `PLAN_WRITER_COMPLETE` when 0 or >1 new artifact files appear, delegating the hard stop to the orchestrator rather than guessing.
+- `plan-writer` Completion section adds a decision-table gate that re-verifies `plan.json.decisionTable.path` is non-empty and the artifact file is non-zero bytes before emitting `PLAN_WRITER_COMPLETE`.
+- `plan-validate` skill now validates the optional `decisionTable` shape and surfaces `decision_table_path` and `decision_table_status` in the `extract_data` output (always present; empty strings when the field is absent), so the orchestrator can read both values without touching the filesystem. PLAN_VALID example in `SKILL.md` updated.
+- Phase 2.7 in the orchestrator prompt now passes `plan_was_imported` and `simple_mode` flags through to `plan-writer` and inspects the launch output for `DECISION_TABLE_ARTIFACT_COUNT_MISMATCH`. On marker present: executes AWAITING_USER_SEQUENCE pointing at `.closedloop-ai/decision-tables/` and HARD STOPS, treating the marker as authoritative even if `PLAN_WRITER_COMPLETE` was also emitted.
+- Phase 7 completion summary now reads `decision_table_status` from the latest `plan-validate` output and logs `Behavioral alignment verified` (or `…with plan clarifications`) referencing the artifact path.
+- `loop-agents.json`: registered `code:behavior-verifier` (max 3 iterations, promise `BEHAVIOR_VERIFIER_COMPLETE`, ALIGNED/MISALIGNED criteria with required `<drift_rows>` fields and `kind` enum); extended `code:plan-writer` `verification_criteria` so `DECISION_TABLE_ARTIFACT_COUNT_MISMATCH` is a legitimate detection state, not a loop failure. `code:behavior-verifier` added to `learning_agents.agents` for capture coverage.
+- Available Skills table in the orchestrator prompt now lists `code:decision-table` with usage in Phase 2.7 (generation via plan-writer) and Phase 5.5 (verification-only via behavior-verifier).
+
 ### code v1.9.4
 
 #### Fixed
@@ -18,6 +36,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Orchestrator Phase 6 INCOMPLETE_DOCS and BLOCKED handlers now store `agent_id` from initial Task spawn and continue via `SendMessage(to=<agent_id>)` instead of launching fresh Task instances
 - Added async wait rule requiring orchestrator to wait for `<task-notification>` before proceeding after SendMessage dispatch
 - `run-loop.sh` now pins `--model claude-opus-4-6` and `--effort high` on the per-iteration `claude` invocation
+
+### code-review v1.5.3
+
+#### Fixed
+- Clarified `partitions.json` schema documentation in `/start` command. The partition output's `files[]` entries use the key `file` (not `path`) for the file path, but the prior doc only listed the entry-level shape implicitly via `{filepath_1}` placeholders. The underspecification caused the orchestrator LLM to construct ad-hoc Python one-liners against `partitions.json` using `f['path']`, throwing `KeyError: 'path'` mid-pipeline. The doc now spells out each entry as `{"file", "loc", "is_test", "line_range"?}`, adds a placeholder-to-source mapping for the per-agent prompt template, and instructs the orchestrator to use the Read tool rather than introspect the JSON shell-style.
 
 ### code-review v1.5.2
 
@@ -46,6 +69,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `/code` slash command now invokes `setup-closedloop.sh` via `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-closedloop.sh"` for portability
 - `run-loop.sh` now emits quoted `/code:code` arguments for workdir, `--prompt`, `--prd`, and `--add-dir` in loop state, preserving argument boundaries for values that contain spaces
 - `plan-with-codex` command gains `SendMessage` in its allowed-tools list
+
+### platform v1.1.2
+
+#### Changed
+- `upload-artifact` skill renamed terminology from "artifact" to "document" to match the renamed ClosedLoop MCP tools (`create-artifact` → `create-document`, `create-artifact-version` → `create-document-version`). Skill description, prompts, and result reporting updated accordingly.
+- `upload-artifact` now supports the `FEATURE` document type alongside `PRD`, `IMPLEMENTATION_PLAN`, and `TEMPLATE`.
+- `upload_artifact.py` and the skill's `--artifact-id` flag now accept a UUID or a user-facing slug (`PRD-*`, `PLN-*`, `FEA-*`) for new-version uploads; the MCP server resolves the identifier. `--project-id` and `--workstream-id` similarly accept slugs (`PRO-*`, `WRK-*`).
+- Result payloads now include `document_id` (mirroring `artifact_id` for backward compatibility) and report the document slug alongside the ID.
 
 ### platform v1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `upload-artifact` now supports the `FEATURE` document type alongside `PRD`, `IMPLEMENTATION_PLAN`, and `TEMPLATE`.
 - `upload_artifact.py` and the skill's `--artifact-id` flag now accept a UUID or a user-facing slug (`PRD-*`, `PLN-*`, `FEA-*`) for new-version uploads; the MCP server resolves the identifier. `--project-id` and `--workstream-id` similarly accept slugs (`PRO-*`, `WRK-*`).
 - Result payloads now include `document_id` (mirroring `artifact_id` for backward compatibility) and report the document slug alongside the ID.
+- `context-engineering` skill: Refactoring Existing Prompts section gains a "Dropped qualifiers" pitfall row (load-bearing single modifiers like `only`, `unless`, `when appropriate`, `must`, `never`) and a four-step Validation Pass that requires labeling every removed line as relocated, redundant, or dropped on purpose before declaring a refactor done.
 
 ### platform v1.1.1
 

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -568,8 +568,10 @@ Read `<CR_DIR>/partitions.json` with the Read tool.
 
 The script performs greedy bin-packing (sorted by LOC descending), splits oversized single files by hunks, and detects test files. It outputs:
 - **partitions**: Array of `{id, files, total_loc, is_test_only}` objects
-- Each `files[]` entry may include optional `line_range: [start, end]` when a large file is split by hunks
+- Each `files[]` entry has the shape `{"file": <path>, "loc": <int>, "is_test": <bool>, "line_range": [start, end]?}`. The path is under the key `file` (NOT `path`). `line_range` is present only when a large file is split by hunks.
 - **test_file_paths**: Array of detected test file paths
+
+When constructing agent prompts, read each entry's `file` field for the path. Do NOT run ad-hoc Python one-liners against `partitions.json` — use the Read tool, then map `entry["file"]` directly into the prompt template.
 
 ### Pre-Extract Patches to Disk (CRITICAL -- eliminates sub-agent Bash dependency)
 
@@ -618,6 +620,12 @@ Each agent's prompt is ONLY the lightweight per-agent parts. The shared instruct
 The orchestrator assigns each agent a unique `AGENT_ID` (e.g., `bha_p0`, `bhb`, `auditor`, `premise`, `domain_0`). The agent writes its findings to `{CR_DIR}/agent_{AGENT_ID}.json`.
 
 **Important:** When constructing agent prompts, substitute the resolved `CR_DIR` path (e.g., `.closedloop-ai/code-review/cr-38291`) into `{CR_DIR}` — agents run in separate processes and do not have access to the orchestrator's shell variables.
+
+**Placeholder source mapping** (read these directly from the partition entry — do NOT run a Python one-liner to inspect the JSON):
+- `{filepath_N}` ← `partition["files"][N]["file"]` (key is `file`, NOT `path`)
+- `{loc_N}` ← `partition["files"][N]["loc"]`
+- `{status_N}` ← `diff_data["file_statuses"][filepath]` (added/modified/removed)
+- `{start_N}-{end_N}` ← `partition["files"][N]["line_range"]` (only emit the `[lines X-Y]` segment if `line_range` is present)
 
 ```
 mode: standalone

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.9.4",
+  "version": "1.10.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/README.md
+++ b/plugins/code/README.md
@@ -36,13 +36,15 @@ graph TD
     P27 --> P3["Phase 3: Implementation"]
     P3 --> P4["Phase 4: Code Simplification"]
     P4 --> P5["Phase 5: Testing & Code Review"]
-    P5 --> P6["Phase 6: Visual Inspection"]
+    P5 --> P55["Phase 5.5: Behavioral Verification"]
+    P55 --> P6["Phase 6: Visual Inspection"]
     P6 --> P7["Phase 7: Logging & Completion"]
 
     style Review fill:#fff3e0
     style P25 fill:#e1f5fe
     style P3 fill:#e8f5e9
     style P5 fill:#fce4ec
+    style P55 fill:#ede7f6
 ```
 
 The orchestrator never reads project files directly. All file operations are delegated to subagents, keeping the orchestrator's context lean for coordination work.
@@ -167,6 +169,9 @@ Discovers and runs project-specific validation commands (test, lint, typecheck, 
 **`code-reviewer`** (model: sonnet)
 Reviews code changes for security vulnerabilities, correctness bugs, type safety issues, performance problems, and DRY violations. Operates on git diffs, applying a strict evidence standard: Critical/High findings require concrete proof, not speculation. Checks multi-tenant authorization on data-access endpoints. Runs as a loop agent (max 5 iterations) — only exits when no Critical/High findings remain.
 
+**`behavior-verifier`** (model: sonnet)
+Verifies that final code aligns with the intended behavior captured in the decision-table artifact. Activates `code:decision-table` in verification-only mode (SKILL.md step 17), appends Verification Findings to the artifact, and returns a structured verdict (`ALIGNED` or `MISALIGNED` with typed `<drift_rows>` JSON: `code_drift`, `test_drift`, `plan_ambiguity`) for orchestrator routing in Phase 5.5. Read-and-report only — never modifies code or tests; drift remediation is owned by the orchestrator. Runs as a loop agent (max 3 iterations).
+
 ### Cross-Repo Agents
 
 **`cross-repo-coordinator`** (model: haiku)
@@ -257,6 +262,10 @@ A 4-phase protocol for orchestrators to refine subagent queries through follow-u
 ### `codex-review`
 
 Runs Codex to review a plan file and returns structured feedback with a verdict. Called once per debate round by the `plan-with-codex` command via `debate-loop.sh`. Supports session resume across rounds using a Codex thread ID. Returns `VERDICT:APPROVED` or `VERDICT:NEEDS_CHANGES` plus a `CODEX_SESSION` token. Emits `CODEX_FAILED` or `CODEX_EMPTY` tokens on error so the orchestrator can ask the user to retry or abort.
+
+### `decision-table`
+
+Generates a repo-local decision-table artifact that makes control-flow and stateful edge cases reviewable. Used when the user wants a code-grounded table for current behavior, wants to compare current behavior against a plan or work item, or needs a control-flow artifact for recovery, retry, finalization, validation, state-machine, or review-heavy edge cases. Writes one artifact per work item under `.closedloop-ai/decision-tables/` (`<plan-id>.md` for plan-scoped work, `<short-work-name>.md` otherwise) using the format defined in `references/artifact-format.md`. Builds the `Current Code` table from code (not expectations), captures the target behavior in `Intended Change`, and freezes both once implementation begins; post-implementation drift is recorded in append-only `Verification Findings`, `Fixes Applied`, `Final Alignment Status`, and optional `Plan Clarifications` sections. Includes a behavioral edge-case expansion pass that explicitly models structured-result setup failures, library-managed lifecycle re-entry, time-bound credentials/signatures, diagnostic reason taxonomies, and side-effect boundaries for validation failures.
 
 ---
 

--- a/plugins/code/README.md
+++ b/plugins/code/README.md
@@ -377,6 +377,14 @@ Installs required Python dependencies for the plugin's tools.
 
 Shell harness for the Codex debate loop used by the `plan-with-codex` command. Drives the round-by-round interaction between the `code:plan-agent` and Codex, maintaining state in sidecar files alongside the plan file.
 
+### `stamp_critic_cache.sh`
+
+Stamps the critic cache after Phase 2.5 reviews complete. Hashes `plan.json` (and `critic-gates.json` when present) and writes the hash to `{WORKDIR}/reviews/.plan-hash` so subsequent iterations can skip critics via the `code:critic-cache` skill.
+
+### `stamp_cross_repo_cache.sh`
+
+Stamps the cross-repo cache after Phase 1.4 coordinator completes. Hashes peer-repo HEADs from `.workspace-repos.json` (falling back to `.cross-repo-needs.json`) and writes to `{WORKDIR}/.cross-repo-hash` so subsequent iterations skip cross-repo discovery via the `code:cross-repo-cache` skill.
+
 ### `loop-agents.json`
 
 Configuration file (not a script) defining which agents participate in the validation loop. Each entry specifies: `validation_script`, `max_iterations`, `promise` (expected completion string), `state_file_suffix`, and `verification_criteria`. Also defines `learning_agents` — the subset of agents that must both acknowledge injected learnings and capture new learnings before stopping.

--- a/plugins/code/agents/behavior-verifier.md
+++ b/plugins/code/agents/behavior-verifier.md
@@ -1,0 +1,105 @@
+---
+name: behavior-verifier
+description: Activates code:decision-table in verification-only mode against the decision-table artifact and final code. Identifies drift and appends Verification Findings to the artifact. Never modifies code or tests. Returns ALIGNED or MISALIGNED with typed drift rows for orchestrator routing.
+model: sonnet
+tools: Read, Bash, Skill
+skills: code:decision-table
+---
+
+# Behavior Verifier Agent
+
+You verify that final code aligns with the intended behavior captured in the decision-table artifact. You activate `code:decision-table` in verification-only mode, append Verification Findings to the artifact, and return a structured verdict (`ALIGNED` or `MISALIGNED`) for the orchestrator. You NEVER modify code or tests — drift remediation is owned by orchestrator Phase 5.5.
+
+## Inputs
+
+The agent receives `WORKDIR`, `DECISION_TABLE_PATH`, and `START_SHA` from the orchestrator prompt.
+
+## Step 1 — Guard
+
+Read `$DECISION_TABLE_PATH`. If the file does not exist or is empty, emit:
+
+```
+MISALIGNED
+<drift_rows>
+[
+  {"kind": "plan_ambiguity", "area": "artifact-missing", "description": "Decision-table artifact not found at expected path. Generation may have failed or been skipped.", "source_file": null, "artifact_row": null}
+]
+</drift_rows>
+```
+
+Then emit `<promise>BEHAVIOR_VERIFIER_COMPLETE</promise>`. Do not treat a missing artifact as ALIGNED.
+
+## Step 2 — Build changed-file set
+
+Build the union of git diffs since `$START_SHA`:
+
+```bash
+{ git diff --name-only "$START_SHA" HEAD 2>/dev/null; \
+  git diff --name-only 2>/dev/null; \
+  git diff --name-only --cached 2>/dev/null; } | sort -u
+```
+
+Mirrors run-loop.sh's union form, but live so it captures unstaged and staged changes during the current Claude session.
+
+## Step 3 — Activate code:decision-table in verification-only mode
+
+- Artifact path is `$DECISION_TABLE_PATH` (already written; do not regenerate Current Code or Intended Change sections).
+- Changed-file set from Step 2 scopes which source files to read.
+- Skill must execute SKILL.md step 17 only: read final code against Intended Change rows and append Verification Findings and Final Alignment Status to the artifact. Verification Findings is the human/audit channel — free-form bullets per the artifact format.
+- Skill must NOT execute SKILL.md step 18 (fixing drift). Read-and-report only. All code/test fixes are routed by orchestrator Phase 5.5 after this agent returns MISALIGNED.
+- Treat Current Code and Intended Change as frozen (do not rewrite).
+
+## Step 4 — Parse and return structured verdict
+
+Parse the artifact's Final Alignment Status section and emit a structured verdict on stdout.
+
+### Two-channel output contract
+
+- Verification Findings section in artifact = human/audit channel (free-form bullets, written by skill in Step 3).
+- Agent terminal output = machine-readable orchestrator channel (structured JSON between `<drift_rows>` markers). Orchestrator extracts this block; it does NOT read the artifact directly.
+
+### ALIGNED format (when Final Alignment Status is "Aligned")
+
+```
+ALIGNED
+verified_rows: N
+test_coverage: pass
+```
+
+Then `<promise>BEHAVIOR_VERIFIER_COMPLETE</promise>`. No `<drift_rows>` block on ALIGNED.
+
+### MISALIGNED format (when Final Alignment Status is not "Aligned" or skill identified unresolved drift)
+
+```
+MISALIGNED
+<drift_rows>
+[
+  {"kind": "code_drift", "area": "<behavior area from artifact>", "description": "<text>", "source_file": "<file:line or null>", "artifact_row": "<exact row text from artifact>"},
+  {"kind": "test_drift", "area": "<behavior area>", "description": "<text>", "source_file": "<file:line or null>", "artifact_row": "<exact row text>"}
+]
+</drift_rows>
+```
+
+Then `<promise>BEHAVIOR_VERIFIER_COMPLETE</promise>`.
+
+Required fields per drift row: `kind`, `area`, `description`, `source_file`, `artifact_row`. `kind` must be exactly one of: `code_drift`, `test_drift`, `plan_ambiguity`. `source_file` is JSON null (not the string "null") when no specific file applies. Every drift row from Verification Findings must appear as a JSON object.
+
+`kind` semantics:
+- `code_drift` = intended behavior not present in code
+- `test_drift` = required test scenario has no test coverage
+- `plan_ambiguity` = intended row is ambiguous or contradicted by repo guardrails; cannot verify without a plan clarification
+
+## Loop budget
+
+Loop agent: max 3 iterations. If verification cannot complete within 3 iterations:
+
+```
+MISALIGNED
+<drift_rows>
+[
+  {"kind": "plan_ambiguity", "area": "verification-timeout", "description": "verification timeout", "source_file": null, "artifact_row": null}
+]
+</drift_rows>
+```
+
+Then `<promise>BEHAVIOR_VERIFIER_COMPLETE</promise>`.

--- a/plugins/code/agents/plan-writer.md
+++ b/plugins/code/agents/plan-writer.md
@@ -190,7 +190,7 @@ When the orchestrator prompt contains **"FINALIZE MODE"**, flesh out the existin
       ```bash
       DT_AFTER=$(ls -1 "$CLOSEDLOOP_WORKDIR/.closedloop-ai/decision-tables/" 2>/dev/null || true)
       DT_NEW=$(comm -13 <(echo "$DT_BEFORE" | sort) <(echo "$DT_AFTER" | sort))
-      DT_NEW_COUNT=$(echo "$DT_NEW" | grep -c . 2>/dev/null || echo 0)
+      DT_NEW_COUNT=$(echo "$DT_NEW" | grep -c . 2>/dev/null || true)
       ```
    4. **Require exactly one new file**: If `DT_NEW_COUNT` is 0 or greater than 1, do NOT guess. Emit the failure marker `DECISION_TABLE_ARTIFACT_COUNT_MISMATCH` to stdout and do NOT emit `<promise>PLAN_WRITER_COMPLETE</promise>`. plan-writer's loop will exit without success and the orchestrator owns the hard stop. If `DT_NEW_COUNT` equals 1, write the exact relative path `.closedloop-ai/decision-tables/$DT_NEW` into `plan.json` as `decisionTable: { path: ".closedloop-ai/decision-tables/$DT_NEW", status: "pending" }` as a top-level JSON-only field (do NOT add it to the `content` markdown or regenerate plan.md for this field alone).
 

--- a/plugins/code/agents/plan-writer.md
+++ b/plugins/code/agents/plan-writer.md
@@ -178,8 +178,27 @@ When the orchestrator prompt contains **"FINALIZE MODE"**, flesh out the existin
    - Edge cases to handle
 4. **Update plan.json**: Modify both the `content` markdown field and structured fields
 5. **Update plan.md**: Write the updated `content` field value
-6. **Preserve all IDs and structure**: Do NOT add, remove, or renumber tasks, ACs, or phases
-7. **Run sync check**: Verify JSON structured fields match the updated markdown
+6. **Generate decision-table artifact**: When `plan_was_imported=false` and `simple_mode=false`, use the following four-step algorithm to generate and capture the artifact path:
+
+   1. **Snapshot before**: Before activating the skill, capture the current file set under `.closedloop-ai/decision-tables/` into a shell variable:
+      ```bash
+      mkdir -p "$CLOSEDLOOP_WORKDIR/.closedloop-ai/decision-tables"
+      DT_BEFORE=$(ls -1 "$CLOSEDLOOP_WORKDIR/.closedloop-ai/decision-tables/" 2>/dev/null || true)
+      ```
+   2. **Activate skill**: Activate `code:decision-table` with the finalized plan as context.
+   3. **Compute set-difference**: After the skill completes, capture the new file set and compute what was added:
+      ```bash
+      DT_AFTER=$(ls -1 "$CLOSEDLOOP_WORKDIR/.closedloop-ai/decision-tables/" 2>/dev/null || true)
+      DT_NEW=$(comm -13 <(echo "$DT_BEFORE" | sort) <(echo "$DT_AFTER" | sort))
+      DT_NEW_COUNT=$(echo "$DT_NEW" | grep -c . 2>/dev/null || echo 0)
+      ```
+   4. **Require exactly one new file**: If `DT_NEW_COUNT` is 0 or greater than 1, do NOT guess. Emit the failure marker `DECISION_TABLE_ARTIFACT_COUNT_MISMATCH` to stdout and do NOT emit `<promise>PLAN_WRITER_COMPLETE</promise>`. plan-writer's loop will exit without success and the orchestrator owns the hard stop. If `DT_NEW_COUNT` equals 1, write the exact relative path `.closedloop-ai/decision-tables/$DT_NEW` into `plan.json` as `decisionTable: { path: ".closedloop-ai/decision-tables/$DT_NEW", status: "pending" }` as a top-level JSON-only field (do NOT add it to the `content` markdown or regenerate plan.md for this field alone).
+
+   Note: SKILL.md does allow splitting into multiple files for very large work items, but this plan's schema supports only one `decisionTable.path` pointer. Emitting the failure marker and withholding `PLAN_WRITER_COMPLETE` is intentional: it delegates the hard stop and user-facing message to the orchestrator.
+
+   When `plan_was_imported=true` or `simple_mode=true`, skip this step entirely.
+7. **Preserve all IDs and structure**: Do NOT add, remove, or renumber tasks, ACs, or phases
+8. **Run sync check**: Verify JSON structured fields match the updated markdown
 
 <critical_constraint>
 **FINALIZE MODE SCOPE** — Only add implementation detail to existing tasks. Do not change the plan's scope, add new tasks, or alter architecture decisions. The human already approved the structure.
@@ -222,6 +241,14 @@ Output `<promise>PLAN_WRITER_COMPLETE</promise>` when all blocking findings are 
 1. Quality checklist items pass (valid JSON, sync checks)
 2. JSON structured fields match markdown content exactly
 3. `$CLOSEDLOOP_WORKDIR/plan.json` and `$CLOSEDLOOP_WORKDIR/plan.md` both exist and are in sync
+
+**Decision-table gate (Finalize Mode only, when not skipped)**: Read `plan.json` and confirm `decisionTable.path` is present and non-empty. Then verify the file at that path exists and is non-empty:
+```bash
+wc -c "$CLOSEDLOOP_WORKDIR/<path-from-plan-json>"
+```
+where `<path-from-plan-json>` is the literal value read from `plan.json.decisionTable.path`. If `plan.json.decisionTable.path` is absent or empty, or the file is missing or zero bytes, this gate has failed — re-run the T-2.1 four-step algorithm (snapshot, activate, set-difference, require exactly one new file) rather than guessing or re-activating blindly. If `DT_NEW_COUNT` is again 0 or >1, emit the failure marker `DECISION_TABLE_ARTIFACT_COUNT_MISMATCH` to stdout and do NOT emit `<promise>PLAN_WRITER_COMPLETE</promise>` (the orchestrator owns the hard stop). If skipped (`plan_was_imported=true` or `simple_mode=true`), bypass this gate entirely. Never recompute the artifact name — always use the value already written in `plan.json.decisionTable.path`.
+
+The gate runs AFTER the existing sync check. No changes to Merge Mode or Addressed Gaps completion conditions.
 
 <examples>
 <example name="addressed_gap_json">

--- a/plugins/code/prompts/prompt.md
+++ b/plugins/code/prompts/prompt.md
@@ -28,6 +28,7 @@ Activate with `Skill(skill="<id>")`.
 | `code:cross-repo-cache` | Phase 1.4.1 entry, before cross-repo-coordinator | `CROSS_REPO_CACHE_HIT` (with status) / `CROSS_REPO_CACHE_MISS` |
 | `judges:eval-cache` | Phase 1.3 entry, before plan-evaluator | `EVAL_CACHE_HIT` (with `simple_mode`, `selected_critics`) / `EVAL_CACHE_MISS` |
 | `code:iterative-retrieval` | Complex subagent calls where initial response may be incomplete (not for simple queries) | 4-phase protocol: Dispatch → Evaluate → Refine → Loop |
+| `code:decision-table` | Phase 2.7 (generation via plan-writer) and Phase 5.5 (verification-only via behavior-verifier) | Activated by subagents, not directly by orchestrator |
 
 **plan-validate vs plan-validator:** Use `code:plan-validate` skill for structural checks. Only launch @code:plan-validator agent after phases that modify plan content (Phase 1, 2.6, 2.7) with "SEMANTIC ONLY" prompt.
 
@@ -72,6 +73,7 @@ Use this sequence at any hard-stop that requires user action before continuing:
 | Phase 3: Implementation | Implementing |
 | Phase 4: Code simplification | Simplifying code |
 | Phase 5: Testing and Validation | Testing |
+| Phase 5.5: Behavioral Verification | Verifying behavioral alignment |
 | Phase 6: Visual inspection | Inspecting visuals |
 | Phase 7: Logging and completion | Completing |
 
@@ -89,8 +91,15 @@ Use this sequence at any hard-stop that requires user action before continuing:
 - Phase 7 failures: add `"reason": "..."` and optionally `"pendingTasks": [...]`
 - Hard stops: status=`AWAITING_USER`, add `"reason"`, `"userAction": {"description", "file", "command"}`
 - Final completion: status=`COMPLETED`
+- Run start: add `"startSha": "<git sha>"` as a top-level field. Written once at the start of the first iteration and re-included on every subsequent state.json write using the value held in orchestrator working memory.
 
 **Rule:** Update state.json at the START of every phase below. This is implied and not repeated per-phase.
+
+**startSha initialization:** At the very start of the first iteration (before Phase 0.9, immediately after writing the initial state.json), source startSha from config.env with a single Bash call and store it in orchestrator working memory for the rest of the run:
+```bash
+START_SHA=$(grep '^CLOSEDLOOP_START_SHA=' "$CLOSEDLOOP_WORKDIR/.closedloop-ai/config.env" 2>/dev/null | cut -d= -f2- | head -n1)
+```
+Always quote `"$CLOSEDLOOP_WORKDIR"` in shell snippets to handle workdir paths that contain spaces. Include `"startSha": "$START_SHA"` in this initial state.json write. On every subsequent state.json write, re-include `"startSha": "$START_SHA"` from working memory — do NOT re-read config.env or state.json. If config.env is absent or `CLOSEDLOOP_START_SHA` is empty, set `startSha` to `""`.
 
 Here are the key phases you must complete:
 
@@ -176,7 +185,10 @@ Here are the key phases you must complete:
 
 **PHASE 2.7: PLAN FINALIZATION**
 
-- Launch @code:plan-writer with `WORKDIR`, FINALIZE MODE: enrich task descriptions with implementation details (code patterns, signatures, edge cases). Do NOT add/remove/renumber tasks.
+- Launch @code:plan-writer with `WORKDIR`, FINALIZE MODE: enrich task descriptions with implementation details (code patterns, signatures, edge cases). Do NOT add/remove/renumber tasks. Include plan_was_imported=$plan_was_imported and simple_mode=$simple_mode in the prompt so plan-writer knows whether to skip decision-table generation.
+- **After @code:plan-writer completes, check its output for the failure marker before proceeding:**
+  - If the output contains the string `DECISION_TABLE_ARTIFACT_COUNT_MISMATCH` (treat the marker as authoritative even if `PLAN_WRITER_COMPLETE` is also present): execute **AWAITING_USER_SEQUENCE** with: phase='Phase 2.7: Plan Finalization', reason='Decision-table artifact count mismatch (expected exactly 1 new file under .closedloop-ai/decision-tables/)', file='$CLOSEDLOOP_WORKDIR/.closedloop-ai/decision-tables/', command='/code:code $ARGUMENTS'. Tell the user: 'Plan-writer found 0 or more than 1 new decision-table files. Inspect .closedloop-ai/decision-tables/, decide which file to keep as the canonical artifact, set plan.json.decisionTable.path to its relative path, and run /code:code $ARGUMENTS to continue.' **HARD STOP.**
+  - If the output does NOT contain the marker, proceed normally (verify PLAN_WRITER_COMPLETE was emitted, then continue to Phase 3).
 - After plan-writer completes (outputs `<promise>PLAN_WRITER_COMPLETE</promise>`), run **PLAN_VALIDATION_SEQUENCE**
 - Proceed to Phase 3
 
@@ -220,6 +232,51 @@ Here are the key phases you must complete:
      b. Re-run @code:build-validator. Repeat until VALIDATION_PASSED (max 20 attempts)
      c. If still failing after 20 attempts: Execute **AWAITING_USER_SEQUENCE** with: phase="Phase 5: Testing and Validation", reason="Validation failed after 20 attempts", file=null, command="/code:code $ARGUMENTS". Tell the user: "Validation failed after 20 attempts. Fix issues manually and run `/code:code $ARGUMENTS` to continue."
 
+**PHASE 5.5: BEHAVIORAL VERIFICATION**
+
+**Skip conditions (check in order):**
+- If `simple_mode = true`: mark Phase 5.5 as `completed`, skip to Phase 6.
+- If `plan_was_imported = true`: mark Phase 5.5 as `completed`, skip to Phase 6.
+
+NOTE: These are the only two valid skip conditions. If neither skip applies, Phase 5.5 MUST run regardless of the decisionTable field state. An empty or missing `decision_table_path` in plan-validate output when no skip flag is set indicates a Phase 2.7 regression and must escalate, not skip.
+
+**Setup (values from orchestrator working memory and last plan-validate output -- no file reads):**
+- `decisionTablePath` = `decision_table_path` field from last `code:plan-validate` skill output
+- `startSha` = value held in orchestrator working memory since T-4.0 initialization
+- Set `dt_attempt = 0`, `dt_max_attempts = 5`, `dt_status = "pending"`, `dt_any_clarifications = false`, `dt_last_failure_reason = ""`.
+- Telemetry counters: `dt_drift_kind_counts = {"code_drift": 0, "test_drift": 0, "plan_ambiguity": 0}`, `dt_fixes_attempted = 0`, `dt_parse_failures = 0`, `dt_verifier_invocations = 0`, `dt_phase_start_iso = $(date -u +%Y-%m-%dT%H:%M:%SZ)`, `dt_phase_start_epoch_ms = $(($(date +%s%N | cut -c1-13)))` (macOS-portable form: `$(($(date +%s) * 1000))` if nanoseconds unavailable).
+
+If `startSha` is `""` in orchestrator working memory (no git context or resumed run predating this feature): log warning "startSha unavailable, skipping Phase 5.5", mark `completed`, skip to Phase 6.
+
+If `decisionTablePath` is `""` (Phase 2.7 generation failed or pointer not written): set `dt_status = "verification_failed"`. Launch haiku subagent: "In $CLOSEDLOOP_WORKDIR/plan.json, set decisionTable.status to 'verification_failed' if the field exists." Execute **AWAITING_USER_SEQUENCE** with: phase="Phase 5.5: Behavioral Verification", reason="Decision-table artifact path is missing from plan.json. Phase 2.7 generation appears to have failed.", file="$CLOSEDLOOP_WORKDIR/plan.json", command="/code:code $ARGUMENTS". Tell the user: "Phase 2.7 did not write a decision-table pointer into plan.json. Review plan.json and re-run /code:code $ARGUMENTS to resume." **HARD STOP.**
+
+**Verification loop:**
+1. Increment `dt_attempt`. **Step 1 is the sole site that increments `dt_attempt` -- no other step may increment it.** Then check: if `dt_attempt > dt_max_attempts`, set `dt_status = "verification_failed"`. Launch haiku subagent: "In $CLOSEDLOOP_WORKDIR/plan.json, set decisionTable.status to 'verification_failed'." Determine the escalation reason based on the previous iteration's outcome (tracked in `dt_last_failure_reason`, initialized to `""`): if `dt_last_failure_reason == "unparseable"`, use reason=`behavior-verifier output unparseable after $dt_max_attempts attempts`; otherwise use reason=`Behavioral drift detected after $dt_max_attempts verification attempts`. Execute **AWAITING_USER_SEQUENCE** with: phase="Phase 5.5: Behavioral Verification", reason=<determined above>, file="$CLOSEDLOOP_WORKDIR/$decisionTablePath", command="/code:code $ARGUMENTS". **HARD STOP.**
+2. Launch @code:behavior-verifier with prompt: "WORKDIR=$CLOSEDLOOP_WORKDIR. DECISION_TABLE_PATH=$CLOSEDLOOP_WORKDIR/$decisionTablePath. START_SHA=$startSha. Verify final code against the decision-table artifact. Report only; do not fix code or tests." Increment `dt_verifier_invocations` by 1.
+3. Parse verifier output:
+   - If `ALIGNED` (first line of output is `ALIGNED`):
+     - If `dt_any_clarifications = true`: set `dt_status = "aligned_with_clarifications"`. Launch haiku subagent: "In $CLOSEDLOOP_WORKDIR/plan.json, set decisionTable.status to 'aligned_with_clarifications'."
+     - Otherwise: set `dt_status = "aligned"`. Launch haiku subagent: "In $CLOSEDLOOP_WORKDIR/plan.json, set decisionTable.status to 'aligned'."
+     - Run telemetry emit (see below), then mark Phase 5.5 `completed`, proceed to Phase 6.
+   - If `MISALIGNED` (first line of output is `MISALIGNED`):
+     - Extract the `<drift_rows>...</drift_rows>` JSON block from the verifier output. Parse the JSON array. **If the block is missing, the JSON is malformed, or any row has an unknown `kind` value not in `{code_drift, test_drift, plan_ambiguity}`, treat as a verifier parse failure**: set `dt_last_failure_reason = "unparseable"`, increment `dt_parse_failures` by 1, log a warning, do NOT route any drift rows, and immediately loop back to step 1. Do NOT increment `dt_attempt` here -- Step 1 owns all increments.
+     - If the block is parseable, set `dt_last_failure_reason = "drift"`. For each JSON object in the `drift_rows` array, increment `dt_drift_kind_counts[kind]` by 1 and `dt_fixes_attempted` by 1, then route by the `kind` field:
+       - `code_drift`: launch @code:implementation-subagent with prompt: "WORKDIR=$CLOSEDLOOP_WORKDIR. Implement missing behavioral requirement. Area: {row.area}. Missing: {row.description}. Source file hint: {row.source_file}."
+       - `test_drift`: launch @test-engineer with prompt: "WORKDIR=$CLOSEDLOOP_WORKDIR. Write tests for missing scenario. Area: {row.area}. Missing test scenario: {row.description}. Source file hint: {row.source_file}. Write the test in the appropriate test file for this area." If `row.source_file` points to a non-test file (indicating production code changes are also needed), also launch @code:implementation-subagent with the production-code requirement.
+       - `plan_ambiguity`: set `dt_any_clarifications = true`. Launch a haiku subagent to append a `Plan Clarifications` note to the decision-table artifact at "$CLOSEDLOOP_WORKDIR/$decisionTablePath" for the following ambiguity: {row.description}. Area: {row.area}. The haiku must NOT modify the `Current Code` or `Intended Change` sections — append only. Quote all paths in shell commands.
+     - After all row handlers complete, loop back to step 1.
+
+**State tracking:** Update state.json at start of Phase 5.5 and after each attempt with `{"phase": "Phase 5.5: Behavioral Verification", "status": "IN_PROGRESS", "startSha": "$startSha", "attempt": dt_attempt, "timestamp": "..."}`.
+
+**Telemetry emit (final step, run at exit before proceeding to Phase 6 or AWAITING_USER hard stop):**
+
+Compute `dt_phase_duration_ms = $(($(date +%s%N | cut -c1-13) - dt_phase_start_epoch_ms))` (or seconds-precision fallback).
+
+Launch a haiku subagent with prompt:
+"WORKDIR=$CLOSEDLOOP_WORKDIR. Append a single JSON line to $CLOSEDLOOP_WORKDIR/.closedloop-ai/decision-table-verifications.jsonl with the following exact fields and values: {\"timestamp\":\"<dt_phase_start_iso>\", \"workdir\":\"$CLOSEDLOOP_WORKDIR\", \"decision_table_path\":\"<decision_table_path from plan-validate>\", \"final_status\":\"<dt_status>\", \"iterations\":<dt_attempt>, \"drift_kind_counts\":<dt_drift_kind_counts>, \"fixes_attempted\":<dt_fixes_attempted>, \"parse_failures\":<dt_parse_failures>, \"verifier_invocations\":<dt_verifier_invocations>, \"phase_duration_ms\":<dt_phase_duration_ms>}. Use mkdir -p on the parent directory first. Use a shell append (>>) so prior lines are preserved. Do NOT pretty-print; one compact line. The file is JSONL, not JSON — no enclosing array, one object per line."
+
+The haiku writes one line and exits. The orchestrator does NOT read the file back. Failure mode: if the haiku append fails for any reason, log a warning and continue — telemetry is non-blocking. Do NOT block phase exit on telemetry failure, do NOT retry, do NOT escalate.
+
 **PHASE 6: VISUAL INSPECTION (if UI changes were made)**
 
 - If `$CLOSEDLOOP_WORKDIR/visual-requirements.md` does not exist or is empty, skip to Phase 7
@@ -235,7 +292,7 @@ Here are the key phases you must complete:
 
 **PHASE 7: LOGGING AND COMPLETION**
 
-- Append a summary of all changes made to $CLOSEDLOOP_WORKDIR/log.md file
+- Append a summary of all changes made to $CLOSEDLOOP_WORKDIR/log.md file. Include the decision-table alignment status if one exists: activate `code:plan-validate` skill and read `decision_table_status` from its output. If `aligned`: mention `Behavioral alignment verified: .closedloop-ai/decision-tables/<filename>.md`. If `aligned_with_clarifications`: mention `Behavioral alignment verified with plan clarifications: .closedloop-ai/decision-tables/<filename>.md`. If `verification_failed`: this state should not reach Phase 7 (AWAITING_USER would have fired at Phase 5.5); log a warning if it somehow does. If `""` (simple mode, imported plan, or no artifact): omit the mention.
 
 **Final verification gate (all must pass before COMPLETE):**
 

--- a/plugins/code/schemas/plan-schema.json
+++ b/plugins/code/schemas/plan-schema.json
@@ -150,6 +150,23 @@
         }
       }
     },
+    "decisionTable": {
+      "type": "object",
+      "description": "Reference to a decision-table artifact produced via the code:decision-table skill, used to ground plan acceptance criteria in current code behavior.",
+      "required": ["path", "status"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Relative path from workdir to the decision-table artifact, e.g. `.closedloop-ai/decision-tables/pln-123.md`"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "aligned", "aligned_with_clarifications", "verification_failed"],
+          "description": "Current verification status of the decision table relative to the plan"
+        }
+      }
+    },
     "amendments": {
       "type": "array",
       "description": "History of plan amendments applied via amend-plan command",

--- a/plugins/code/scripts/loop-agents.json
+++ b/plugins/code/scripts/loop-agents.json
@@ -12,7 +12,7 @@
       "max_iterations": 5,
       "promise": "PLAN_WRITER_COMPLETE",
       "state_file_suffix": "plan-writer-loop.local.md",
-      "verification_criteria": "JSON/markdown sync valid, task IDs preserved (no renumbering or removal), no scope expansion beyond requested changes, all tasks enriched with code patterns and integration points (finalize mode) or all blocking findings addressed (merge mode), valid JSON with all required fields"
+      "verification_criteria": "JSON/markdown sync valid, task IDs preserved (no renumbering or removal), no scope expansion beyond requested changes, all tasks enriched with code patterns and integration points (finalize mode) or all blocking findings addressed (merge mode), valid JSON with all required fields, decision-table artifact written to .closedloop-ai/decision-tables/ and plan.json decisionTable pointer set with status=pending (finalize mode only, unless plan_was_imported or simple_mode). If the marker DECISION_TABLE_ARTIFACT_COUNT_MISMATCH is present in plan-writer output, plan-writer's exit without PLAN_WRITER_COMPLETE is a legitimate detection state, not a loop-agent failure; the orchestrator handles escalation."
     },
     "code:code-reviewer": {
       "max_iterations": 5,
@@ -30,6 +30,12 @@
       "promise": "IMPLEMENTATION_VERIFIED",
       "state_file_suffix": "implementation-subagent-loop.local.md",
       "verification_criteria": "All referenced types and interfaces verified from source before use, no new utilities or constants that duplicate existing codebase implementations, all integration points connected, static analysis passes on modified files"
+    },
+    "code:behavior-verifier": {
+      "max_iterations": 3,
+      "promise": "BEHAVIOR_VERIFIER_COMPLETE",
+      "state_file_suffix": "behavior-verifier-loop.local.md",
+      "verification_criteria": "Output is ALIGNED (with verified_rows count, no drift_rows block required) or MISALIGNED (with a parseable <drift_rows>...</drift_rows> JSON block containing at least one object with required fields: kind [enum: code_drift|test_drift|plan_ambiguity], area, description, source_file, artifact_row). Promise is always emitted regardless of verdict. Missing artifact must produce MISALIGNED with a drift_rows block, not ALIGNED. Agent is verification-only: it does not modify code or tests. The artifact Verification Findings section is the human audit channel; the <drift_rows> JSON block is the machine routing channel."
     }
   },
   "learning_agents": {
@@ -42,7 +48,8 @@
       "code:cross-repo-coordinator",
       "code:generic-discovery",
       "code:code-reviewer",
-      "code:plan-validator"
+      "code:plan-validator",
+      "code:behavior-verifier"
     ]
   }
 }

--- a/plugins/code/scripts/setup-closedloop.sh
+++ b/plugins/code/scripts/setup-closedloop.sh
@@ -314,6 +314,17 @@ fi
 
 mkdir -p "$WORKDIR/$CLOSEDLOOP_STATE_DIR"
 
+# Preserve run-loop-managed keys before truncating config.env. run-loop.sh
+# writes CLOSEDLOOP_START_SHA and CLOSEDLOOP_SELF_LEARNING during create_state_file;
+# setup-closedloop.sh runs every /code:code iteration and previously clobbered
+# them with the truncating heredoc below.
+EXISTING_START_SHA=""
+EXISTING_SELF_LEARNING=""
+if [[ -f "$WORKDIR/$CLOSEDLOOP_STATE_DIR/config.env" ]]; then
+    EXISTING_START_SHA=$(grep '^CLOSEDLOOP_START_SHA=' "$WORKDIR/$CLOSEDLOOP_STATE_DIR/config.env" 2>/dev/null | head -n1 | cut -d= -f2-)
+    EXISTING_SELF_LEARNING=$(grep '^CLOSEDLOOP_SELF_LEARNING=' "$WORKDIR/$CLOSEDLOOP_STATE_DIR/config.env" 2>/dev/null | head -n1 | cut -d= -f2-)
+fi
+
 # Write full config to WORKDIR
 mkdir -p "$WORKDIR/$CLOSEDLOOP_STATE_DIR"
 
@@ -344,6 +355,14 @@ CLOSEDLOOP_ADD_DIRS="$add_dirs_joined"
 CLOSEDLOOP_ADD_DIR_NAMES="$add_dir_names_joined"
 CLOSEDLOOP_REPO_MAP="$repo_map_joined"
 EOF
+
+# Re-append run-loop-managed keys captured above.
+if [[ -n "$EXISTING_START_SHA" ]]; then
+    echo "CLOSEDLOOP_START_SHA=$EXISTING_START_SHA" >> "$WORKDIR/$CLOSEDLOOP_STATE_DIR/config.env"
+fi
+if [[ -n "$EXISTING_SELF_LEARNING" ]]; then
+    echo "CLOSEDLOOP_SELF_LEARNING=$EXISTING_SELF_LEARNING" >> "$WORKDIR/$CLOSEDLOOP_STATE_DIR/config.env"
+fi
 
 echo "ClosedLoop config written to $WORKDIR/$CLOSEDLOOP_STATE_DIR/config.env"
 cat "$WORKDIR/$CLOSEDLOOP_STATE_DIR/config.env"

--- a/plugins/code/skills/decision-table/SKILL.md
+++ b/plugins/code/skills/decision-table/SKILL.md
@@ -7,204 +7,82 @@ description: Use when the user wants a code-grounded decision table for current 
 
 ## Purpose
 
-Generate a repo-local decision-table artifact that makes control-flow and stateful edge cases reviewable.
-
-Use the decision table as the source of truth. A flowchart is optional and secondary.
+Generate a repo-local decision-table artifact that makes control-flow and stateful edge cases reviewable. The decision table is the source of truth; a Mermaid diagram is optional and secondary.
 
 ## Output Location
 
-Write artifacts under:
+Write artifacts under `<repo-root>/.closedloop-ai/decision-tables/`. Create the directory if missing.
 
-`<repo-root>/.closedloop-ai/decision-tables/`
-
-Create the directory if it does not exist.
-
-Default to one artifact per full work item:
+Default to one artifact per work item:
 
 - plan-scoped: `<plan-id>.md`
-- non-plan-scoped: `<short-work-name>.md`
+- non-plan-scoped: `<short-work-name>.md` (lowercase kebab-case)
 
-Use lowercase kebab-case for non-plan names.
-
-If the work item contains multiple important behavior areas, keep them as sections inside the same artifact.
-
-Only split into multiple files when one artifact would be too large to review quickly or when the work clearly spans separate repos or systems.
+Keep multiple behavior areas as sections inside the same artifact. Only split into multiple files when one artifact would be too large to review quickly or when the work clearly spans separate repos/systems.
 
 ## Workflow
 
 1. Resolve the repo root and the work item under review.
-2. If the user supplied a plan, ticket, or work description, infer what behavior needs to be mapped:
-   - control-flow or stateful surfaces that can change externally visible behavior
-   - retries, recovery, replay, or finalization paths
-   - validation, rejection, and error handling paths
-   - state transitions and durable side effects
-3. Ignore purely mechanical edits unless they change behavior.
-4. If the user supplied a plan, read it first and extract only behaviorally relevant requirements.
-5. Read repo-level guardrails that can constrain or overrule the plan, such as agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalent), compatibility rules, contributor docs, and API contract guidance. Treat these as co-equal requirements, not optional context.
-6. If the plan and repo-level guardrails conflict, do not silently pick one. Record the tension in the artifact, add a `Plan Clarifications` note when appropriate, and surface the conflict to the user if it affects implementation or review.
-7. Read the code paths that currently implement the work item. Build the table from code, not from expectations.
-8. For shared routes, handlers, helpers, contracts, or policy surfaces, build a call-site inventory before choosing axes. Search for literal route paths, exported helper names, event names, header/reason/status strings, and shared types. For each caller, record what data it can supply, what response shapes/statuses it expects, whether older or newer peer versions exist, and how missing or unknown fields degrade.
-9. When mapping handlers, services, or adapters, explicitly model dependency outcomes that can change externally visible behavior: success, null/absent, validation failure, and thrown/rejected dependency failure when the callee can throw or reject.
-10. Before implementation, run a behavioral edge-case expansion pass for each intended row:
-   - Structured-result contracts: include rows for synchronous preparation failures before fetch/await/return, such as URL construction, payload building, JSON/body/header construction, parser setup, and other throw-capable setup code.
-   - Exported boundary invariants: when a helper, service, adapter, route, command, job, or handler can be called by more than one path, include rows for the invariants it must enforce itself even when current callers validate first, especially before network I/O, persistence, credentials, filesystem mutation, or other durable side effects.
-   - Contract-signal precedence: when a dependency or peer returns multiple signals that can affect the same decision, such as transport status, structured body fields, error codes, reason strings, headers, metadata, exit status, or sentinel files, include rows for each signal and for conflicts between signals. State which signal wins and how unknown or missing signals degrade.
-   - Library-managed lifecycle re-entry: include rows for automatic reconnects, retry timers, callbacks, restarts, framework-owned replays, and other paths that can re-enter with reused state.
-   - Active-processing re-entry: when a flow can receive a new event, request, callback, file, message, or retry while an earlier item is still being handled, include rows for idle, active, queued, coalesced, duplicate, dropped, and shutdown states as applicable. State when pending work drains and whether callers see a retryable, terminal, or silent outcome.
-   - Terminal-state transition guards: when a flow has terminal or one-way states such as approved, denied, expired, consumed, completed, cancelled, revoked, or failed, include rows for every mutating action attempted from each terminal state. State which states are mutable, which are no-ops, which return a terminal error, and which durable fields must never be rewritten. Include repeated UI actions such as approve-then-deny, deny-then-approve, double-clicks, retries after timeout, and stale browser tabs after another actor already completed the flow.
-   - Cancellation and shutdown: when a flow waits, sleeps, backs off, schedules a timer, retries, or runs asynchronously, include rows for cancellation or shutdown before the wait, during the wait, after the wait but before the next side effect, and during the side effect when applicable.
-   - Time-bound credentials, signatures, or payloads: include rows for first attempt, retry/reconnect, restart, expired past timestamps, future timestamps, and clock-boundary conditions, and state whether timestamped or expiring material is regenerated, rejected, or reused.
-   - One-time side effects: when a flow deletes, consumes, rotates, invalidates, acknowledges, commits, uploads, locks, or otherwise spends a one-time resource, include rows for failures and re-entry before and after that side effect. Include cleanup or consume failures on success, validation failure, parse failure, and dependency failure branches when those branches attempt cleanup. State whether the resource can be safely reused, retried, replaced, or must be considered spent.
-   - Shared durable resources: when deleting, rotating, revoking, or clearing persisted keys, credentials, locks, cache entries, files, profiles, identities, or other durable resources, include rows for no remaining references, another saved/profile reference, active runtime reference, stale reference, and unknown lookup failure. State whether the resource is reference-counted, ownership-scoped, shared, or safe to delete unconditionally.
-   - Profile or config cloning: when saving, duplicating, importing, switching, or snapshotting a profile/config from active runtime state, include rows for fields that must be copied, regenerated, omitted, or downgraded. Treat credentials, signing keys, service IDs, device IDs, integration IDs, public keys, machine identities, and other ownership-scoped identifiers as non-transferable by default unless the plan explicitly says they are shared.
-   - Diagnostic contracts: when the plan requires redacted diagnostics, telemetry, or structured reasons, include expected reason/category values for each failure class, such as validation failure, missing state, unavailable secure storage, signer failure, timeout, network failure, and remote rejection.
-   - Advertised status inventory: when code exposes statuses, reasons, modes, variants, exit values, event names, or other enumerated outcomes, inventory which branches can produce each value and flag dead, unreachable, duplicated, or misleading values.
-   - Exception scope: for route handlers, middleware, auth wrappers, and policy helpers, distinguish setup failures, auth/proof failures, database or lookup failures, and downstream handler failures so catch-all blocks do not collapse unrelated errors into the same external status or message.
-   - Serverless async side effects: for serverless or edge route handlers, include rows for side effects that happen after the response path, such as last-used timestamps, telemetry, uploads, notifications, and cleanup. State whether they are awaited, passed to a platform lifecycle primitive such as `waitUntil` where available, persisted through an outbox, or intentionally best-effort.
-   - Path and identity policy canonicalization: for allowlists, denylists, ownership checks, cache keys, dedupe keys, lock keys, object identifiers, and other policy comparisons, include rows for raw input, normalized form, canonical form, aliases, symbolic references, case or separator variants, parent/child boundaries, empty values, and missing targets where applicable.
-   - Partial update preservation: when a route or service updates a nested object, JSON blob, configuration record, metadata map, or persisted state bundle, include rows for omitted fields, explicit empty/null fields, single-field updates, and full replacement. State whether the operation merges with existing state or replaces it, and which existing fields must survive unknown or partial updates.
-   - Persistence access paths: when adding persisted fields, tables, indexes, uniqueness constraints, or cleanup jobs, inventory the actual reads, writes, filters, sort orders, expiry scans, rate limits, and ownership checks that will use them. Distinguish query-critical indexes from write-only metadata, future-only fields, redundant left-prefix indexes, and indexes that need additional columns to match the real predicate.
-   - Side-effect boundary: for every validation or preparation failure, state whether network calls, persistence, key generation, retries, telemetry, or other durable side effects should happen.
-   - Testable invariant: for signing, canonicalization, validation, and compatibility rows, state the exact invariant a test must prove, including a positive control and one-axis mutation when a field binding matters.
-11. Choose a small set of state axes that explain the branch behavior. Reuse the same axes within each behavior area for current and intended tables.
-12. Write the artifact using the format in `references/artifact-format.md`.
-13. When a plan is in scope, include:
-   - `Current Code`
-   - `Intended Change`
-   - `Delta Checklist`
-   - `Required Tests`
-14. When writing `Required Tests`, name the invariant being proved, the positive path, and the failure or compatibility mutation. Do not let a test merely trigger a generic rejection when the row claims to prove a specific binding, fallback, or diagnostic reason.
-15. When no plan is in scope, omit `Intended Change` and focus on the current-state table plus gaps or suspicious branches.
-16. Once implementation begins, treat `Current Code` and `Intended Change` as frozen. Do not rewrite them to match the final implementation.
-17. After implementation, verify the final code against the intended behavior in the artifact by appending:
-   - `Verification Findings`
-   - `Fixes Applied`
-   - `Final Alignment Status`
-18. If verification or review finds drift, behavioral mismatches, missing edge cases, missing tests, or repo-guardrail violations, fix them in the code and tests, append the verification/fix sections, and re-verify until the final code aligns with the intended behavior.
-19. Organize `Fixes Applied` by discovery source when more than one source exists. Use source labels such as `Initial verification`, `Runtime/manual testing`, `Review findings`, `Validation failures`, `Repo guardrails`, `Plan clarification`, and `Final hygiene`. Do not leave a broad `During verification` bucket once review, runtime, validation, or follow-up fixes have also been applied.
-20. Treat `Verification Findings` as a resolution queue, not a backlog. Every finding must be fixed, marked not applicable with evidence, or carried into `Final Alignment Status: Not aligned` with the specific human/external blocker that prevents autonomous completion. Do not leave fixable repo-local work as a recorded gap when the user asked for implementation.
-21. Before marking final alignment, run an internal consistency pass over the artifact. If the same state, reason, or dependency failure appears with different intended external outcomes, add the missing distinguishing axis, record a plan clarification, or treat it as a mismatch to fix.
-22. Before marking final alignment, run a review-prevention pass over every touched externally visible surface. For each changed route, handler, service, command, adapter, UI action, persisted-state update, and shared helper, ask whether a code reviewer could still find:
-   - an unmodeled dependency throw/reject branch that maps to the wrong external status, retryability, or message
-   - a terminal-state or repeated-action mutation that overwrites durable state
-   - a partial update that drops unrelated existing nested/JSON/config/metadata fields
-   - a feature-flag, rollout, or permission path that bypasses the intended gate or uses the wrong identity
-   - a caller or version-skew path that cannot supply a newly required field, header, proof, or response shape
-   - duplicated policy, helper, constant, or wire-contract logic that should be shared or parity-tested
-   - a test that asserts only that something failed, without proving the specific invariant, fallback, binding, or diagnostic reason from the table
-23. For every item from the review-prevention pass, add a verification note: fixed, already covered by a named row/test, not applicable with the reason, or `Not aligned` with the human/external blocker. Do not mark `Aligned` while any item is merely assumed covered.
-24. Only change `Intended Change` after implementation if the plan itself was ambiguous or incorrect. When that happens, add an explicit `Plan Clarifications` note with the reason and source rather than silently rewriting the target behavior.
-25. Always give the user a human-facing closeout summary outside the artifact after verification is complete.
-26. In that closeout summary, explicitly separate:
-   - what was verified and fixed
-   - important nuances the user should know
-   - anything that still needs user input or external action
-27. If there is any user-actionable item that the agent cannot safely complete itself, surface it directly to the user as an explicit question or action item. Do not leave it only inside the decision table.
-28. If there is no user action required, say so plainly.
-29. If the user also asks for review, use the written artifact as a first-class input to the review rather than recreating the analysis from scratch.
+2. If a plan/ticket/description is supplied, infer behavior to map: control-flow surfaces, retries/recovery/finalization, validation/error paths, state transitions, durable side effects. Ignore purely mechanical edits.
+3. Read the plan first (if any) and extract only behaviorally relevant requirements.
+4. Read repo-level guardrails as co-equal requirements: agent instruction files (`AGENTS.md`, `CLAUDE.md`), compatibility rules, contributor docs, API contracts. If the plan and guardrails conflict, record the tension in the artifact, add a `Plan Clarifications` note when appropriate, and surface the conflict to the user if it affects implementation or review.
+5. Read the actual code paths. Build the table from code, not expectations.
+6. For shared routes, handlers, helpers, contracts, or policy surfaces, build a call-site inventory before choosing axes. Search for literal route paths, exported helper names, event names, header/reason/status strings, and shared types. For each caller, record what data it can supply, what response shapes/statuses it expects, peer version skew, and how missing/unknown fields degrade.
+7. For dependencies, model success, null/absent, validation failure, and thrown/rejected branches whenever externally visible behavior depends on them.
+8. Run the behavioral edge-case expansion pass. Apply every category in `references/edge-cases.md`. Each must be represented by rows or an explicit non-applicability note.
+9. Choose a small set of state axes that explain the branch behavior. Reuse the same axes within a behavior area across `Current Code` and `Intended Change`.
+10. Write the artifact using `references/artifact-format.md`.
+11. When a plan is in scope, include `Current Code`, `Intended Change`, `Delta Checklist`, and `Required Tests`. When no plan is in scope, omit `Intended Change` and focus on the current-state table plus gaps or suspicious branches.
+12. For `Required Tests`, name the invariant being proved, the positive path, and the failure or compatibility mutation. A test must prove the specific binding/fallback/diagnostic the row claims; it cannot just trigger a generic rejection.
+13. Once implementation begins, freeze `Current Code` and `Intended Change`. All later updates are append-only in `Verification Findings`, `Fixes Applied`, `Final Alignment Status`, and optional `Plan Clarifications`.
+14. After implementation, verify the final code against the intended behavior. If drift, missing edges, missing tests, or guardrail violations exist, fix them, append the verification/fix sections, and re-verify until aligned.
+15. Group `Fixes Applied` by discovery source when more than one source exists (e.g., `Initial verification`, `Runtime testing`, `Review findings`, `Validation failures`, `Repo guardrails`, `Plan clarification`, `Final hygiene`). Do not leave a broad `During verification` bucket once other sources have produced fixes.
+16. Treat `Verification Findings` as a resolution queue, not a backlog. Every finding must be (a) fixed, (b) marked not applicable with source-backed evidence, or (c) carried into `Final Alignment Status: Not aligned` with a specific human/external blocker (credentials, deployment access, product decision, etc.). Do not record fixable repo-local work as a permanent gap when the user asked for implementation.
+17. Before marking final alignment, run two passes:
+    - **Internal consistency:** if the same state, reason, or dependency failure appears with different intended outcomes, add the missing distinguishing axis or fix the mismatch.
+    - **Review-prevention:** for every touched externally visible surface, walk `references/review-prevention.md`. Each item must be fixed, already covered by a named row/test, marked not applicable with reason, or carried into `Not aligned`. Do not mark `Aligned` while any item is merely assumed covered.
+18. Only change `Intended Change` post-implementation if the plan itself was ambiguous or wrong. Record this as `Plan Clarifications` with reason and source. Never silently rewrite the target.
+19. Always give the user a human-facing closeout summary outside the artifact. Separate: what was verified and fixed, important nuances, and anything still requiring user input or external action. If the agent cannot complete something autonomously (product decision, credentials, deployment access), ask the user directly. If no user action is required, say so. If the user also asked for review, use the artifact as a first-class input rather than recreating the analysis.
 
 ## Table Rules
 
 - Prefer rows over prose. If a behavioral difference matters, capture it as a row.
-- Keep row wording compact and behaviorally specific.
-- Default to one artifact per plan or work item, with internal sections for distinct behavior areas when needed.
-- Use source references for non-obvious rows:
-  - workspace files with clickable links
-  - plan identifiers or URLs for intended behavior
-- Separate explicit requirements from inference. If the plan implies behavior that is not directly stated, label that as inferred.
-- When repo-level guardrails impose compatibility, version-skew, or fallback requirements, include them in `Intended Change` even if the plan text is narrower.
-- Treat an entry path as an actual caller plus its capabilities, not just a route or module name. Include rows for callers that cannot provide newly required headers, proof material, payload fields, or response handling.
-- Call out parity requirements between entry paths, such as live path vs recovery path, upload path vs replay path, retry path vs terminal path, middleware path vs direct route path, or internal caller vs external caller.
-- When two entry paths are meant to enforce the same policy, final verification should confirm a shared helper or focused parity tests unless there is a documented reason to keep duplicated logic.
-- For route handlers, RPC handlers, webhooks, and other contract surfaces, include rows for dependency throws/rejections whenever the handler promises exact externally visible status codes or error bodies.
-- For structured-result or compatibility surfaces, include rows or explicit non-applicability notes for newly introduced throw-capable preparation code and framework-managed retry/reconnect paths before marking final alignment.
-- For shared helpers or exported boundaries, do not rely only on caller-side validation. Either record that the boundary enforces its own invariants, or record why the boundary is intentionally private/single-caller and how that is kept true.
-- For contracts with multiple decision signals, include rows or explicit non-applicability notes for signal precedence, including conflicts between transport-level and payload-level signals, older peers that omit newer fields, and newer peers that send unknown fields or values.
-- For stateful flows with in-progress guards, waits, delays, timers, retries, or asynchronous continuations, include rows or explicit non-applicability notes for new work arriving while processing is active, after one-time side effects have happened, and before/during/after shutdown or cancellation.
-- For stateful approval, denial, cancellation, expiration, consumption, or completion flows, require transition rows for every mutating action from terminal states. Final verification must prove terminal states cannot be overwritten by later actions unless the intended table explicitly allows a rollback or superseding transition.
-- For time-window checks, require both stale/too-old and future/too-new rows unless future values are impossible by construction and that construction is documented.
-- For cleanup, consume, or delete behavior, require parity rows for invalid and dependency-failure branches, not only valid or happy-path branches.
-- For deletion, revocation, rotation, or clearing of durable keys, credentials, identities, files, locks, cache entries, profiles, or state bundles, require reference-safety rows proving the resource is not still used by another saved profile, active runtime identity, fallback identity, retry path, or recovery path before deletion.
-- For save, duplicate, import, switch, or snapshot flows, require profile/config identity rows proving which fields are copied versus regenerated or omitted. Final verification must prove a new profile/config cannot accidentally inherit another profile's ownership-scoped service ID, device ID, integration ID, signing key, public key, machine identity, or credential binding.
-- For enumerated external outcomes, verify that every advertised status/reason/value is produced by some branch, and every produced value is documented by the table.
-- For path, identity, or policy comparisons, include rows or explicit non-applicability notes for canonicalization and equivalence classes such as aliases, symbolic references, separator differences, case differences, parent/child lookalikes, and non-existent targets.
-- For partial updates to nested objects, JSON blobs, metadata, configuration, or persisted state bundles, require rows that distinguish merge-vs-replace behavior and prove omitted existing fields are preserved unless full replacement is explicitly intended.
-- For schema or persistence changes, require an access-path inventory for every new index and constraint. Remove or mark not-applicable any index that is not justified by a current query, rate limit, cleanup path, uniqueness guarantee, sort order, or explicitly documented near-term requirement.
-- For serverless or edge route handlers, do not treat fire-and-forget promises as durable unless the code awaits them, passes them to a platform lifecycle primitive, persists work for later processing, or explicitly declares the side effect best-effort.
-- For wire contracts that cross packages, apps, repos, or process boundaries, prefer shared constants/types for header names, reason strings, modes, status meanings, and response shapes. If constants are duplicated, record the drift risk or add a follow-up.
-- For signing, canonicalization, validation, and compatibility tests, require a positive control and one-axis mutation when the decision row claims a specific field binding or fallback behavior.
-- For retry or recovery tests, require a positive retryable case, a terminal/non-retryable case, and an unknown-or-legacy-shape case when the contract supports partial or version-skewed peers.
-- For lifecycle re-entry tests, require an idle path, an active-processing path, and a drain or terminal-outcome assertion when the implementation queues, coalesces, deduplicates, drops, or rejects repeated work.
-- For path-policy tests, require a safe positive control, a blocked canonical control, and at least one equivalent or near-equivalent mutation that could bypass naive string comparison.
-- If the same state or failure reason appears in multiple rows with different intended outcomes, add the missing axis or flag the contradiction before implementation.
+- Keep wording compact and behaviorally specific. Use clickable file links and plan IDs/URLs for non-obvious rows.
+- Treat an entry path as actual caller plus capabilities, not just a route or module name. Include rows for callers that cannot supply newly required headers, proof material, payload fields, or response handling.
+- Call out parity requirements between entry paths (live vs recovery, upload vs replay, retry vs terminal, middleware vs direct, internal vs external). When two entry paths must enforce the same policy, final verification should confirm a shared helper or focused parity tests unless duplication is intentionally documented.
+- Separate explicit requirements from inference. When the plan implies behavior without stating it, label the row inferred.
+- When repo guardrails impose compatibility, version-skew, or fallback requirements, include them in `Intended Change` even if the plan text is narrower.
 - Surface externally visible outcomes, not just internal branches.
-- `Current Code` is a pre-implementation baseline snapshot. Freeze it once implementation begins.
-- `Intended Change` is the target behavior derived from the plan or work item. Do not rewrite it to match final code.
-- Post-implementation updates must be append-only in `Verification Findings`, `Fixes Applied`, `Final Alignment Status`, and optional `Plan Clarifications`.
-- `Fixes Applied` should be grouped by discovery source once the section contains more than one source of fixes. Keep each group factual and tied to a corresponding finding, validation failure, review issue, runtime check, guardrail issue, or final hygiene step.
-- `Verification Findings` is not a passive backlog. Every finding must have a matching fix, a source-backed not-applicable explanation, or a `Not aligned` blocker that requires user input, credentials, external access, deployment state, or a product decision.
-- Do not use soft final states such as `Partially aligned`, `Mostly aligned`, or `Recorded Gaps`. Use `Aligned` only when no known fixable drift or required-test gap remains. Otherwise use `Not aligned` and state the blocker or required user action.
-- Do not mark `Final Alignment Status` as aligned if repo-level guardrails are violated, if a required backward-compatible fallback path is missing, or if plan-vs-guardrail tension remains unresolved.
-- Do not mark `Final Alignment Status` as aligned for a structured-result or compatibility surface until all newly introduced throw-capable preparation code and framework-managed retry/reconnect paths are represented by either a decision-table row or an explicit non-applicability note.
-- Do not mark `Final Alignment Status` as aligned until the review-prevention pass has covered every touched externally visible surface and recorded how likely review findings were prevented or ruled out.
-- The decision table is an LLM working artifact, not the only communication channel for the human user.
-- Never bury user-actionable information only in the artifact; surface it in the final response.
+- For wire contracts crossing packages, apps, repos, or process boundaries, prefer shared constants/types for header names, reason strings, modes, status meanings, and response shapes. If duplicated, record the drift risk or add a follow-up.
+- If the same state or failure reason appears in multiple rows with different intended outcomes, add the missing axis or flag the contradiction before implementation.
+- Do not use soft final states (`Partially aligned`, `Mostly aligned`, `Recorded Gaps`). Use `Aligned` only when no known fixable drift or required-test gap remains; otherwise `Not aligned` with the blocker.
+- Do not mark `Aligned` if repo guardrails are violated, a required backward-compatible fallback is missing, plan/guardrail tension is unresolved, throw-capable preparation or framework-managed retry/reconnect paths are unrepresented, or the review-prevention pass is incomplete.
+- The decision table is an LLM working artifact. Never bury user-actionable information only in the artifact; surface it in the final response.
 
 ## Prompt Guidance
 
-Good default invocation:
+Default invocation:
 
-`Invoke the decision-table skill for this work item. Infer what needs to be mapped, write one artifact under .closedloop-ai/decision-tables/, then implement, verify final code against that artifact, and fix any drift or missing tests before finishing. Treat verification findings as a resolution queue, not a backlog: every finding must be fixed, proven not applicable, or carried into Final Alignment Status: Not aligned with a concrete human/external blocker. Keep the baseline and target sections frozen; append verification and fixes instead of rewriting them.`
+> Invoke the decision-table skill for this work item. Infer what needs to be mapped, write one artifact under `.closedloop-ai/decision-tables/`, then implement, verify final code against that artifact, and fix any drift or missing tests before finishing. Treat verification findings as a resolution queue: every finding must be fixed, proven not applicable, or carried into `Final Alignment Status: Not aligned` with a concrete human/external blocker. Keep baseline and target sections frozen; append verification and fixes.
 
-When a plan exists:
-
-`Invoke the decision-table skill with PLAN-123. Before coding, generate the current-state and intended-state decision table for the full plan, write it to .closedloop-ai/decision-tables/plan-123.md, and incorporate repo guardrails such as agent instruction files and compatibility docs as co-equal requirements. Then implement the plan, verify final code against that artifact, and fix any drift or missing tests before finishing. Treat verification findings as a resolution queue, not a backlog: every finding must be fixed, proven not applicable, or carried into Final Alignment Status: Not aligned with a concrete human/external blocker. Keep the baseline and target sections frozen; append verification and fixes instead of rewriting them.`
-
-When you want the requirement spelled out even more explicitly:
-
-`Invoke the decision-table skill with PLAN-123. Before coding, generate the current-state and intended-state decision table for the full plan and write it to .closedloop-ai/decision-tables/plan-123.md. Read repo guardrails such as agent instruction files and compatibility docs and treat them as co-equal requirements. Model dependency success, null/absent, and thrown/rejected branches anywhere the surface promises exact status or error behavior. Then implement the plan. After implementation, verify the final code against the intended table. If the code, tests, artifact, or compatibility behavior drift from the intended behavior, fix the issues, append verification and fix sections, and re-verify until aligned. Treat verification findings as a resolution queue, not a backlog: every finding must be fixed, proven not applicable, or carried into Final Alignment Status: Not aligned with a concrete human/external blocker. Do not rewrite the baseline or intended sections unless you are explicitly recording a plan clarification.`
+When a plan is in scope, replace "this work item" with the plan ID, point the artifact path at `.closedloop-ai/decision-tables/<plan-id>.md`, and add: "Read repo guardrails such as agent instruction files and compatibility docs and treat them as co-equal requirements. Model dependency success, null/absent, and thrown/rejected branches anywhere the surface promises exact status or error behavior."
 
 ## Human Handoff
 
-The final user-facing message must not assume the user will read the decision table.
-
-Include a concise summary of:
+The final user-facing message must not assume the user will read the artifact. Include:
 
 - what was verified
 - what was fixed
 - any behavior nuance or plan clarification the user should know
-- any external or human action required
-
-If the agent cannot complete something autonomously because it requires a product decision, credentials, deployment access, or another human-controlled step, ask the user directly in the final response.
-
-If there is no human action required, say that explicitly.
+- any external/human action required (asked directly, not buried in the artifact)
+- "no user action required" when that applies
 
 ## Review Guidance
 
-Normal review is enough once the artifact exists. Review the change against the decision table, the plan, and repo-level guardrails such as agent instruction files, compatibility rules, and contributor docs. Treat any mismatches as issues to fix, not just findings to report, and surface any remaining user-actionable items directly in the final response.
+Normal review is enough once the artifact exists. Review the change against the decision table, the plan, and repo-level guardrails. Treat mismatches as issues to fix, not just findings to report, and surface user-actionable items directly in the final response.
 
-For contract-heavy work, explicitly review:
-
-- new-shape and old/unknown-shape compatibility behavior when repo guardrails require version-skew safety
-- precedence between competing decision signals, such as status, structured fields, error codes, headers, metadata, exit state, and persisted markers
-- call-site inventory completeness for shared routes, helpers, contracts, and policy surfaces
-- caller capability differences, especially callers that cannot supply newly required headers, proof material, fields, or response handling
-- dependency throw/reject branches on route or handler surfaces that promise exact status codes or error bodies
-- catch-all error handling that may map unrelated failures to a specific auth, verifier, validation, or dependency diagnostic
-- in-progress guards that return without preserving, rejecting, or explicitly classifying later work
-- terminal-state guards that fail to preserve approved, denied, expired, consumed, completed, cancelled, revoked, or failed state when a later or repeated action arrives
-- retries or replays that reuse resources after delete, consume, rotate, invalidate, acknowledge, commit, upload, or lock side effects
-- destructive cleanup that deletes a shared durable resource still referenced by another profile, active runtime identity, fallback identity, retry path, or recovery path
-- path, identity, and policy checks that compare raw spelling instead of normalized or canonical equivalents where equivalence matters
-- partial updates that overwrite unrelated fields in nested objects, JSON blobs, metadata, configuration, or persisted state bundles when the intended behavior is additive or merge-preserving
-- schema indexes or constraints that are redundant, unused by current access paths, mismatched to predicates or sort orders, or added for write-only metadata without a documented read path
-- serverless async side effects that may be dropped unless awaited, scheduled with a platform primitive, or persisted
-- test oracle quality for canonicalization, signing, validation, and compatibility rows
-- duplicated policy logic or wire-contract constants that can drift between intended-parity entry paths
-- whether `Final Alignment Status` is still defensible given the implemented compatibility and failure behavior
-
-A separate review skill is only worth adding if this becomes a repeated, high-volume workflow and you want a fixed review rubric layered on top of the existing review prompt.
+For contract-heavy work, walk `references/review-prevention.md` against the implemented surfaces. A separate review skill is only worth adding if this becomes a repeated, high-volume workflow that needs a fixed rubric layered on top of the existing review prompt.
 
 ## Optional Mermaid
 
-Only produce a Mermaid diagram if the user asks for it or if the table is too large to scan quickly. The Mermaid should be derived from the decision table, not the other way around.
+Only produce a Mermaid diagram if the user asks for it or if the table is too large to scan quickly. Derive Mermaid from the decision table, not the other way around.

--- a/plugins/code/skills/decision-table/SKILL.md
+++ b/plugins/code/skills/decision-table/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: decision-table
+description: Use when the user wants a code-grounded decision table for current behavior, wants to compare current behavior against a plan or work item, or needs a control-flow artifact for recovery, retry, finalization, validation, state-machine, or review-heavy edge cases.
+---
+
+# Decision Table
+
+## Purpose
+
+Generate a repo-local decision-table artifact that makes control-flow and stateful edge cases reviewable.
+
+Use the decision table as the source of truth. A flowchart is optional and secondary.
+
+## Output Location
+
+Write artifacts under:
+
+`<repo-root>/.closedloop-ai/decision-tables/`
+
+Create the directory if it does not exist.
+
+Default to one artifact per full work item:
+
+- plan-scoped: `<plan-id>.md`
+- non-plan-scoped: `<short-work-name>.md`
+
+Use lowercase kebab-case for non-plan names.
+
+If the work item contains multiple important behavior areas, keep them as sections inside the same artifact.
+
+Only split into multiple files when one artifact would be too large to review quickly or when the work clearly spans separate repos or systems.
+
+## Workflow
+
+1. Resolve the repo root and the work item under review.
+2. If the user supplied a plan, ticket, or work description, infer what behavior needs to be mapped:
+   - control-flow or stateful surfaces that can change externally visible behavior
+   - retries, recovery, replay, or finalization paths
+   - validation, rejection, and error handling paths
+   - state transitions and durable side effects
+3. Ignore purely mechanical edits unless they change behavior.
+4. If the user supplied a plan, read it first and extract only behaviorally relevant requirements.
+5. Read repo-level guardrails that can constrain or overrule the plan, such as agent instruction files (`AGENTS.md`, `CLAUDE.md`, or equivalent), compatibility rules, contributor docs, and API contract guidance. Treat these as co-equal requirements, not optional context.
+6. If the plan and repo-level guardrails conflict, do not silently pick one. Record the tension in the artifact, add a `Plan Clarifications` note when appropriate, and surface the conflict to the user if it affects implementation or review.
+7. Read the code paths that currently implement the work item. Build the table from code, not from expectations.
+8. For shared routes, handlers, helpers, contracts, or policy surfaces, build a call-site inventory before choosing axes. Search for literal route paths, exported helper names, event names, header/reason/status strings, and shared types. For each caller, record what data it can supply, what response shapes/statuses it expects, whether older or newer peer versions exist, and how missing or unknown fields degrade.
+9. When mapping handlers, services, or adapters, explicitly model dependency outcomes that can change externally visible behavior: success, null/absent, validation failure, and thrown/rejected dependency failure when the callee can throw or reject.
+10. Before implementation, run a behavioral edge-case expansion pass for each intended row:
+   - Structured-result contracts: include rows for synchronous preparation failures before fetch/await/return, such as URL construction, payload building, JSON/body/header construction, parser setup, and other throw-capable setup code.
+   - Exported boundary invariants: when a helper, service, adapter, route, command, job, or handler can be called by more than one path, include rows for the invariants it must enforce itself even when current callers validate first, especially before network I/O, persistence, credentials, filesystem mutation, or other durable side effects.
+   - Contract-signal precedence: when a dependency or peer returns multiple signals that can affect the same decision, such as transport status, structured body fields, error codes, reason strings, headers, metadata, exit status, or sentinel files, include rows for each signal and for conflicts between signals. State which signal wins and how unknown or missing signals degrade.
+   - Library-managed lifecycle re-entry: include rows for automatic reconnects, retry timers, callbacks, restarts, framework-owned replays, and other paths that can re-enter with reused state.
+   - Active-processing re-entry: when a flow can receive a new event, request, callback, file, message, or retry while an earlier item is still being handled, include rows for idle, active, queued, coalesced, duplicate, dropped, and shutdown states as applicable. State when pending work drains and whether callers see a retryable, terminal, or silent outcome.
+   - Terminal-state transition guards: when a flow has terminal or one-way states such as approved, denied, expired, consumed, completed, cancelled, revoked, or failed, include rows for every mutating action attempted from each terminal state. State which states are mutable, which are no-ops, which return a terminal error, and which durable fields must never be rewritten. Include repeated UI actions such as approve-then-deny, deny-then-approve, double-clicks, retries after timeout, and stale browser tabs after another actor already completed the flow.
+   - Cancellation and shutdown: when a flow waits, sleeps, backs off, schedules a timer, retries, or runs asynchronously, include rows for cancellation or shutdown before the wait, during the wait, after the wait but before the next side effect, and during the side effect when applicable.
+   - Time-bound credentials, signatures, or payloads: include rows for first attempt, retry/reconnect, restart, expired past timestamps, future timestamps, and clock-boundary conditions, and state whether timestamped or expiring material is regenerated, rejected, or reused.
+   - One-time side effects: when a flow deletes, consumes, rotates, invalidates, acknowledges, commits, uploads, locks, or otherwise spends a one-time resource, include rows for failures and re-entry before and after that side effect. Include cleanup or consume failures on success, validation failure, parse failure, and dependency failure branches when those branches attempt cleanup. State whether the resource can be safely reused, retried, replaced, or must be considered spent.
+   - Shared durable resources: when deleting, rotating, revoking, or clearing persisted keys, credentials, locks, cache entries, files, profiles, identities, or other durable resources, include rows for no remaining references, another saved/profile reference, active runtime reference, stale reference, and unknown lookup failure. State whether the resource is reference-counted, ownership-scoped, shared, or safe to delete unconditionally.
+   - Profile or config cloning: when saving, duplicating, importing, switching, or snapshotting a profile/config from active runtime state, include rows for fields that must be copied, regenerated, omitted, or downgraded. Treat credentials, signing keys, service IDs, device IDs, integration IDs, public keys, machine identities, and other ownership-scoped identifiers as non-transferable by default unless the plan explicitly says they are shared.
+   - Diagnostic contracts: when the plan requires redacted diagnostics, telemetry, or structured reasons, include expected reason/category values for each failure class, such as validation failure, missing state, unavailable secure storage, signer failure, timeout, network failure, and remote rejection.
+   - Advertised status inventory: when code exposes statuses, reasons, modes, variants, exit values, event names, or other enumerated outcomes, inventory which branches can produce each value and flag dead, unreachable, duplicated, or misleading values.
+   - Exception scope: for route handlers, middleware, auth wrappers, and policy helpers, distinguish setup failures, auth/proof failures, database or lookup failures, and downstream handler failures so catch-all blocks do not collapse unrelated errors into the same external status or message.
+   - Serverless async side effects: for serverless or edge route handlers, include rows for side effects that happen after the response path, such as last-used timestamps, telemetry, uploads, notifications, and cleanup. State whether they are awaited, passed to a platform lifecycle primitive such as `waitUntil` where available, persisted through an outbox, or intentionally best-effort.
+   - Path and identity policy canonicalization: for allowlists, denylists, ownership checks, cache keys, dedupe keys, lock keys, object identifiers, and other policy comparisons, include rows for raw input, normalized form, canonical form, aliases, symbolic references, case or separator variants, parent/child boundaries, empty values, and missing targets where applicable.
+   - Partial update preservation: when a route or service updates a nested object, JSON blob, configuration record, metadata map, or persisted state bundle, include rows for omitted fields, explicit empty/null fields, single-field updates, and full replacement. State whether the operation merges with existing state or replaces it, and which existing fields must survive unknown or partial updates.
+   - Persistence access paths: when adding persisted fields, tables, indexes, uniqueness constraints, or cleanup jobs, inventory the actual reads, writes, filters, sort orders, expiry scans, rate limits, and ownership checks that will use them. Distinguish query-critical indexes from write-only metadata, future-only fields, redundant left-prefix indexes, and indexes that need additional columns to match the real predicate.
+   - Side-effect boundary: for every validation or preparation failure, state whether network calls, persistence, key generation, retries, telemetry, or other durable side effects should happen.
+   - Testable invariant: for signing, canonicalization, validation, and compatibility rows, state the exact invariant a test must prove, including a positive control and one-axis mutation when a field binding matters.
+11. Choose a small set of state axes that explain the branch behavior. Reuse the same axes within each behavior area for current and intended tables.
+12. Write the artifact using the format in `references/artifact-format.md`.
+13. When a plan is in scope, include:
+   - `Current Code`
+   - `Intended Change`
+   - `Delta Checklist`
+   - `Required Tests`
+14. When writing `Required Tests`, name the invariant being proved, the positive path, and the failure or compatibility mutation. Do not let a test merely trigger a generic rejection when the row claims to prove a specific binding, fallback, or diagnostic reason.
+15. When no plan is in scope, omit `Intended Change` and focus on the current-state table plus gaps or suspicious branches.
+16. Once implementation begins, treat `Current Code` and `Intended Change` as frozen. Do not rewrite them to match the final implementation.
+17. After implementation, verify the final code against the intended behavior in the artifact by appending:
+   - `Verification Findings`
+   - `Fixes Applied`
+   - `Final Alignment Status`
+18. If verification or review finds drift, behavioral mismatches, missing edge cases, missing tests, or repo-guardrail violations, fix them in the code and tests, append the verification/fix sections, and re-verify until the final code aligns with the intended behavior.
+19. Organize `Fixes Applied` by discovery source when more than one source exists. Use source labels such as `Initial verification`, `Runtime/manual testing`, `Review findings`, `Validation failures`, `Repo guardrails`, `Plan clarification`, and `Final hygiene`. Do not leave a broad `During verification` bucket once review, runtime, validation, or follow-up fixes have also been applied.
+20. Treat `Verification Findings` as a resolution queue, not a backlog. Every finding must be fixed, marked not applicable with evidence, or carried into `Final Alignment Status: Not aligned` with the specific human/external blocker that prevents autonomous completion. Do not leave fixable repo-local work as a recorded gap when the user asked for implementation.
+21. Before marking final alignment, run an internal consistency pass over the artifact. If the same state, reason, or dependency failure appears with different intended external outcomes, add the missing distinguishing axis, record a plan clarification, or treat it as a mismatch to fix.
+22. Before marking final alignment, run a review-prevention pass over every touched externally visible surface. For each changed route, handler, service, command, adapter, UI action, persisted-state update, and shared helper, ask whether a code reviewer could still find:
+   - an unmodeled dependency throw/reject branch that maps to the wrong external status, retryability, or message
+   - a terminal-state or repeated-action mutation that overwrites durable state
+   - a partial update that drops unrelated existing nested/JSON/config/metadata fields
+   - a feature-flag, rollout, or permission path that bypasses the intended gate or uses the wrong identity
+   - a caller or version-skew path that cannot supply a newly required field, header, proof, or response shape
+   - duplicated policy, helper, constant, or wire-contract logic that should be shared or parity-tested
+   - a test that asserts only that something failed, without proving the specific invariant, fallback, binding, or diagnostic reason from the table
+23. For every item from the review-prevention pass, add a verification note: fixed, already covered by a named row/test, not applicable with the reason, or `Not aligned` with the human/external blocker. Do not mark `Aligned` while any item is merely assumed covered.
+24. Only change `Intended Change` after implementation if the plan itself was ambiguous or incorrect. When that happens, add an explicit `Plan Clarifications` note with the reason and source rather than silently rewriting the target behavior.
+25. Always give the user a human-facing closeout summary outside the artifact after verification is complete.
+26. In that closeout summary, explicitly separate:
+   - what was verified and fixed
+   - important nuances the user should know
+   - anything that still needs user input or external action
+27. If there is any user-actionable item that the agent cannot safely complete itself, surface it directly to the user as an explicit question or action item. Do not leave it only inside the decision table.
+28. If there is no user action required, say so plainly.
+29. If the user also asks for review, use the written artifact as a first-class input to the review rather than recreating the analysis from scratch.
+
+## Table Rules
+
+- Prefer rows over prose. If a behavioral difference matters, capture it as a row.
+- Keep row wording compact and behaviorally specific.
+- Default to one artifact per plan or work item, with internal sections for distinct behavior areas when needed.
+- Use source references for non-obvious rows:
+  - workspace files with clickable links
+  - plan identifiers or URLs for intended behavior
+- Separate explicit requirements from inference. If the plan implies behavior that is not directly stated, label that as inferred.
+- When repo-level guardrails impose compatibility, version-skew, or fallback requirements, include them in `Intended Change` even if the plan text is narrower.
+- Treat an entry path as an actual caller plus its capabilities, not just a route or module name. Include rows for callers that cannot provide newly required headers, proof material, payload fields, or response handling.
+- Call out parity requirements between entry paths, such as live path vs recovery path, upload path vs replay path, retry path vs terminal path, middleware path vs direct route path, or internal caller vs external caller.
+- When two entry paths are meant to enforce the same policy, final verification should confirm a shared helper or focused parity tests unless there is a documented reason to keep duplicated logic.
+- For route handlers, RPC handlers, webhooks, and other contract surfaces, include rows for dependency throws/rejections whenever the handler promises exact externally visible status codes or error bodies.
+- For structured-result or compatibility surfaces, include rows or explicit non-applicability notes for newly introduced throw-capable preparation code and framework-managed retry/reconnect paths before marking final alignment.
+- For shared helpers or exported boundaries, do not rely only on caller-side validation. Either record that the boundary enforces its own invariants, or record why the boundary is intentionally private/single-caller and how that is kept true.
+- For contracts with multiple decision signals, include rows or explicit non-applicability notes for signal precedence, including conflicts between transport-level and payload-level signals, older peers that omit newer fields, and newer peers that send unknown fields or values.
+- For stateful flows with in-progress guards, waits, delays, timers, retries, or asynchronous continuations, include rows or explicit non-applicability notes for new work arriving while processing is active, after one-time side effects have happened, and before/during/after shutdown or cancellation.
+- For stateful approval, denial, cancellation, expiration, consumption, or completion flows, require transition rows for every mutating action from terminal states. Final verification must prove terminal states cannot be overwritten by later actions unless the intended table explicitly allows a rollback or superseding transition.
+- For time-window checks, require both stale/too-old and future/too-new rows unless future values are impossible by construction and that construction is documented.
+- For cleanup, consume, or delete behavior, require parity rows for invalid and dependency-failure branches, not only valid or happy-path branches.
+- For deletion, revocation, rotation, or clearing of durable keys, credentials, identities, files, locks, cache entries, profiles, or state bundles, require reference-safety rows proving the resource is not still used by another saved profile, active runtime identity, fallback identity, retry path, or recovery path before deletion.
+- For save, duplicate, import, switch, or snapshot flows, require profile/config identity rows proving which fields are copied versus regenerated or omitted. Final verification must prove a new profile/config cannot accidentally inherit another profile's ownership-scoped service ID, device ID, integration ID, signing key, public key, machine identity, or credential binding.
+- For enumerated external outcomes, verify that every advertised status/reason/value is produced by some branch, and every produced value is documented by the table.
+- For path, identity, or policy comparisons, include rows or explicit non-applicability notes for canonicalization and equivalence classes such as aliases, symbolic references, separator differences, case differences, parent/child lookalikes, and non-existent targets.
+- For partial updates to nested objects, JSON blobs, metadata, configuration, or persisted state bundles, require rows that distinguish merge-vs-replace behavior and prove omitted existing fields are preserved unless full replacement is explicitly intended.
+- For schema or persistence changes, require an access-path inventory for every new index and constraint. Remove or mark not-applicable any index that is not justified by a current query, rate limit, cleanup path, uniqueness guarantee, sort order, or explicitly documented near-term requirement.
+- For serverless or edge route handlers, do not treat fire-and-forget promises as durable unless the code awaits them, passes them to a platform lifecycle primitive, persists work for later processing, or explicitly declares the side effect best-effort.
+- For wire contracts that cross packages, apps, repos, or process boundaries, prefer shared constants/types for header names, reason strings, modes, status meanings, and response shapes. If constants are duplicated, record the drift risk or add a follow-up.
+- For signing, canonicalization, validation, and compatibility tests, require a positive control and one-axis mutation when the decision row claims a specific field binding or fallback behavior.
+- For retry or recovery tests, require a positive retryable case, a terminal/non-retryable case, and an unknown-or-legacy-shape case when the contract supports partial or version-skewed peers.
+- For lifecycle re-entry tests, require an idle path, an active-processing path, and a drain or terminal-outcome assertion when the implementation queues, coalesces, deduplicates, drops, or rejects repeated work.
+- For path-policy tests, require a safe positive control, a blocked canonical control, and at least one equivalent or near-equivalent mutation that could bypass naive string comparison.
+- If the same state or failure reason appears in multiple rows with different intended outcomes, add the missing axis or flag the contradiction before implementation.
+- Surface externally visible outcomes, not just internal branches.
+- `Current Code` is a pre-implementation baseline snapshot. Freeze it once implementation begins.
+- `Intended Change` is the target behavior derived from the plan or work item. Do not rewrite it to match final code.
+- Post-implementation updates must be append-only in `Verification Findings`, `Fixes Applied`, `Final Alignment Status`, and optional `Plan Clarifications`.
+- `Fixes Applied` should be grouped by discovery source once the section contains more than one source of fixes. Keep each group factual and tied to a corresponding finding, validation failure, review issue, runtime check, guardrail issue, or final hygiene step.
+- `Verification Findings` is not a passive backlog. Every finding must have a matching fix, a source-backed not-applicable explanation, or a `Not aligned` blocker that requires user input, credentials, external access, deployment state, or a product decision.
+- Do not use soft final states such as `Partially aligned`, `Mostly aligned`, or `Recorded Gaps`. Use `Aligned` only when no known fixable drift or required-test gap remains. Otherwise use `Not aligned` and state the blocker or required user action.
+- Do not mark `Final Alignment Status` as aligned if repo-level guardrails are violated, if a required backward-compatible fallback path is missing, or if plan-vs-guardrail tension remains unresolved.
+- Do not mark `Final Alignment Status` as aligned for a structured-result or compatibility surface until all newly introduced throw-capable preparation code and framework-managed retry/reconnect paths are represented by either a decision-table row or an explicit non-applicability note.
+- Do not mark `Final Alignment Status` as aligned until the review-prevention pass has covered every touched externally visible surface and recorded how likely review findings were prevented or ruled out.
+- The decision table is an LLM working artifact, not the only communication channel for the human user.
+- Never bury user-actionable information only in the artifact; surface it in the final response.
+
+## Prompt Guidance
+
+Good default invocation:
+
+`Invoke the decision-table skill for this work item. Infer what needs to be mapped, write one artifact under .closedloop-ai/decision-tables/, then implement, verify final code against that artifact, and fix any drift or missing tests before finishing. Treat verification findings as a resolution queue, not a backlog: every finding must be fixed, proven not applicable, or carried into Final Alignment Status: Not aligned with a concrete human/external blocker. Keep the baseline and target sections frozen; append verification and fixes instead of rewriting them.`
+
+When a plan exists:
+
+`Invoke the decision-table skill with PLAN-123. Before coding, generate the current-state and intended-state decision table for the full plan, write it to .closedloop-ai/decision-tables/plan-123.md, and incorporate repo guardrails such as agent instruction files and compatibility docs as co-equal requirements. Then implement the plan, verify final code against that artifact, and fix any drift or missing tests before finishing. Treat verification findings as a resolution queue, not a backlog: every finding must be fixed, proven not applicable, or carried into Final Alignment Status: Not aligned with a concrete human/external blocker. Keep the baseline and target sections frozen; append verification and fixes instead of rewriting them.`
+
+When you want the requirement spelled out even more explicitly:
+
+`Invoke the decision-table skill with PLAN-123. Before coding, generate the current-state and intended-state decision table for the full plan and write it to .closedloop-ai/decision-tables/plan-123.md. Read repo guardrails such as agent instruction files and compatibility docs and treat them as co-equal requirements. Model dependency success, null/absent, and thrown/rejected branches anywhere the surface promises exact status or error behavior. Then implement the plan. After implementation, verify the final code against the intended table. If the code, tests, artifact, or compatibility behavior drift from the intended behavior, fix the issues, append verification and fix sections, and re-verify until aligned. Treat verification findings as a resolution queue, not a backlog: every finding must be fixed, proven not applicable, or carried into Final Alignment Status: Not aligned with a concrete human/external blocker. Do not rewrite the baseline or intended sections unless you are explicitly recording a plan clarification.`
+
+## Human Handoff
+
+The final user-facing message must not assume the user will read the decision table.
+
+Include a concise summary of:
+
+- what was verified
+- what was fixed
+- any behavior nuance or plan clarification the user should know
+- any external or human action required
+
+If the agent cannot complete something autonomously because it requires a product decision, credentials, deployment access, or another human-controlled step, ask the user directly in the final response.
+
+If there is no human action required, say that explicitly.
+
+## Review Guidance
+
+Normal review is enough once the artifact exists. Review the change against the decision table, the plan, and repo-level guardrails such as agent instruction files, compatibility rules, and contributor docs. Treat any mismatches as issues to fix, not just findings to report, and surface any remaining user-actionable items directly in the final response.
+
+For contract-heavy work, explicitly review:
+
+- new-shape and old/unknown-shape compatibility behavior when repo guardrails require version-skew safety
+- precedence between competing decision signals, such as status, structured fields, error codes, headers, metadata, exit state, and persisted markers
+- call-site inventory completeness for shared routes, helpers, contracts, and policy surfaces
+- caller capability differences, especially callers that cannot supply newly required headers, proof material, fields, or response handling
+- dependency throw/reject branches on route or handler surfaces that promise exact status codes or error bodies
+- catch-all error handling that may map unrelated failures to a specific auth, verifier, validation, or dependency diagnostic
+- in-progress guards that return without preserving, rejecting, or explicitly classifying later work
+- terminal-state guards that fail to preserve approved, denied, expired, consumed, completed, cancelled, revoked, or failed state when a later or repeated action arrives
+- retries or replays that reuse resources after delete, consume, rotate, invalidate, acknowledge, commit, upload, or lock side effects
+- destructive cleanup that deletes a shared durable resource still referenced by another profile, active runtime identity, fallback identity, retry path, or recovery path
+- path, identity, and policy checks that compare raw spelling instead of normalized or canonical equivalents where equivalence matters
+- partial updates that overwrite unrelated fields in nested objects, JSON blobs, metadata, configuration, or persisted state bundles when the intended behavior is additive or merge-preserving
+- schema indexes or constraints that are redundant, unused by current access paths, mismatched to predicates or sort orders, or added for write-only metadata without a documented read path
+- serverless async side effects that may be dropped unless awaited, scheduled with a platform primitive, or persisted
+- test oracle quality for canonicalization, signing, validation, and compatibility rows
+- duplicated policy logic or wire-contract constants that can drift between intended-parity entry paths
+- whether `Final Alignment Status` is still defensible given the implemented compatibility and failure behavior
+
+A separate review skill is only worth adding if this becomes a repeated, high-volume workflow and you want a fixed review rubric layered on top of the existing review prompt.
+
+## Optional Mermaid
+
+Only produce a Mermaid diagram if the user asks for it or if the table is too large to scan quickly. The Mermaid should be derived from the decision table, not the other way around.

--- a/plugins/code/skills/decision-table/references/artifact-format.md
+++ b/plugins/code/skills/decision-table/references/artifact-format.md
@@ -1,0 +1,111 @@
+# Decision Table Artifact Format
+
+Write the artifact to `.closedloop-ai/decision-tables/<slug>.md`.
+
+Use this structure:
+
+```md
+# <work item title>
+
+## Inputs
+
+- Repo: <repo-root-name>
+- Work item: <plan id / ticket / feature / short description>
+- Current code sources:
+  - [path](/abs/path/file.ts:line)
+- Plan sources:
+  - plan id / URL / local file
+- Notes:
+  - assumptions or missing details
+
+## Behavior Areas
+
+- <area 1>: why this area is included
+- <area 2>: why this area is included
+
+## Behavioral Edge-Case Expansion
+
+- Structured-result setup failures: <rows or non-applicability note>
+- Library-managed lifecycle re-entry: <rows or non-applicability note>
+- Time-bound credentials/signatures: <rows or non-applicability note>
+- Diagnostic reason/category taxonomy: <rows or non-applicability note>
+- Side-effect boundaries for validation/preparation failures: <rows or non-applicability note>
+
+## Shared State Axes
+
+- <axis 1>
+- <axis 2>
+- <axis 3>
+
+### <behavior area 1>
+
+#### Current Code
+
+Frozen pre-implementation baseline. Do not rewrite after implementation begins.
+
+| Entry Path | State Inputs | Decision / Branch | Actions / Side Effects | External Outcome | Source |
+| --- | --- | --- | --- | --- | --- |
+| ... | ... | ... | ... | ... | ... |
+
+#### Intended Change
+
+Frozen target behavior derived from the plan or work item. Only change after implementation if you are explicitly recording a plan clarification.
+
+| Entry Path | State Inputs | Decision / Branch | Actions / Side Effects | External Outcome | Source |
+| --- | --- | --- | --- | --- | --- |
+| ... | ... | ... | ... | ... | ... |
+
+### <behavior area 2>
+
+Repeat as needed.
+
+## Delta Checklist
+
+- Behavior that changes
+- Behavior that must stay identical
+- Open questions or plan ambiguities
+
+## Required Tests
+
+- Exact scenario coverage implied by the changed rows
+
+## Verification Findings
+
+- Drift or mismatches found after implementation
+- Missing edge cases or missing tests
+- Every finding must be resolved by a corresponding fix, marked not applicable with source evidence, or carried into `Final Alignment Status: Not aligned` with a specific human/external blocker.
+
+## Fixes Applied
+
+- Code or test fixes made to resolve verification findings
+
+## Final Alignment Status
+
+- `Aligned` or `Not aligned`
+- Short explanation with source links
+- Do not use soft statuses such as `Partially aligned`, `Mostly aligned`, or `Recorded Gaps`.
+- Use `Aligned` only when no known fixable drift or required-test gap remains. Otherwise use `Not aligned` and state the blocker or user action.
+
+## Plan Clarifications
+
+Only include if the plan itself was ambiguous or incorrect and the intended target needed an explicit correction. Do not use this section to silently rewrite the target to match the implementation.
+
+## Optional Mermaid
+
+Only add this section when the user explicitly asks for a flowchart or when the table is too large to review quickly without one.
+```
+
+Guidelines:
+
+- Default to one artifact per plan or work item.
+- Use sections for multiple behavior areas inside one artifact.
+- Only split into multiple files if the work spans clearly separate repos/systems or the single artifact becomes too large to review effectively.
+- Use `Behavioral Edge-Case Expansion` to record behavior-only edge cases that must be represented in rows or explicitly ruled out as not applicable.
+- Keep the same state axes and column meanings across `Current Code` and `Intended Change` within each behavior area.
+- Use additive rows rather than prose for behavior changes whenever possible.
+- Every nontrivial row should include file or plan references.
+- Mark inferred target-state behavior explicitly when the plan implies it but does not say it directly.
+- Freeze `Current Code` and `Intended Change` once implementation begins.
+- Record post-implementation work in `Verification Findings`, `Fixes Applied`, `Final Alignment Status`, and optional `Plan Clarifications`.
+- Treat `Verification Findings` as a resolution queue, not a backlog. Do not leave fixable repo-local work as a recorded gap when the user asked for implementation.
+- Do not assume a human will read this artifact. Anything the user needs to know or do must also be surfaced in the final response.

--- a/plugins/code/skills/decision-table/references/artifact-format.md
+++ b/plugins/code/skills/decision-table/references/artifact-format.md
@@ -25,11 +25,14 @@ Use this structure:
 
 ## Behavioral Edge-Case Expansion
 
+Apply every category in [`edge-cases.md`](edge-cases.md). Each must be represented by rows or an explicit non-applicability note before marking `Final Alignment Status: Aligned`. The bullets below are placeholder shape — the canonical list is in `edge-cases.md`; do not skip categories that are absent from this template.
+
 - Structured-result setup failures: <rows or non-applicability note>
 - Library-managed lifecycle re-entry: <rows or non-applicability note>
 - Time-bound credentials/signatures: <rows or non-applicability note>
 - Diagnostic reason/category taxonomy: <rows or non-applicability note>
 - Side-effect boundaries for validation/preparation failures: <rows or non-applicability note>
+- ... (continue with every category from `edge-cases.md`)
 
 ## Shared State Axes
 

--- a/plugins/code/skills/decision-table/references/edge-cases.md
+++ b/plugins/code/skills/decision-table/references/edge-cases.md
@@ -1,0 +1,97 @@
+# Behavioral Edge-Case Expansion
+
+For each intended row, run this expansion pass. Every category must be represented by rows or an explicit non-applicability note before marking `Final Alignment Status: Aligned`.
+
+Where a category lists test invariants, the test must prove the specific binding/fallback/diagnostic the row claims, not just trigger a generic rejection.
+
+## Structured-result contracts
+
+Include rows for synchronous preparation failures before fetch/await/return: URL construction, payload building, JSON/body/header construction, parser setup, and other throw-capable setup code.
+
+## Exported boundary invariants
+
+When a helper, service, adapter, route, command, job, or handler can be called by more than one path, include rows for the invariants it must enforce itself even when current callers validate first, especially before network I/O, persistence, credentials, filesystem mutation, or other durable side effects. Do not rely only on caller-side validation: either the boundary enforces its own invariants, or record why it is intentionally private/single-caller and how that is kept true.
+
+## Contract-signal precedence
+
+When a dependency or peer returns multiple signals affecting the same decision (transport status, structured body fields, error codes, reason strings, headers, metadata, exit status, sentinel files), include rows for each signal and for conflicts between signals. State which signal wins and how unknown/missing signals degrade. Cover transport-vs-payload conflicts, older peers omitting newer fields, and newer peers sending unknown values.
+
+## Library-managed lifecycle re-entry
+
+Include rows for automatic reconnects, retry timers, callbacks, restarts, framework-owned replays, and other paths that re-enter with reused state.
+
+## Active-processing re-entry
+
+When a flow can receive a new event/request/callback/file/message/retry while an earlier item is still being handled, include rows for idle, active, queued, coalesced, duplicate, dropped, and shutdown states. State when pending work drains and whether callers see a retryable, terminal, or silent outcome.
+
+**Tests:** require an idle path, an active-processing path, and a drain or terminal-outcome assertion when the implementation queues, coalesces, deduplicates, drops, or rejects repeated work.
+
+## Terminal-state transition guards
+
+When a flow has terminal/one-way states (approved, denied, expired, consumed, completed, cancelled, revoked, failed), include rows for every mutating action attempted from each terminal state. State which states are mutable, which are no-ops, which return a terminal error, and which durable fields must never be rewritten. Include repeated UI actions (approve-then-deny, deny-then-approve, double-clicks, retries after timeout, stale browser tabs after another actor completed the flow).
+
+Final verification must prove terminal states cannot be overwritten by later actions unless the intended table explicitly allows a rollback or superseding transition.
+
+## Cancellation and shutdown
+
+When a flow waits, sleeps, backs off, schedules a timer, retries, or runs asynchronously, include rows for cancellation/shutdown before the wait, during the wait, after the wait but before the next side effect, and during the side effect when applicable.
+
+## Time-bound credentials, signatures, or payloads
+
+Include rows for first attempt, retry/reconnect, restart, expired past timestamps, future timestamps, and clock-boundary conditions. State whether timestamped or expiring material is regenerated, rejected, or reused. Require both stale/too-old and future/too-new rows unless future values are impossible by construction and that construction is documented.
+
+## One-time side effects
+
+When a flow deletes, consumes, rotates, invalidates, acknowledges, commits, uploads, locks, or otherwise spends a one-time resource, include rows for failures and re-entry before and after that side effect. Include cleanup/consume failures on success, validation failure, parse failure, and dependency failure branches when those branches attempt cleanup. State whether the resource can be safely reused, retried, replaced, or must be considered spent.
+
+Require parity rows for invalid and dependency-failure branches, not only valid or happy-path branches.
+
+## Shared durable resources
+
+When deleting, rotating, revoking, or clearing persisted keys, credentials, locks, cache entries, files, profiles, identities, or other durable resources, include rows for: no remaining references, another saved/profile reference, active runtime reference, stale reference, and unknown lookup failure. State whether the resource is reference-counted, ownership-scoped, shared, or safe to delete unconditionally.
+
+## Profile or config cloning
+
+When saving, duplicating, importing, switching, or snapshotting a profile/config from active runtime state, include rows for fields that must be copied, regenerated, omitted, or downgraded. Treat credentials, signing keys, service IDs, device IDs, integration IDs, public keys, machine identities, and other ownership-scoped identifiers as non-transferable by default unless the plan explicitly says they are shared.
+
+Final verification must prove a new profile/config cannot accidentally inherit another profile's ownership-scoped identity or credential binding.
+
+## Diagnostic contracts
+
+When the plan requires redacted diagnostics, telemetry, or structured reasons, include expected reason/category values for each failure class: validation failure, missing state, unavailable secure storage, signer failure, timeout, network failure, remote rejection.
+
+## Advertised status inventory
+
+When code exposes statuses, reasons, modes, variants, exit values, event names, or other enumerated outcomes, inventory which branches produce each value and flag dead, unreachable, duplicated, or misleading values. Every advertised value must be produced by some branch; every produced value must be documented by the table.
+
+## Exception scope
+
+For route handlers, middleware, auth wrappers, and policy helpers, distinguish setup failures, auth/proof failures, database/lookup failures, and downstream handler failures so catch-all blocks do not collapse unrelated errors into the same external status or message.
+
+## Serverless async side effects
+
+For serverless or edge route handlers, include rows for side effects after the response path: last-used timestamps, telemetry, uploads, notifications, cleanup. State whether they are awaited, passed to a platform lifecycle primitive (e.g., `waitUntil`), persisted through an outbox, or intentionally best-effort. Do not treat fire-and-forget promises as durable.
+
+## Path and identity policy canonicalization
+
+For allowlists, denylists, ownership checks, cache keys, dedupe keys, lock keys, object identifiers, and other policy comparisons, include rows for raw input, normalized form, canonical form, aliases, symbolic references, case/separator variants, parent/child boundaries, empty values, and missing targets where applicable.
+
+**Tests:** require a safe positive control, a blocked canonical control, and at least one equivalent or near-equivalent mutation that could bypass naive string comparison.
+
+## Partial update preservation
+
+When a route or service updates a nested object, JSON blob, configuration record, metadata map, or persisted state bundle, include rows for omitted fields, explicit empty/null fields, single-field updates, and full replacement. State whether the operation merges with existing state or replaces it, and which existing fields must survive unknown or partial updates.
+
+## Persistence access paths
+
+When adding persisted fields, tables, indexes, uniqueness constraints, or cleanup jobs, inventory the actual reads, writes, filters, sort orders, expiry scans, rate limits, and ownership checks that will use them. Distinguish query-critical indexes from write-only metadata, future-only fields, redundant left-prefix indexes, and indexes that need additional columns to match the real predicate. Remove or mark not-applicable any index not justified by a current query, rate limit, cleanup path, uniqueness guarantee, sort order, or documented near-term requirement.
+
+## Side-effect boundary
+
+For every validation or preparation failure, state whether network calls, persistence, key generation, retries, telemetry, or other durable side effects should happen.
+
+## Testable invariant
+
+For signing, canonicalization, validation, and compatibility rows, state the exact invariant a test must prove, including a positive control and one-axis mutation when a field binding matters.
+
+For retry or recovery tests, require a positive retryable case, a terminal/non-retryable case, and an unknown-or-legacy-shape case when the contract supports partial or version-skewed peers.

--- a/plugins/code/skills/decision-table/references/review-prevention.md
+++ b/plugins/code/skills/decision-table/references/review-prevention.md
@@ -1,0 +1,37 @@
+# Review-Prevention Pass
+
+Run this pass before marking `Final Alignment Status: Aligned`. For every touched externally visible surface (route, handler, service, command, adapter, UI action, persisted-state update, shared helper), ask whether a code reviewer could still find any of the items below.
+
+For every item: fix it, mark it already covered by a named row/test, mark not applicable with reason, or carry it into `Not aligned` with a concrete blocker. Do not mark `Aligned` while any item is merely assumed covered.
+
+## Items
+
+1. **Unmodeled dependency throw/reject branch** that maps to the wrong external status, retryability, or message.
+2. **Terminal-state or repeated-action mutation** that overwrites durable state (approved, denied, expired, consumed, completed, cancelled, revoked, failed).
+3. **Partial update** that drops unrelated existing nested/JSON/config/metadata fields.
+4. **Feature-flag, rollout, or permission path** that bypasses the intended gate or uses the wrong identity.
+5. **Caller or version-skew path** that cannot supply a newly required field, header, proof, or response shape.
+6. **Duplicated policy, helper, constant, or wire-contract logic** that should be shared or parity-tested.
+7. **Test that asserts only that something failed**, without proving the specific invariant, fallback, binding, or diagnostic reason from the table.
+
+## Contract-Heavy Review Surface
+
+For contract-heavy work, also explicitly review:
+
+- new-shape and old/unknown-shape compatibility behavior when guardrails require version-skew safety
+- precedence between competing decision signals (status, structured fields, error codes, headers, metadata, exit state, persisted markers)
+- call-site inventory completeness for shared routes, helpers, contracts, and policy surfaces
+- caller capability differences, especially callers that cannot supply newly required headers, proof material, fields, or response handling
+- dependency throw/reject branches on route/handler surfaces that promise exact status codes or error bodies
+- catch-all error handling that may map unrelated failures to a specific auth/verifier/validation/dependency diagnostic
+- in-progress guards that return without preserving, rejecting, or explicitly classifying later work
+- terminal-state guards that fail to preserve approved/denied/expired/consumed/completed/cancelled/revoked/failed state when a later or repeated action arrives
+- retries or replays that reuse resources after delete/consume/rotate/invalidate/acknowledge/commit/upload/lock side effects
+- destructive cleanup that deletes a shared durable resource still referenced by another profile, active runtime identity, fallback identity, retry path, or recovery path
+- path/identity/policy checks comparing raw spelling instead of normalized or canonical equivalents where equivalence matters
+- partial updates that overwrite unrelated fields when the intended behavior is additive or merge-preserving
+- schema indexes/constraints that are redundant, unused by current access paths, mismatched to predicates or sort orders, or added for write-only metadata without a documented read path
+- serverless async side effects that may be dropped unless awaited, scheduled with a platform primitive, or persisted
+- test oracle quality for canonicalization, signing, validation, and compatibility rows
+- duplicated policy logic or wire-contract constants that can drift between intended-parity entry paths
+- whether `Final Alignment Status` is still defensible given the implemented compatibility and failure behavior

--- a/plugins/code/skills/plan-validate/SKILL.md
+++ b/plugins/code/skills/plan-validate/SKILL.md
@@ -44,11 +44,13 @@ The script prints JSON to stdout matching the exact plan-validator output format
   "addressed_gaps": [],
   "pending_tasks": [{"id": "T-1.1", "description": "...", "acceptanceCriteria": ["AC-001"]}],
   "completed_tasks": [],
-  "manual_tasks": []
+  "manual_tasks": [],
+  "decision_table_path": ".closedloop-ai/decision-tables/pln-001.md",
+  "decision_table_status": "pending"
 }
 ```
 
-**Action:** Parse the extracted data fields. Use `pending_tasks`, `completed_tasks`, etc. as if the plan-validator agent returned them.
+**Action:** Parse the extracted data fields. Use `pending_tasks`, `completed_tasks`, etc. as if the plan-validator agent returned them. The `decision_table_path` and `decision_table_status` keys are always present — they are empty strings (`""`) when the plan does not yet reference a decision-table artifact.
 
 ### Plan Format Issues (PLAN_FORMAT_ISSUES)
 

--- a/plugins/code/skills/plan-validate/scripts/test_validate_plan.py
+++ b/plugins/code/skills/plan-validate/scripts/test_validate_plan.py
@@ -1,5 +1,5 @@
 """Tests for validate_plan.py."""
-from validate_plan import validate_schema_fields
+from validate_plan import extract_data, validate_schema_fields
 
 
 def _minimal_plan() -> dict:
@@ -31,3 +31,64 @@ def test_validate_schema_accepts_canonical_repositories() -> None:
     issues = validate_schema_fields(plan)
 
     assert issues == [], f"expected no issues but got: {issues}"
+
+
+def test_decision_table_absent_is_valid() -> None:
+    """Plans without a decisionTable field are valid (field is optional)."""
+    plan = _minimal_plan()
+
+    issues = validate_schema_fields(plan)
+
+    assert issues == [], f"expected no issues but got: {issues}"
+
+
+def test_decision_table_valid_shape() -> None:
+    """A well-formed decisionTable with path + status='pending' validates clean."""
+    plan = _minimal_plan()
+    plan["decisionTable"] = {
+        "path": ".closedloop-ai/decision-tables/pln-001.md",
+        "status": "pending",
+    }
+
+    issues = validate_schema_fields(plan)
+
+    assert issues == [], f"expected no issues but got: {issues}"
+
+
+def test_decision_table_invalid_status() -> None:
+    """A decisionTable with a status outside the enum surfaces an issue."""
+    plan = _minimal_plan()
+    plan["decisionTable"] = {
+        "path": ".closedloop-ai/decision-tables/pln-001.md",
+        "status": "unknown",
+    }
+
+    issues = validate_schema_fields(plan)
+
+    assert any("status" in issue for issue in issues), (
+        f"expected an issue mentioning 'status', got: {issues}"
+    )
+
+
+def test_extract_data_surfaces_decision_table() -> None:
+    """extract_data exposes decisionTable.path and .status as flat keys."""
+    plan = _minimal_plan()
+    plan["decisionTable"] = {
+        "path": ".closedloop-ai/decision-tables/pln-001.md",
+        "status": "pending",
+    }
+
+    result = extract_data(plan)
+
+    assert result["decision_table_path"] == ".closedloop-ai/decision-tables/pln-001.md"
+    assert result["decision_table_status"] == "pending"
+
+
+def test_extract_data_decision_table_absent() -> None:
+    """When decisionTable is absent, extract_data returns empty strings for both keys."""
+    plan = _minimal_plan()
+
+    result = extract_data(plan)
+
+    assert result["decision_table_path"] == ""
+    assert result["decision_table_status"] == ""

--- a/plugins/code/skills/plan-validate/scripts/validate_plan.py
+++ b/plugins/code/skills/plan-validate/scripts/validate_plan.py
@@ -54,10 +54,10 @@ PENDING_TASK_RE = re.compile(r"^\s*- \[ \] \*\*T-(\d+\.\d+)\*\*(?:\s+\[MANUAL\])
 COMPLETED_TASK_RE = re.compile(r"^\s*- \[x\] \*\*T-(\d+\.\d+)\*\*:")
 # Manual task line
 MANUAL_TASK_RE = re.compile(r"^\s*- \[ \] \*\*T-(\d+\.\d+)\*\* \[MANUAL\]:")
-# Open question line
-OPEN_Q_RE = re.compile(r"^\s*- \[ \] (Q-\d{3}):")
-# Answered question line
-ANSWERED_Q_RE = re.compile(r"^\s*- \[x\] (Q-\d{3}):")
+# Open question line (supports optional bold markers: **Q-001** or Q-001)
+OPEN_Q_RE = re.compile(r"^\s*- \[ \] \*{0,2}(Q-\d{3})\*{0,2}:")
+# Answered question line (supports optional bold markers: **Q-001** or Q-001)
+ANSWERED_Q_RE = re.compile(r"^\s*- \[x\] \*{0,2}(Q-\d{3})\*{0,2}:")
 # AC table row pattern
 AC_TABLE_ROW_RE = re.compile(r"\| (AC-\d{3}) \|")
 # Gap content pattern
@@ -170,6 +170,20 @@ def validate_schema_fields(data: dict) -> list[str]:
         gid = gap.get("id", "")
         if not GAP_ID_RE.match(gid):
             issues.append(f"Invalid gap ID format: '{gid}'")
+
+    if "decisionTable" in data:
+        dt = data["decisionTable"]
+        if not isinstance(dt, dict):
+            issues.append("Field 'decisionTable' must be an object")
+        else:
+            dt_path = dt.get("path")
+            if not isinstance(dt_path, str) or not dt_path:
+                issues.append("decisionTable.path must be a non-empty string")
+            allowed_statuses = {"pending", "aligned", "aligned_with_clarifications", "verification_failed"}
+            if dt.get("status") not in allowed_statuses:
+                issues.append(
+                    "decisionTable.status must be one of pending|aligned|aligned_with_clarifications|verification_failed"
+                )
 
     return issues
 
@@ -344,6 +358,10 @@ def extract_data(data: dict) -> dict:
         if isinstance(t, dict)
     ]
 
+    decision_table = data.get("decisionTable")
+    dt_path = decision_table.get("path", "") if isinstance(decision_table, dict) else ""
+    dt_status = decision_table.get("status", "") if isinstance(decision_table, dict) else ""
+
     return {
         "status": "VALID",
         "issues": [],
@@ -356,6 +374,8 @@ def extract_data(data: dict) -> dict:
         "pending_tasks": pending,
         "completed_tasks": completed,
         "manual_tasks": manual,
+        "decision_table_path": dt_path,
+        "decision_table_status": dt_status,
     }
 
 

--- a/plugins/code/tools/python/test_validate_plan_sync.py
+++ b/plugins/code/tools/python/test_validate_plan_sync.py
@@ -70,6 +70,16 @@ def test_manual_task_without_manual_line() -> None:
     )
 
 
+def test_decision_table_field_ignored_by_sync() -> None:
+    """validate_sync ignores the decisionTable field — content has no marker for it."""
+    data = make_minimal_data(
+        decisionTable={"path": "x", "status": "pending"},
+    )
+    content = ""
+
+    assert validate_sync(data, content) == []
+
+
 def test_valid_plan_all_fields_in_sync() -> None:
     """A plan where all arrays and content are in sync produces no issues."""
     content = (

--- a/plugins/platform/.claude-plugin/plugin.json
+++ b/plugins/platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platform",
   "description": "ClosedLoop Platform plugin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/platform/README.md
+++ b/plugins/platform/README.md
@@ -7,7 +7,7 @@ The Platform plugin provides foundational skills for working with the ClosedLoop
 - **Claude Code expert guidance**: Comprehensive quick-reference for building and maintaining skills, agents, slash commands, hooks, and plugins, including file format specifications, validation checklists, and a decision framework for choosing extension types.
 - **Context engineering**: Distilled Anthropic prompt engineering documentation covering nine techniques—from basic clarity to extended thinking—with prioritized guidance on when to apply each.
 - **Mermaid visualization**: Generates clear, effective Mermaid diagrams for system architectures, control flows, data flows, state machines, sequence diagrams, and entity relationships directly in markdown.
-- **Artifact upload**: Automates uploading files to the ClosedLoop platform as typed artifacts (PRD, implementation plan, or template) using either a direct-API script or MCP fallback.
+- **Artifact upload**: Automates uploading files to the ClosedLoop platform as typed documents (PRD, implementation plan, feature, or template) using either a direct-API script or MCP fallback.
 - **Skill creation**: Scaffolds new skill directories with proper structure, generates SKILL.md templates with frontmatter, and guides through a five-step creation process from understanding use cases through iteration.
 
 ## Architecture Overview
@@ -140,19 +140,19 @@ A comprehensive guide for creating Mermaid diagrams embedded in markdown. Covers
 
 ### upload-artifact
 
-**Trigger conditions**: Any of the following phrases or intentions — "upload artifact", "upload PRD", "upload implementation plan", "create artifact from file", "save as artifact", "push to closedloop", "new artifact version", "test artifact upload", "verify artifact content", "upload to project".
+**Trigger conditions**: Any of the following phrases or intentions — "upload artifact", "upload PRD", "upload implementation plan", "upload feature", "create artifact from file", "save as artifact", "push to closedloop", "new artifact version", "test artifact upload", "verify artifact content", "upload to project".
 
 **What it provides**:
 
-A two-mode workflow for uploading file content to the ClosedLoop platform as a typed artifact:
+A two-mode workflow for uploading file content to the ClosedLoop platform as a typed document:
 
-**Script mode** (preferred when `CLOSEDLOOP_API_KEY` is available in the shell environment): Runs `skills/upload-artifact/scripts/upload_artifact.py` via `uv`, which connects directly to the MCP server over Streamable HTTP without loading file content into the conversation context. Supports creating new artifacts and new versions of existing artifacts.
+**Script mode** (preferred when `CLOSEDLOOP_API_KEY` is available in the shell environment): Runs `skills/upload-artifact/scripts/upload_artifact.py` via `uv`, which connects directly to the MCP server over Streamable HTTP without loading file content into the conversation context. Supports creating new documents and new versions of existing documents.
 
-**MCP fallback** (when no API key is configured): Uses Claude Code's existing MCP authentication to call `mcp__closedloop__create-artifact` or `mcp__closedloop__create-artifact-version` directly. File content is loaded into conversation context in this mode.
+**MCP fallback** (when no API key is configured): Uses Claude Code's existing MCP authentication to call `mcp__closedloop__create-document` or `mcp__closedloop__create-document-version` directly. File content is loaded into conversation context in this mode.
 
 Both modes follow the same five-step workflow: resolve credentials and choose mode, list projects, collect remaining parameters (file path, title, type), upload, and report results.
 
-**Artifact types**: `PRD`, `IMPLEMENTATION_PLAN`, `TEMPLATE`
+**Document types**: `PRD`, `IMPLEMENTATION_PLAN`, `FEATURE`, `TEMPLATE`
 
 **Script parameters**:
 
@@ -162,12 +162,12 @@ Both modes follow the same five-step workflow: resolve credentials and choose mo
 | `--api-key` | Yes | ClosedLoop API key (`sk_live_...`) |
 | `--list-projects` | No | List projects and exit |
 | `--file` | Upload | Path to content file |
-| `--title` | Create | Artifact title |
-| `--type` | Create | `PRD`, `IMPLEMENTATION_PLAN`, or `TEMPLATE` |
-| `--project-id` | No | Project association |
-| `--workstream-id` | No | Workstream association |
-| `--artifact-id` | Version | Existing artifact ID for new version |
-| `--verify` | No | Fetch artifact back after upload and compare content lengths |
+| `--title` | Create | Document title |
+| `--type` | Create | `PRD`, `IMPLEMENTATION_PLAN`, `FEATURE`, or `TEMPLATE` |
+| `--project-id` | No | Project ID or slug (`PRO-*`) |
+| `--workstream-id` | No | Workstream ID or slug (`WRK-*`) |
+| `--artifact-id` | Version | Existing document ID or slug (`PRD-*`/`PLN-*`/`FEA-*`) for new version |
+| `--verify` | No | Fetch the document back after upload and compare content lengths |
 
 ### claude-creator
 

--- a/plugins/platform/skills/context-engineering/skill.md
+++ b/plugins/platform/skills/context-engineering/skill.md
@@ -316,9 +316,17 @@ When optimizing or compressing an existing prompt, apply these checks after ever
 | Pitfall | Check |
 |---------|-------|
 | Stale cross-references | After renaming or renumbering steps, search for ALL references to old labels (jump targets, "see Step X", resume points) and update them |
-| Over-abstraction | If the model needs exact values to execute (specific keys, field names, command arguments), keep them literal even if they look repetitive -- a generic placeholder the model cannot expand is worse than duplication |
+| Over-abstraction | If the model needs exact values to execute (specific keys, field names, command arguments), keep them literal even if they look repetitive. A generic placeholder the model cannot expand is worse than duplication |
 | Lost preconditions | When merging or removing steps, verify that any precondition checks or guards in the removed step are preserved elsewhere |
+| Dropped qualifiers | Single modifiers like `only`, `when appropriate`, `unless X`, `if it affects Y`, `must`, `never`, `always` are load-bearing constraints that look like filler during compression. For every modifier deleted, confirm the constraint it carried is preserved or that dropping it is the intended behavior change |
 | Silent behavior changes | Diff the before/after and confirm every deleted line is either redundant or relocated, not dropped |
+
+**Validation Pass (run before declaring a refactor done):**
+
+1. Read the original and the refactor side by side, top to bottom.
+2. For every line removed from the original, classify it as: (a) relocated (state where), (b) genuinely redundant (state which surviving line subsumes it), or (c) dropped on purpose (state why).
+3. Pay special attention to qualifiers and short connector phrases. They compress to nothing visually but carry constraints.
+4. Only declare done after every removed line has a label.
 
 ### Common Tag Names
 

--- a/plugins/platform/skills/upload-artifact/SKILL.md
+++ b/plugins/platform/skills/upload-artifact/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: upload-artifact
 description: |
-  Upload a file as a ClosedLoop artifact (PRD, implementation plan, or template).
+  Upload a file as a ClosedLoop document (PRD, implementation plan, feature, or template).
   Reads file content and uploads via MCP without consuming conversation context.
-  Also supports creating new versions of existing artifacts.
+  Also supports creating new versions of existing documents.
   Triggers on: "upload artifact", "upload PRD", "upload implementation plan",
-  "create artifact from file", "save as artifact", "push to closedloop",
-  "new artifact version", "test artifact upload", "verify artifact content",
-  "upload to project".
-allowed-tools: Bash, Read, AskUserQuestion, mcp__closedloop__create-artifact, mcp__closedloop__create-artifact-version, mcp__closedloop__list-projects
+  "upload feature", "create artifact from file", "save as artifact",
+  "push to closedloop", "new artifact version", "test artifact upload",
+  "verify artifact content", "upload to project".
+allowed-tools: Bash, Read, AskUserQuestion, mcp__closedloop__create-document, mcp__closedloop__create-document-version, mcp__closedloop__list-projects
 ---
 
 # Upload Artifact
@@ -21,7 +21,7 @@ Upload file content as a ClosedLoop MCP artifact. Two modes:
    `NEXT_PUBLIC_MCP_SERVER_URL` to already be present in the current shell
    environment.
 
-2. **MCP fallback** — reads the file into context and calls `mcp__closedloop__create-artifact`
+2. **MCP fallback** — reads the file into context and calls `mcp__closedloop__create-document`
    directly. Uses Claude Code's existing MCP auth. Used when the required
    script-mode environment variables are not available.
 
@@ -66,8 +66,8 @@ If only one project exists, skip the question and use it automatically.
 
 Use `AskUserQuestion` to collect any parameters the user hasn't already specified:
 - **file_path**: "Which file should be uploaded?"
-- **title**: "What title should this artifact have?"
-- **type**: "What type of artifact?" (options: PRD, IMPLEMENTATION_PLAN, TEMPLATE)
+- **title**: "What title should this document have?"
+- **type**: "What type of document?" (options: PRD, IMPLEMENTATION_PLAN, FEATURE, TEMPLATE)
 
 Only ask for parameters the user hasn't already specified. For example, if they
 said "upload /tmp/my-prd.txt as a PRD", you already have the file path and
@@ -87,13 +87,14 @@ uv run --with 'mcp[cli]' <base_directory>/scripts/upload_artifact.py \
 
 Add `--verify` if the user requested verification or if testing limits.
 
-Add `--artifact-id <ID>` instead of `--title`/`--type`/`--project-id` when
-creating a new version of an existing artifact.
+Add `--artifact-id <ID_OR_SLUG>` instead of `--title`/`--type`/`--project-id`
+when creating a new version of an existing document. The flag accepts a UUID
+or a user-facing slug (`PRD-*`, `PLN-*`, `FEA-*`); the server resolves it.
 
 ### Step 5a: Report Result
 
 Parse the JSON output and report to the user:
-- Artifact ID
+- Document slug (e.g. `PLN-376`) and ID
 - Content length (characters)
 - Upload status
 - Verification results (if `--verify` was used)
@@ -115,16 +116,18 @@ Same as Step 3a — use `AskUserQuestion` for any missing file_path, title, or t
 ### Step 4b: Upload via MCP Tool
 
 Read the file content with the `Read` tool, then call:
-- `mcp__closedloop__create-artifact` for new artifacts (pass `title`, `type`,
-  `content`, and `projectId`)
-- `mcp__closedloop__create-artifact-version` for new versions (pass `artifactId`
-  and `content`)
+- `mcp__closedloop__create-document` for new documents (pass `title`, `type`,
+  `content`, and `projectId`). `type` is one of `PRD`, `IMPLEMENTATION_PLAN`,
+  `FEATURE`, or `TEMPLATE`.
+- `mcp__closedloop__create-document-version` for new versions (pass
+  `documentId` and `content`). `documentId` accepts a UUID or a user-facing
+  slug (`PRD-*`, `PLN-*`, `FEA-*`).
 
 Note: the file content will be loaded into conversation context in this mode.
 
 ### Step 5b: Report Result
 
-Report the artifact ID and confirmation from the MCP tool response.
+Report the document slug (`PRD-*`, `PLN-*`, `FEA-*`) and ID from the MCP tool response.
 
 ## Script Parameters
 
@@ -134,9 +137,9 @@ Report the artifact ID and confirmation from the MCP tool response.
 | `--api-key` | Yes | ClosedLoop API key (`sk_live_...`) |
 | `--list-projects` | No | List projects and exit |
 | `--file` | Upload | Path to content file |
-| `--title` | Create | Artifact title |
-| `--type` | Create | `PRD`, `IMPLEMENTATION_PLAN`, or `TEMPLATE` |
-| `--project-id` | No | Project association |
-| `--workstream-id` | No | Workstream association |
-| `--artifact-id` | Version | Existing artifact ID for new version |
+| `--title` | Create | Document title |
+| `--type` | Create | `PRD`, `IMPLEMENTATION_PLAN`, `FEATURE`, or `TEMPLATE` |
+| `--project-id` | No | Project ID or slug (`PRO-*`) |
+| `--workstream-id` | No | Workstream ID or slug (`WRK-*`) |
+| `--artifact-id` | Version | Existing document ID or slug (`PRD-*`/`PLN-*`/`FEA-*`) for new version |
 | `--verify` | No | Fetch back after upload and compare lengths |

--- a/plugins/platform/skills/upload-artifact/scripts/upload_artifact.py
+++ b/plugins/platform/skills/upload-artifact/scripts/upload_artifact.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""Upload a file as a ClosedLoop MCP artifact via Streamable HTTP transport.
+"""Upload a file as a ClosedLoop MCP document via Streamable HTTP transport.
 
 Connects directly to the MCP server, authenticates with an API key,
-and calls create-artifact or create-artifact-version.
+and calls create-document or create-document-version. The CLI flag
+``--artifact-id`` is preserved for backward compatibility and refers to the
+same identifier the server now exposes via ``documentId``.
 
 Reads `CLOSEDLOOP_API_KEY` and `NEXT_PUBLIC_MCP_SERVER_URL` from the current
 process environment by default. `--api-key` and `--url` can still be provided
@@ -16,17 +18,17 @@ Usage:
     uv run --with 'mcp[cli]' scripts/upload_artifact.py \\
         --list-projects
 
-    # Create artifact:
+    # Create document:
     uv run --with 'mcp[cli]' scripts/upload_artifact.py \\
         --file /path/to/content.md \\
         --title "My PRD" \\
         --type PRD \\
         --project-id <PROJECT_ID>
 
-    # New version of existing artifact:
+    # New version of existing document:
     uv run --with 'mcp[cli]' scripts/upload_artifact.py \\
         --file /path/to/content.md \\
-        --artifact-id <ARTIFACT_ID>
+        --artifact-id <DOCUMENT_ID_OR_SLUG>
 
     # Create + verify round-trip:
     uv run --with 'mcp[cli]' scripts/upload_artifact.py \\
@@ -116,31 +118,32 @@ def _error_details(result: object) -> dict:
     return {"details": [getattr(c, "text", str(c)) for c in content]}
 
 
-async def _version_artifact(
-    session: ClientSession, artifact_id: str, content: str
+async def _version_document(
+    session: ClientSession, document_id: str, content: str
 ) -> dict:
-    """Create a new version of an existing artifact."""
+    """Append a new version to an existing document."""
     result = await session.call_tool(
-        "create-artifact-version",
-        {"artifactId": artifact_id, "content": content},
+        "create-document-version",
+        {"documentId": document_id, "content": content},
     )
     if result.isError:
-        return {"error": "create-artifact-version failed", **_error_details(result)}
+        return {"error": "create-document-version failed", **_error_details(result)}
     text = _extract_text(result)
     parsed = json.loads(text) if text else {}
     return {
         "mode": "version",
-        "artifact_id": artifact_id,
+        "artifact_id": document_id,
+        "document_id": document_id,
         "content_length": len(content),
         "status": "success",
         "response": parsed,
     }
 
 
-async def _create_artifact(
+async def _create_document(
     session: ClientSession, args: _Args, content: str
 ) -> dict:
-    """Create a new artifact."""
+    """Create a new document."""
     assert args.title is not None
     assert args.type is not None
     tool_args: dict[str, str] = {
@@ -153,17 +156,20 @@ async def _create_artifact(
     if args.workstream_id:
         tool_args["workstreamId"] = args.workstream_id
 
-    result = await session.call_tool("create-artifact", tool_args)
+    result = await session.call_tool("create-document", tool_args)
     if result.isError:
-        return {"error": "create-artifact failed", **_error_details(result)}
+        return {"error": "create-document failed", **_error_details(result)}
     text = _extract_text(result)
     if not text:
-        return {"error": "Empty response from create-artifact"}
+        return {"error": "Empty response from create-document"}
     parsed = json.loads(text)
     data = parsed.get("data", parsed)
+    document_id = data.get("id", parsed.get("id", "unknown"))
     return {
         "mode": "create",
-        "artifact_id": data.get("id", parsed.get("id", "unknown")),
+        "artifact_id": document_id,
+        "document_id": document_id,
+        "slug": data.get("slug", parsed.get("slug")),
         "content_length": len(content),
         "status": "success",
         "response": parsed,
@@ -171,7 +177,7 @@ async def _create_artifact(
 
 
 async def upload(args: _Args) -> dict:
-    """Create or version an artifact from a file."""
+    """Create or version a document from a file."""
     assert args.file is not None
     file_path = Path(args.file).expanduser().resolve()
     if not file_path.is_file():
@@ -188,12 +194,12 @@ async def upload(args: _Args) -> dict:
                 await session.initialize()
 
                 if args.artifact_id:
-                    output = await _version_artifact(session, args.artifact_id, content)
+                    output = await _version_document(session, args.artifact_id, content)
                 else:
-                    output = await _create_artifact(session, args, content)
+                    output = await _create_document(session, args, content)
 
                 if "error" not in output and args.verify:
-                    output["verify"] = await _verify_artifact(
+                    output["verify"] = await _verify_document(
                         session, output["artifact_id"], len(content)
                     )
 
@@ -202,29 +208,29 @@ async def upload(args: _Args) -> dict:
         return _format_exception(exc)
 
 
-async def _verify_artifact(
-    session: ClientSession, artifact_id: str, expected_length: int
+async def _verify_document(
+    session: ClientSession, document_id: str, expected_length: int
 ) -> dict:
-    """Fetch an artifact back and compare content lengths."""
+    """Fetch a document back and compare content lengths."""
     fetch_max = min(expected_length, 120_000)
     result = await session.call_tool(
-        "get-artifact",
+        "get-document",
         {
-            "artifactId": artifact_id,
+            "documentId": document_id,
             "includeContent": True,
             "contentMaxChars": fetch_max,
         },
     )
     if result.isError:
         return {
-            "error": "get-artifact failed",
+            "error": "get-document failed",
             "details": [
                 getattr(c, "text", str(c)) for c in (result.content or [])
             ],
         }
     text = _extract_text(result)
     if not text:
-        return {"error": "Empty response from get-artifact"}
+        return {"error": "Empty response from get-document"}
     parsed = json.loads(text)
     version_data = parsed.get("version", {})
     actual_length = version_data.get("contentLength", 0)
@@ -274,7 +280,7 @@ def _require_arg_or_env(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Upload file content as a ClosedLoop MCP artifact."
+        description="Upload file content as a ClosedLoop MCP document."
     )
     parser.add_argument(
         "--url",
@@ -298,16 +304,17 @@ def main() -> None:
         help="List available projects and exit.",
     )
     parser.add_argument("--file", help="Path to content file.")
-    parser.add_argument("--title", help="Artifact title (create mode).")
+    parser.add_argument("--title", help="Document title (create mode).")
     parser.add_argument(
         "--type",
-        choices=["PRD", "IMPLEMENTATION_PLAN", "TEMPLATE"],
-        help="Artifact type (create mode).",
+        choices=["PRD", "IMPLEMENTATION_PLAN", "TEMPLATE", "FEATURE"],
+        help="Document type (create mode).",
     )
-    parser.add_argument("--project-id", help="Project ID.")
-    parser.add_argument("--workstream-id", help="Workstream ID.")
+    parser.add_argument("--project-id", help="Project ID or slug (PRO-*).")
+    parser.add_argument("--workstream-id", help="Workstream ID or slug (WRK-*).")
     parser.add_argument(
-        "--artifact-id", help="Existing artifact ID (version mode)."
+        "--artifact-id",
+        help="Existing document ID or slug (PRD-*/PLN-*/FEA-*) (version mode).",
     )
     parser.add_argument(
         "--verify",

--- a/plugins/platform/skills/upload-artifact/scripts/upload_artifact.py
+++ b/plugins/platform/skills/upload-artifact/scripts/upload_artifact.py
@@ -130,10 +130,12 @@ async def _version_document(
         return {"error": "create-document-version failed", **_error_details(result)}
     text = _extract_text(result)
     parsed = json.loads(text) if text else {}
+    data = parsed.get("data", parsed) if isinstance(parsed, dict) else {}
     return {
         "mode": "version",
         "artifact_id": document_id,
         "document_id": document_id,
+        "slug": data.get("slug", parsed.get("slug") if isinstance(parsed, dict) else None),
         "content_length": len(content),
         "status": "success",
         "response": parsed,

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"


### PR DESCRIPTION
### Primary benefit: intent preservation under iteration drift.

The orchestrator currently reads a plan, implements it, runs tests, and code-reviews, but every step is a fresh-context LLM. Each agent re-reads the plan and re-derives "what should this do?" from prose. That re-derivation is lossy: edge cases the planner had in mind never make it into the implementation prompt, the implementer fills the gap with reasonable-sounding defaults, code review checks for security/quality but not "did we build the behavior the planner intended," and tests verify what the test-writer thought of. By the time the loop completes, you've often built a working thing, not the thing the plan implied.

The decision-table pins down branch-by-branch externally-visible behavior at Phase 2.7 in a frozen, machine-checkable form (Current Code vs Intended Change rows with state axes, dependency outcomes, and test invariants). Phase 5.5's verifier then mechanically checks the implementation against those rows and routes drift back into the auto-fix loop. The plan stays a scope/intent document; the decision-table becomes the executable contract.

### Specific bug class it catches that the rest of the pipeline misses:

- Edge cases that "feel obvious" so they never get spelled out: retry vs first-attempt with expiring credentials, throw-capable preparation code in structured-result contracts, lifecycle re-entry under reconnect/restart, fire-and-forget side effects on serverless, dependency-throw vs dependency-null mapping to externally visible status codes, canonicalization on policy comparisons, signal-precedence conflicts between transport status and payload fields. These are exactly the bugs the patch you applied to SKILL.md was designed to surface, they're the long tail of post-incident learnings, not novel discoveries.
- Silent drift between iterations: if iteration N implements a behavior correctly and iteration N+1 refactors it (e.g., simplifier in Phase 4 collapses two branches), the verifier catches the regression because the artifact is frozen. Without the artifact, the "is the new code still correct?" check has nothing to compare against.
 - Test gap detection rather than test failure: the verifier surfaces "this row has no test covering its invariant" as test_drift. Today, the system only knows about tests that exist and fail — not about behavior that should have a test and doesn't.

### Where it doesn't help (and is correctly skipped):

Pure UI work, simple CRUD, doc-only changes, anything where there's no real branching behavior to map. That's why simple-mode skips the entire flow — the overhead doesn't pay back when the plan is "add a button" or "fix a typo." The 7 signals in plan-evaluator (PRD length, AC count, task count, forbidden terms, cross-repo keywords, etc.) are a reasonable proxy for "is the surface area worth mapping?" If those signals are wrong in either direction (too aggressive, too loose), the T-4.6 telemetry will show it: you'll see runs marked aligned after zero verifier iterations (overhead with no catches → skip threshold should be looser) or runs that escalate after exhausting retries on simple plans (skip threshold too tight). That's the feedback loop that lets us tune the gates against real data rather than guessing.

### Do we still need this even though our implementation plan gets fully fleshed out with code snippets and critic reviewed?

Yes, and the value isn't redundant with the enriched plan, it operates at a different layer. The enriched plan tells the implementation-subagent what to build (signatures, code patterns, integration points). The decision-table tells the verifier what to check after it's built. Even with code snippets in tasks, those snippets describe the happy path plus a handful of prose-mentioned edge cases, not an exhaustive enumeration of branch behavior.

#### Specific bug classes the enriched plan tends to miss but the decision-table catches:

1. State × dependency-outcome combinations. Plan task says "handle the dependency failure" with a snippet showing the catch block. The decision-table forces enumeration of (success / null / validation-fail / throw / reject) × (first-attempt / retry / restart), that's 15 cells, none of which a single code snippet naturally enumerates.
2. Signal-precedence conflicts. Snippet shows reading both transport status and body field. Doesn't answer what happens when they disagree. Decision-table forces a precedence row with the "wins when X, degrades when Y" axis.
3. Caller capability skew. Plan covers the current-version caller. Snippet doesn't enumerate older peers omitting newly required fields, or newer peers sending unknowns. The skill's call-site inventory step forces this.
4. Side-effect ordering across failure boundaries. Snippet shows persist → emit-event → return. Doesn't explicitly answer: if emit-event throws after persist succeeds, is persist rolled back? The side-effect-boundary row forces this.
5. Drift across the loop's own iterations. This is the one the enriched plan structurally can't catch. Iteration 1 implements correctly. Iteration 4's Phase 4 simplifier collapses two branches that were genuinely distinct per the plan but read as locally redundant. The simplifier's local view is fine; behavior regresses globally. The decision-table is the only artifact in the loop frozen at Phase 2.7 and verified again at 5.5 / on every later iteration — it's the contract that survives Phase 4 simplifier passes, Phase 5 code-reviewer fix loops, /code:amend-plan runs, and re-entries from AWAITING_USER.
6. Test-shape invariants. Plan says "test the validation logic." Without the decision-table, a test that triggers any 400 passes. Required Tests rows force "prove field-level binding, not just status-level rejection" — positive control plus one-axis mutation.

So ultimately: decision-table converts "the plan we approved" from prose-with-implicit-edge-cases into an executable contract, so iteration N+M can still verify behavior against iteration 1's intent without a human re-reading the original plan and re-judging. That's the value compounding over a long autonomous loop.