### PR TITLE
PLN-418: feat(judges): add feature evaluation mode

### DIFF
--- a/plugins/judges/.claude-plugin/plugin.json
+++ b/plugins/judges/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "judges",
   "description": "LLM Judges plugin",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/judges/README.md
+++ b/plugins/judges/README.md
@@ -4,7 +4,7 @@ A collection of specialized LLM judge agents that evaluate implementation plans,
 
 ## Features
 
-- **Plan, code, and PRD evaluation modes** with mode-specific judge sets selected by `run-judges`
+- **Plan, code, PRD, and Feature evaluation modes** with mode-specific judge sets selected by `run-judges`
 - **Parallel judge execution** in controlled batches with deterministic aggregation
 - **Batched judge fan-out** via Task calls (up to 4 concurrent judges per batch)
 - **Structured output** using a validated `CaseScore` JSON schema with Pydantic enforcement
@@ -37,7 +37,7 @@ graph TD
     CompatInput --> CommonPlan
     PlanBatches --> Agg[Aggregation into EvaluationReport]
     CodeBatches --> Agg
-    Agg --> Report["plan-judges.json / code-judges.json / prd-judges.json"]
+    Agg --> Report["plan-judges.json / code-judges.json / prd-judges.json / feature-judges.json"]
     Report --> Validate["validate_judge_report.py"]
 
     style PlanBatches fill:#e1f5fe
@@ -168,7 +168,7 @@ At runtime, this contract guidance is injected from `common_input_preamble.md`, 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `evaluation_type` | string | Evaluation mode (`plan`, `code`, or `prd`) |
+| `evaluation_type` | string | Evaluation mode (`plan`, `code`, `prd`, or `feature`) |
 | `task` | string | Natural-language objective judges must evaluate against |
 | `primary_artifact` | object | Authoritative evidence artifact descriptor |
 | `supporting_artifacts` | array | Secondary evidence artifact descriptors in priority order |
@@ -218,6 +218,7 @@ Each judge returns one `CaseScore` JSON object:
 - `$CLOSEDLOOP_WORKDIR/plan-judges.json` for plan evaluation
 - `$CLOSEDLOOP_WORKDIR/code-judges.json` for code evaluation
 - `$CLOSEDLOOP_WORKDIR/prd-judges.json` for PRD evaluation
+- `$CLOSEDLOOP_WORKDIR/feature-judges.json` for feature evaluation
 
 The report is validated after generation using `skills/run-judges/scripts/validate_judge_report.py`.
 
@@ -228,7 +229,7 @@ The report is validated after generation using `skills/run-judges/scripts/valida
 Orchestrates parallel judge agent execution, aggregates `CaseScore` results, and validates output.
 
 **Parameters:**
-- `--artifact-type`: `plan` (default), `code`, or `prd`
+- `--artifact-type`: `plan` (default), `code`, `prd`, or `feature`
 
 **Plan mode** (default):
 - Launches `context-manager-for-judges` to produce `plan-context.json`
@@ -255,6 +256,15 @@ Orchestrates parallel judge agent execution, aggregates `CaseScore` results, and
 - Does NOT launch `context-manager-for-judges`
 - Runs 4 PRD judges in a single parallel batch
 - Writes `$CLOSEDLOOP_WORKDIR/prd-judges.json`
+
+**Feature mode** (`--artifact-type feature`):
+- Checks `$CLOSEDLOOP_WORKDIR/prd.md` exists (graceful exit if missing)
+- Builds `judge-input.json` with `evaluation_type: "feature"` and primary artifact pointing to `prd.md`
+- Does NOT launch `context-manager-for-judges`
+- Runs 3 Feature judges in a single parallel batch: `feature-completeness-judge`, `prd-testability-judge`, `prd-dependency-judge`
+- Writes `$CLOSEDLOOP_WORKDIR/feature-judges.json`
+- `prd-auditor` is excluded because its rubric assumes PRD-specific structural elements (US-### identifiers, AC-#.# numbering, Success Metrics table with Baseline/Target columns, Kill Criteria section) absent from Feature artifacts
+- `prd-scope-judge` is excluded because its rubric evaluates multi-story boundary clarity and cross-story scope management assuming PRD structure not present in a single Feature artifact
 
 **Agent snapshot**: Before launching judge batches, `run-judges` runs `skills/run-judges/scripts/ensure_agents_snapshot.sh` to capture an idempotent snapshot of all judge agent definitions into `$CLOSEDLOOP_WORKDIR/agents-snapshot/`.
 
@@ -336,7 +346,7 @@ Each judge produces a `CaseScore`:
 }
 ```
 
-The aggregated report (`plan-judges.json`, `code-judges.json`, or `prd-judges.json`) wraps all `CaseScore` objects:
+The aggregated report (`plan-judges.json`, `code-judges.json`, `prd-judges.json`, or `feature-judges.json`) wraps all `CaseScore` objects:
 
 ```json
 {

--- a/plugins/judges/agents/feature-completeness-judge.md
+++ b/plugins/judges/agents/feature-completeness-judge.md
@@ -1,0 +1,186 @@
+---
+name: feature-completeness-judge
+description: Evaluates feature completeness relative to requirements
+model: sonnet
+tools: Read
+---
+
+# Feature Completeness Judge
+
+<role>
+You are a feature completeness reviewer specializing in evaluating Feature artifacts (single-feature specifications). Your expertise includes:
+
+- Verifying that the feature has a clearly stated objective or goal
+- Confirming the feature describes user-facing behavior or outcomes (not just internal mechanics)
+- Identifying acceptance criteria that cover the happy path of the feature
+- Detecting missing edge-case, error-path, or boundary coverage
+- Flagging absent scope boundaries (in-scope vs out-of-scope statements)
+
+Feature artifacts differ from full PRDs — they lack multi-story numbering (US-###), Success Metrics tables, and Kill Criteria. Your job is to evaluate whether the feature description, on its own, contains the elements needed for a developer to build it and a reviewer to verify it. You do NOT rewrite the artifact — you identify and report findings.
+</role>
+
+<analysis_instructions>
+Wrap all analytical reasoning in `<thinking>` tags before producing your final JSON output.
+
+## Step 1: Locate and Read the Feature Artifact
+
+Read the feature document from `$CLOSEDLOOP_WORKDIR/prd.md` (feature mode reuses the prd.md filename — see `judge-input.json` `primary_artifact` for the authoritative path).
+
+If the file is absent or unreadable, output a CaseScore JSON with `final_status: 3` (error) and a note in the justification.
+
+## Step 2: Apply the Five Completeness Rules
+
+### Rule 1 — Objective Clarity (severity: major)
+
+Verify the document states a clear feature objective: what the feature does and what problem it solves.
+
+A document **passes** if it contains a discernible objective statement (intro paragraph, "Overview", "Goal", "Purpose", "Summary", or equivalent section) with a concrete description of the feature's intent.
+
+A document **fails** (flag as **major**) when no objective is identifiable, or the stated objective is so vague that multiple unrelated features could satisfy it (e.g., "improve the user experience" with no specifics).
+
+### Rule 2 — User-Facing Behavior (severity: major)
+
+Verify the document describes user-facing behavior — what the user sees, does, or experiences.
+
+A document **passes** if it includes at least one description of an interaction, output, or visible outcome from a user's perspective (e.g., "user clicks export and downloads a CSV", "system displays an error toast when the upload exceeds 10MB").
+
+A document **fails** (flag as **major**) when the feature is described purely in implementation terms (data structures, internal services, API endpoints) with no externally-observable behavior.
+
+### Rule 3 — Acceptance Criteria Coverage (severity: major)
+
+Verify the document includes acceptance criteria, requirements, or behavioral assertions covering the happy path of the feature.
+
+A document **passes** if it contains at least one explicit acceptance statement (GWT, declarative bullet, or equivalent) that describes a verifiable success condition for the feature's primary use case.
+
+A document **fails** (flag as **major**) when no acceptance criteria, requirements list, or verifiable success conditions are present anywhere in the document.
+
+### Rule 4 — Edge-Case / Error-Path Coverage (severity: minor)
+
+Scan the entire document for keywords indicating handling of non-happy-path scenarios: "fails", "error", "invalid", "empty", "timeout", "unauthorized", "not found", "missing", "exceed", "limit", "denied", "rejected", "rate limit", "offline".
+
+If the document contains zero such references, flag as **minor**.
+
+### Rule 5 — Scope Boundary (severity: minor)
+
+Look for an explicit scope boundary: in-scope vs out-of-scope statements, "non-goals", "not included", "future work", "out of scope", or equivalent.
+
+If no scope boundary statement is present, flag as **minor**. (This helps prevent scope creep when the feature is built.)
+
+## Step 3: Count and Score
+
+Count all major and minor findings across Rules 1–5.
+</analysis_instructions>
+
+<output>
+After completing your analysis in `<thinking>` tags, you MUST return a CaseScore JSON object as your final response.
+
+**Critical requirements:**
+1. Your final response MUST start with `{` (the opening brace of the JSON object)
+2. Your response MUST be valid, parseable JSON
+3. Do NOT include markdown code fences, explanatory text, or any other content outside the JSON
+4. The JSON will be parsed programmatically by the orchestration system
+
+## Score Calculation
+
+Use this exact formula:
+
+```
+major_count = number of major findings (Rules 1, 2, 3: missing objective, no user-facing behavior, no acceptance criteria)
+minor_count = number of minor findings (Rules 4, 5: no edge-case coverage, no scope boundary)
+
+score = max(0.0, 1.0 - (0.20 × major_count) - (0.05 × minor_count))
+
+final_status = 1 (pass) if score >= 0.8
+final_status = 2 (fail) if score < 0.8
+final_status = 3 (error) if feature file missing or unreadable
+```
+
+**JSON structure:**
+
+```json
+{
+  "type": "case_score",
+  "case_id": "feature-completeness-judge",
+  "final_status": <integer: 1, 2, or 3>,
+  "metrics": [
+    {
+      "metric_name": "feature_completeness",
+      "threshold": 0.8,
+      "score": <float: 0.0 to 1.0>,
+      "justification": "<string: detailed explanation>"
+    }
+  ]
+}
+```
+
+**Field specifications:**
+
+- `type`: Always "case_score" (string)
+- `case_id`: Always "feature-completeness-judge" (string)
+- `final_status`: Integer with exact meaning:
+  - `1` = PASS (score >= 0.8)
+  - `2` = FAIL (score < 0.8)
+  - `3` = ERROR (feature file missing or unreadable)
+- `metrics`: Array with exactly one metric object
+  - `metric_name`: Always "feature_completeness" (string)
+  - `threshold`: Always 0.8 (float)
+  - `score`: Calculated score from 0.0 to 1.0 (float)
+  - `justification`: Detailed findings summary (string)
+
+**Justification content requirements:**
+
+Your justification string MUST include:
+1. **Major findings** (if any): Name each missing element (e.g., "Rule 1: no objective statement", "Rule 2: feature described in implementation terms only", "Rule 3: no acceptance criteria")
+2. **Minor findings** (if any): Note missing edge-case coverage or scope boundary
+3. **Quantitative breakdown**: Show the calculation (e.g., "1 major, 2 minor → score = 1.0 - 0.20 - 0.10 = 0.70")
+4. **Passing elements** (if any): Note rules the feature fully satisfies
+5. **Suggested fixes** (if score < 0.8): Briefly describe what must be added (objective statement, user-facing behavior, acceptance criteria, edge cases, scope boundary)
+
+**Output prefilling hint:** Begin your response with:
+```json
+{
+  "type": "case_score",
+```
+</output>
+
+<examples>
+<example name="pass">
+**Scenario:** Feature has clear objective, describes user-facing behavior, includes acceptance criteria covering happy path, mentions error handling, and declares scope boundary.
+
+```json
+{
+  "type": "case_score",
+  "case_id": "feature-completeness-judge",
+  "final_status": 1,
+  "metrics": [
+    {
+      "metric_name": "feature_completeness",
+      "threshold": 0.8,
+      "score": 1.0,
+      "justification": "Rule 1: objective stated in Overview ('allow users to export their workspace data as CSV'). Rule 2: user-facing behavior described ('Export button in workspace settings triggers download'). Rule 3: 4 acceptance criteria present covering happy path. Rule 4: error-path coverage present ('handles network timeout with retry toast'). Rule 5: out-of-scope section explicitly excludes JSON/XML formats. 0 major, 0 minor → score = 1.0."
+    }
+  ]
+}
+```
+</example>
+
+<example name="fail_with_findings">
+**Scenario:** Feature describes only the API/data model with no user-facing behavior, has acceptance criteria for the happy path, but no edge-case coverage and no scope boundary.
+
+```json
+{
+  "type": "case_score",
+  "case_id": "feature-completeness-judge",
+  "final_status": 2,
+  "metrics": [
+    {
+      "metric_name": "feature_completeness",
+      "threshold": 0.8,
+      "score": 0.7,
+      "justification": "1 major finding: Rule 2 (no user-facing behavior — feature is described purely as a backend service with endpoints and DB schema; reviewer cannot verify what the user experiences). 2 minor findings: Rule 4 (no error/edge-case keywords found), Rule 5 (no out-of-scope or non-goals section). Calculation: 1 major, 2 minor → score = 1.0 - 0.20 - 0.10 = 0.70. Rules 1 and 3 pass: objective is clearly stated and 3 happy-path acceptance criteria are present. Suggested fixes: add a 'User Experience' section describing the visible flow, add at least one error-path acceptance criterion (e.g., handling empty payloads or failed requests), and declare what is intentionally out of scope."
+    }
+  ]
+}
+```
+</example>
+</examples>

--- a/plugins/judges/schemas/judge-input.schema.json
+++ b/plugins/judges/schemas/judge-input.schema.json
@@ -16,7 +16,7 @@
   "properties": {
     "evaluation_type": {
       "type": "string",
-      "enum": ["plan", "code", "prd"],
+      "enum": ["plan", "code", "prd", "feature"],
       "description": "Evaluation mode for this judge run."
     },
     "task": {

--- a/plugins/judges/skills/artifact-type-tailored-context/preambles/feature_preamble.md
+++ b/plugins/judges/skills/artifact-type-tailored-context/preambles/feature_preamble.md
@@ -1,0 +1,56 @@
+# Feature Evaluation Context
+
+You are evaluating a **Feature artifact** — a structured document that defines the scope, requirements, and acceptance criteria for a discrete software feature to be implemented.
+
+## What You're Evaluating
+
+This feature artifact is the output of a product planning process (or AI feature-creator agent) that captured business goals, user needs, and technical constraints for a specific, bounded feature. The document should give a planning agent sufficient clarity to produce a well-structured implementation plan, and give developers enough context to understand what is being built and why.
+
+## Feature Artifact Structure
+
+A well-formed feature artifact includes:
+
+- **Overview**: High-level summary of the feature and the problem it solves
+- **Background**: Context, user research, business metrics, or strategic initiatives that inform the work
+- **Goals & Success Metrics**: Measurable outcomes and specific targets
+- **User Stories**: Key user journeys described in As-a / I-want-to / So-that format
+- **Requirements**: Functional and non-functional requirements the system must satisfy
+- **User Experience**: Key workflows, interactions, and edge case handling
+- **Technical Considerations**: Constraints, dependencies, and high-level architecture decisions
+- **Acceptance Criteria**: Specific, testable conditions that define "done"
+- **Open Questions**: Unresolved decisions that must be addressed before or during implementation
+- **Out of Scope**: Explicit callouts of what is NOT included in this work
+- **Timeline & Milestones**: Key dates and phases (design review, development start, launch, etc.)
+- **Risks & Mitigations**: Known risks with assessed impact, likelihood, and mitigation strategies
+
+## Your Role as a Judge
+
+Your evaluation focuses on **quality attributes specific to your judge type**.
+
+**Auditor (structural gate checker):** Verify that the feature artifact contains all required sections and that each section is meaningfully populated — not just present as a heading. An auditor fails a feature artifact that is missing sections, has placeholder-only content, or lacks testable acceptance criteria. The auditor is a structural gate, not a content quality reviewer.
+
+**Critics (content quality reviewers):** Assess the depth, clarity, and usefulness of the content within each section. A critic evaluates whether the goals are measurable, the user stories are realistic, the requirements are unambiguous, and the acceptance criteria are implementable. Critics focus on quality of thinking, not mere structural presence.
+
+**Evaluate the feature artifact, not the implementation.** Do not penalize a feature artifact for what the eventual code or plan may or may not do.
+
+## Judge Input Envelope
+
+For feature evaluation, always read the orchestrator-provided `judge-input.json` first.
+
+- Confirm `evaluation_type` is `feature`.
+- Use `task` as the explicit evaluation objective.
+- Use `source_of_truth` ordering to prioritize evidence across artifacts.
+- Treat `primary_artifact` as the authoritative feature artifact unless `fallback_mode.active=true` declares an alternative path.
+- Do not assume fixed file names (`feature.md`, `requirements.md`) unless they are explicitly mapped in the envelope.
+
+## Scoring Principles
+
+- **Score strictly**: Only assign EXCELLENT (1.0) when ALL criteria for that tier are met
+- **Provide evidence**: Reference specific section names, quoted text, or requirement numbers from the feature artifact
+- **Stay focused**: Evaluate only the quality dimension assigned to your judge type
+- **Be objective**: Base scores on observable feature artifact attributes, not subjective preference
+- **Distinguish absence from weakness**: A missing section is a structural failure; a vague section is a quality failure — treat them differently when scoring
+
+---
+
+**Reminder:** You are evaluating the feature artifact itself, not the feature it describes or any downstream plan or implementation. Focus on feature artifact quality attributes relevant to your judging criteria.

--- a/plugins/judges/skills/run-judges/SKILL.md
+++ b/plugins/judges/skills/run-judges/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-judges
-description: Orchestrate parallel judge agent execution, aggregate CaseScore results, write plan-judges.json, code-judges.json, or prd-judges.json, and validate output. Supports evaluating implementation plans (16 judges), code artifacts (11 judges), or PRD artifacts (4 judges) via --artifact-type parameter.
+description: Orchestrate parallel judge agent execution, aggregate CaseScore results, write plan-judges.json, code-judges.json, prd-judges.json, or feature-judges.json, and validate output. Supports evaluating implementation plans (16 judges), code artifacts (11 judges), PRD artifacts (4 judges), or feature artifacts (3 judges) via --artifact-type parameter.
 context: fork
 ---
 
@@ -8,7 +8,7 @@ context: fork
 
 ## Purpose
 
-Execute specialized judge agents in parallel to evaluate implementation plan quality (16 judges), code quality (11 judges), or PRD quality (4 judges). Aggregates results into `$CLOSEDLOOP_WORKDIR/plan-judges.json` (plan), `$CLOSEDLOOP_WORKDIR/code-judges.json` (code), or `$CLOSEDLOOP_WORKDIR/prd-judges.json` (prd) with validated output format.
+Execute specialized judge agents in parallel to evaluate implementation plan quality (16 judges), code quality (11 judges), PRD quality (4 judges), or feature quality (3 judges). Aggregates results into `$CLOSEDLOOP_WORKDIR/plan-judges.json` (plan), `$CLOSEDLOOP_WORKDIR/code-judges.json` (code), `$CLOSEDLOOP_WORKDIR/prd-judges.json` (prd), or `$CLOSEDLOOP_WORKDIR/feature-judges.json` (feature) with validated output format.
 
 ## Parameters
 
@@ -16,13 +16,14 @@ Execute specialized judge agents in parallel to evaluate implementation plan qua
 
 - Resolved in order: `--workdir` argument → `$CLOSEDLOOP_WORKDIR` environment variable → `.closedloop-ai/judges` (default, relative to current working directory)
 - The directory is created automatically if it does not exist
-- All output files (`plan-judges.json`, `code-judges.json`, `prd-judges.json`, `judge-input.json`, `perf.jsonl`, etc.) are written to this resolved directory
+- All output files (`plan-judges.json`, `code-judges.json`, `prd-judges.json`, `feature-judges.json`, `judge-input.json`, `perf.jsonl`, etc.) are written to this resolved directory
 
-**--artifact-type**: Artifact category to evaluate (plan | code | prd), default: plan
+**--artifact-type**: Artifact category to evaluate (plan | code | prd | feature), default: plan
 
 - **plan** (default): Evaluate implementation plan with 16 judges, 4 batches, output to plan-judges.json
 - **code**: Evaluate implemented code with 11 judges, 3 batches, output to code-judges.json
 - **prd**: Evaluate PRD document with 4 judges, single parallel batch, output to prd-judges.json
+- `feature` — Feature artifact evaluation (3 judges: feature-completeness-judge, prd-testability-judge, prd-dependency-judge)
 
 ## Judge Input Contract (`judge-input.json`)
 
@@ -59,6 +60,18 @@ You are orchestrating quality evaluation for a ClosedLoop artifact (implementati
 4. Aggregate all 4 CaseScores into a valid EvaluationReport
 5. Write the report to `$CLOSEDLOOP_WORKDIR/prd-judges.json`
 6. Validate output structure and completeness
+
+**For Feature artifacts (--artifact-type feature):**
+1. Check `$CLOSEDLOOP_WORKDIR/prd.md` exists (graceful exit if missing)
+2. Build `judge-input.json` with `evaluation_type: "feature"` and `primary_artifact` pointing to `prd.md`
+3. Launch 3 feature judges in a single parallel batch: `feature-completeness-judge`, `prd-testability-judge`, `prd-dependency-judge`
+4. Aggregate all 3 CaseScores into a valid EvaluationReport
+5. Write the report to `$CLOSEDLOOP_WORKDIR/feature-judges.json`
+6. Validate output structure and completeness
+
+**Note — excluded judges for feature mode:**
+- `prd-auditor` is excluded (PRD-specific: US/AC numbering, Success Metrics tables, Kill Criteria — not applicable to feature artifacts)
+- `prd-scope-judge` is excluded (multi-story traceability — not applicable to single-feature evaluation)
 
 **Success criteria:**
 - All judges executed (or error CaseScores generated for failures)
@@ -131,7 +144,7 @@ When loading threshold overrides, the skill applies the following validation rul
 - Configuration must contain an `"overrides"` key
 - Each key must match the pattern `artifact_type:judge_name`
 - Each value must be a float in range `[0.0, 1.0]`
-- Keys must reference valid artifact types (`plan`, `code`, `prd`) and judge names
+- Keys must reference valid artifact types (`plan`, `code`, `prd`, `feature`) and judge names
 
 **Error Behavior:**
 - **Malformed JSON**: Log warning and continue with hardcoded defaults
@@ -182,6 +195,10 @@ Use `sub_step` as numeric phase order and optional `sub_step_name` to capture th
 | prd      | 1        | prd_judges      |
 | prd      | 2        | aggregate       |
 | prd      | 3        | validate        |
+| feature  | 0        | context_prep (skipped — feature mode does not use context-manager-for-judges) |
+| feature  | 1        | feature_judges  |
+| feature  | 2        | aggregate       |
+| feature  | 3        | validate        |
 
 **Start of phase (run Bash once at the beginning of each phase):** Set the two sub-step variables at the top for the current phase, then run the block. It writes start time to a temp file so the end-of-phase Bash can compute duration. `CLOSEDLOOP_PARENT_STEP` and `CLOSEDLOOP_PARENT_STEP_NAME` are already in the environment (set by run-loop on the `claude` invocation).
 
@@ -412,14 +429,40 @@ fi
 - No context manager is launched; `judge-input.json` is built directly with `primary_artifact` pointing to `$CLOSEDLOOP_WORKDIR/prd.md`
 - Performance: emit sub_step=0 (context_prep, skipped=true) perf event immediately, then proceed to sub_step=1 (prd_judges)
 
+**For Feature artifacts (--artifact-type feature):**
+
+Feature mode does NOT use context-manager-for-judges. Context preparation is lightweight: verify the feature document (`prd.md`) exists, then build judge-input.json directly from it.
+
+```bash
+# Feature mode context prep: check prd.md exists
+if [ ! -f "$CLOSEDLOOP_WORKDIR/prd.md" ]; then
+  echo "WARNING: $CLOSEDLOOP_WORKDIR/prd.md not found. Skipping feature judges."
+  exit 0  # Graceful exit — do not fail parent workflow
+fi
+
+# Build feature-mode judge-input.json
+# - evaluation_type: "feature"
+# - task: Feature quality evaluation objective (3-judge workflow)
+# - primary_artifact: $CLOSEDLOOP_WORKDIR/prd.md
+# - supporting_artifacts: [] (none required)
+# - source_of_truth: ["prd"]
+```
+
+**Feature context prep notes:**
+- Missing `prd.md` results in a WARNING and graceful exit (code 0), not an error
+- No context manager is launched; `judge-input.json` is built directly with `primary_artifact` pointing to `$CLOSEDLOOP_WORKDIR/prd.md`
+- `evaluation_type` MUST be set to `"feature"` (not `"prd"`) to route correctly
+- Performance: emit sub_step=0 (context_prep, skipped=true) perf event immediately, then proceed to sub_step=1 (feature_judges)
+
 **If required files are missing:**
 - Plan mode: Exit gracefully with code 0 (do not fail parent workflow)
 - Code mode: Exit with error if context preparation fails
 - PRD mode: Exit gracefully with code 0 if prd.md is not found
+- Feature mode: Exit gracefully with code 0 if prd.md is not found
 
 ## Artifact Type Configuration
 
-The run-judges skill supports three artifact types with different judge configurations:
+The run-judges skill supports four artifact types with different judge configurations:
 
 ### Plan Artifacts (Default)
 - **Judges**: 16 total
@@ -470,11 +513,31 @@ The run-judges skill supports three artifact types with different judge configur
 - `judges:prd-testability-judge` — evaluates requirement testability
 - `judges:prd-scope-judge` — evaluates scope definition and boundary clarity
 
+### Feature Artifacts (--artifact-type feature)
+- **Judges**: 3 total
+- **Execution**: single parallel batch
+- **Context manager**: not used (no context-manager-for-judges)
+- **Output**: `feature-judges.json`
+- **Report ID**: `{RUN_ID}-feature-judges`
+- **Validation**: `--category feature` (3 judges expected)
+- **Canonical input**: `$CLOSEDLOOP_WORKDIR/prd.md`
+
+**Feature Execution:**
+
+**Batch 1: All Feature Judges (sub_step=1)**
+- `judges:feature-completeness-judge` — evaluates feature completeness relative to requirements
+- `judges:prd-testability-judge` — evaluates requirement testability and measurability
+- `judges:prd-dependency-judge` — evaluates dependency clarity and completeness
+
+**Excluded judges (not applicable to feature artifacts):**
+- `prd-auditor` — excluded (PRD-specific: US/AC numbering, Success Metrics tables, Kill Criteria)
+- `prd-scope-judge` — excluded (multi-story traceability not applicable to single-feature evaluation)
+
 ---
 
 ### Step 1: Launch Judge Agents in Parallel
 
-**Performance:** For each batch/phase, run "start of phase" Bash before launching the batch and "end of phase" Bash after the batch completes. Plan: batch_1=sub_step 1, batch_2=sub_step 2, batch_3=sub_step 3, batch_4=sub_step 4. Code: batch_1=sub_step 1, batch_2=sub_step 2, batch_3=sub_step 3. PRD: prd_judges=sub_step 1.
+**Performance:** For each batch/phase, run "start of phase" Bash before launching the batch and "end of phase" Bash after the batch completes. Plan: batch_1=sub_step 1, batch_2=sub_step 2, batch_3=sub_step 3, batch_4=sub_step 4. Code: batch_1=sub_step 1, batch_2=sub_step 2, batch_3=sub_step 3. PRD: prd_judges=sub_step 1. Feature: feature_judges=sub_step 1.
 
 **Constraint:** The Task tool supports maximum 4 concurrent agents per batch.
 
@@ -531,6 +594,16 @@ The run-judges skill supports three artifact types with different judge configur
 | `judges:prd-testability-judge` | Requirement testability and measurability |
 | `judges:prd-scope-judge` | Scope definition and boundary clarity |
 
+### Feature Artifact Judge Batch (3 judges, single parallel batch)
+
+**Batch 1: All Feature Judges (sub_step=1)**
+
+| Agent Type | Evaluates |
+|------------|-----------|
+| `judges:feature-completeness-judge` | Feature completeness relative to requirements |
+| `judges:prd-testability-judge` | Requirement testability and measurability |
+| `judges:prd-dependency-judge` | Dependency clarity and completeness |
+
 </judge_batches>
 
 <prompt_template>
@@ -585,6 +658,17 @@ Evaluate according to `task` and `source_of_truth` ordering.
 Treat the envelope's `primary_artifact` ($CLOSEDLOOP_WORKDIR/prd.md) as the authoritative PRD document.
 Apply your {judge_name} criteria to assess PRD quality.
 ```
+
+**For Feature artifacts:**
+```
+WORKDIR=$CLOSEDLOOP_WORKDIR. Read $CLOSEDLOOP_WORKDIR/judge-input.json first.
+Evaluate according to `task` and `source_of_truth` ordering.
+Treat the envelope's `primary_artifact` ($CLOSEDLOOP_WORKDIR/prd.md) as the authoritative feature document.
+Apply your {judge_name} criteria to assess feature quality.
+```
+
+Note: Feature artifacts load `feature_preamble.md` directly via the `{artifact_type}_preamble.md` pattern. Locate the preamble as:
+`skills/artifact-type-tailored-context/preambles/feature_preamble.md`
 
 </prompt_template>
 
@@ -648,7 +732,7 @@ Each judge returns a **CaseScore** JSON object:
 
 **Continue-on-failure semantics:**
 - Even if ALL judges fail, you MUST aggregate error CaseScores
-- Always produce a complete report with 16 CaseScore entries (plan), 11 CaseScore entries (code), or 4 CaseScore entries (prd)
+- Always produce a complete report with 16 CaseScore entries (plan), 11 CaseScore entries (code), 4 CaseScore entries (prd), or 3 CaseScore entries (feature)
 - Never abort the workflow due to judge failures
 
 </error_handling>
@@ -657,7 +741,7 @@ Each judge returns a **CaseScore** JSON object:
 
 ### Step 2: Aggregate Results into EvaluationReport
 
-**Performance:** Run "start of phase" with sub_step 5 (plan), 4 (code), or 2 (prd), sub_step_name=aggregate. Emit 'end of phase' after the aggregation step regardless of file write outcome.
+**Performance:** Run "start of phase" with sub_step 5 (plan), 4 (code), 2 (prd), or 2 (feature), sub_step_name=aggregate. Emit 'end of phase' after the aggregation step regardless of file write outcome.
 
 **Task:** Collect all CaseScore outputs and structure them into an `EvaluationReport`.
 
@@ -671,6 +755,9 @@ if artifact_type == 'code':
 elif artifact_type == 'prd':
     report_filename = 'prd-judges.json'
     report_id = f'{RUN_ID}-prd-judges'
+elif artifact_type == 'feature':
+    report_filename = 'feature-judges.json'
+    report_id = f'{RUN_ID}-feature-judges'
 else:
     report_filename = 'plan-judges.json'
     report_id = f'{RUN_ID}-plan-judges'
@@ -742,9 +829,9 @@ output_path = $CLOSEDLOOP_WORKDIR / report_filename
 
 | Field | Format | How to Derive |
 |-------|--------|---------------|
-| `report_id` | `{RUN_ID}-plan-judges`, `{RUN_ID}-code-judges`, or `{RUN_ID}-prd-judges` | Extract RUN_ID from `$CLOSEDLOOP_WORKDIR` directory name, append suffix based on artifact type |
+| `report_id` | `{RUN_ID}-plan-judges`, `{RUN_ID}-code-judges`, `{RUN_ID}-prd-judges`, or `{RUN_ID}-feature-judges` | Extract RUN_ID from `$CLOSEDLOOP_WORKDIR` directory name, append suffix based on artifact type |
 | `timestamp` | ISO 8601 | Generate with `date -u +%Y-%m-%dT%H:%M:%SZ` |
-| `stats` | Array[CaseScore] | 16 CaseScore objects for plan, 11 for code, 4 for prd (one per judge) |
+| `stats` | Array[CaseScore] | 16 CaseScore objects for plan, 11 for code, 4 for prd, 3 for feature (one per judge) |
 
 </output_structure>
 
@@ -752,7 +839,7 @@ output_path = $CLOSEDLOOP_WORKDIR / report_filename
 
 ### Step 3: Validate Output (MANDATORY)
 
-**Performance:** Run "start of phase" with sub_step 6 (plan), 5 (code), or 3 (prd), sub_step_name=validate. Emit 'end of phase' after each validation attempt regardless of exit code, then apply failure recovery logic.
+**Performance:** Run "start of phase" with sub_step 6 (plan), 5 (code), 3 (prd), or 3 (feature), sub_step_name=validate. Emit 'end of phase' after each validation attempt regardless of exit code, then apply failure recovery logic.
 
 **CRITICAL:** You MUST run the validation script after writing the judge report. Do not consider the task complete until validation passes.
 
@@ -787,6 +874,8 @@ if [ "$ARTIFACT_TYPE" = "code" ]; then
   CATEGORY="code"
 elif [ "$ARTIFACT_TYPE" = "prd" ]; then
   CATEGORY="prd"
+elif [ "$ARTIFACT_TYPE" = "feature" ]; then
+  CATEGORY="feature"
 fi
 
 # Run validation with appropriate category
@@ -795,8 +884,8 @@ uv run "$SCRIPT_PATH" --workdir "$CLOSEDLOOP_WORKDIR" --category "$CATEGORY"
 
 **Argument requirements:**
 - `--workdir` must be the **absolute path** to `$CLOSEDLOOP_WORKDIR`
-- `--category` must be `plan` (16 judges), `code` (11 judges), or `prd` (4 judges)
-- This is where `plan-judges.json`, `code-judges.json`, or `prd-judges.json` is located
+- `--category` must be `plan` (16 judges), `code` (11 judges), `prd` (4 judges), or `feature` (3 judges)
+- This is where `plan-judges.json`, `code-judges.json`, `prd-judges.json`, or `feature-judges.json` is located
 
 </validation_workflow>
 
@@ -812,10 +901,10 @@ The script validates using strict Pydantic models:
 |-------|-------------|
 | **JSON syntax** | Valid JSON format |
 | **Required fields** | report_id, timestamp, stats array |
-| **Judge coverage** | All expected judges present (16 for plan, 11 for code, 4 for prd) |
+| **Judge coverage** | All expected judges present (16 for plan, 11 for code, 4 for prd, 3 for feature) |
 | **Status values** | final_status ∈ {1, 2, 3} |
 | **Metric completeness** | Each judge has ≥1 metric |
-| **Report ID format** | Ends with '-judges' (plan), '-code-judges' (code), or '-prd-judges' (prd) |
+| **Report ID format** | Ends with '-judges' (plan), '-code-judges' (code), '-prd-judges' (prd), or '-feature-judges' (feature) |
 
 **Expected judge case_ids for plan artifacts (16 total):**
 ```
@@ -863,6 +952,15 @@ prd-scope-judge
 ```
 
 **Note:** All 4 PRD judges run in a single parallel batch.
+
+**Expected judge case_ids for feature artifacts (3 total):**
+```
+feature-completeness-judge
+prd-dependency-judge
+prd-testability-judge
+```
+
+**Note:** Feature artifacts exclude prd-auditor (PRD-specific checks) and prd-scope-judge (multi-story traceability).
 
 </validation_checks>
 
@@ -970,6 +1068,16 @@ Before marking this task complete, verify:
 - [ ] **Report ID format** - report_id ends with '-prd-judges'
 - [ ] **Validation passed** - Script exits with code 0 using `--category prd` (sub_step=3)
 
+**For feature artifacts (--artifact-type feature):**
+- [ ] **prd.md existence check** - `$CLOSEDLOOP_WORKDIR/prd.md` found, or graceful exit with WARNING (code 0)
+- [ ] **No context manager** - context-manager-for-judges is NOT launched for feature mode
+- [ ] **Judge input contract** - `judge-input.json` written with `evaluation_type="feature"` and `primary_artifact=$CLOSEDLOOP_WORKDIR/prd.md`
+- [ ] **Parallel execution** - All 3 feature judges launched in a single parallel batch (sub_step=1)
+- [ ] **Result aggregation** - Valid EvaluationReport with 3 CaseScore entries (sub_step=2)
+- [ ] **File output** - `feature-judges.json` written to `$CLOSEDLOOP_WORKDIR`
+- [ ] **Report ID format** - report_id ends with '-feature-judges'
+- [ ] **Validation passed** - Script exits with code 0 using `--category feature` (sub_step=3)
+
 </completion_criteria>
 
 ---
@@ -980,9 +1088,9 @@ Before marking this task complete, verify:
 
 | Error Message | Root Cause | Solution |
 |---------------|------------|----------|
-| "Report file does not exist" | File not written to correct location | Verify `$CLOSEDLOOP_WORKDIR` is set; check write path matches artifact type (plan-judges.json, code-judges.json, or prd-judges.json) |
-| "Invalid JSON" | Syntax error in output file | Run `python3 -m json.tool "$CLOSEDLOOP_WORKDIR/{plan,code,prd}-judges.json"` to identify syntax error |
-| "Missing expected judges" | Incomplete batch execution | Verify all batches launched (4 for plan, 3 for code, 1 for prd); check error CaseScores for failures; plan expects 16 judges, code expects 11, prd expects 4 |
+| "Report file does not exist" | File not written to correct location | Verify `$CLOSEDLOOP_WORKDIR` is set; check write path matches artifact type (plan-judges.json, code-judges.json, prd-judges.json, or feature-judges.json) |
+| "Invalid JSON" | Syntax error in output file | Run `python3 -m json.tool "$CLOSEDLOOP_WORKDIR/{plan,code,prd,feature}-judges.json"` to identify syntax error |
+| "Missing expected judges" | Incomplete batch execution | Verify all batches launched (4 for plan, 3 for code, 1 for prd, 1 for feature); check error CaseScores for failures; plan expects 16 judges, code expects 11, prd expects 4, feature expects 3 |
 | "final_status must be 1, 2, or 3" | Invalid status code | Use only: 1 (pass), 2 (fail), 3 (error) |
 | "report_id should end with '-plan-judges'" | Incorrect ID format for plan | Use pattern: `{RUN_ID}-plan-judges` for plan artifacts |
 | "report_id should end with '-code-judges'" | Incorrect ID format for code | Use pattern: `{RUN_ID}-code-judges` for code artifacts |
@@ -995,9 +1103,10 @@ Before marking this task complete, verify:
 | "pre-explorer unavailable" | `@code:pre-explorer` not installed/resolvable | Log warning and use internal fallback investigation to create `investigation-log.md` |
 | "investigation-log.md missing after fallback" | Both pre-explorer and internal fallback failed | Log warning and continue; do not block context preparation |
 | "investigation-log.md missing in code mode" | pre-explorer unavailable or generation failed during code preflight | Log warning and continue with `code-context.json` only (non-blocking) |
-| "Invalid --artifact-type value" | Unsupported artifact type | Use only 'plan', 'code', or 'prd' |
+| "Invalid --artifact-type value" | Unsupported artifact type | Use only 'plan', 'code', 'prd', or 'feature' |
 | "prd.md not found" | PRD document missing from workdir | Emit WARNING and exit gracefully (code 0); do not fail the parent workflow |
 | "report_id should end with '-prd-judges'" | Incorrect ID format for prd | Use pattern: `{RUN_ID}-prd-judges` for PRD artifacts |
+| "report_id should end with '-feature-judges'" | Incorrect ID format for feature | Use pattern: `{RUN_ID}-feature-judges` for feature artifacts |
 
 </troubleshooting>
 
@@ -1007,7 +1116,7 @@ Before marking this task complete, verify:
 
 ### Invalid Artifact Type
 
-If `--artifact-type` value is not 'plan', 'code', or 'prd':
+If `--artifact-type` value is not 'plan', 'code', 'prd', or 'feature':
 - Fail immediately with clear error message
 - Do not attempt judge execution
 - Exit with non-zero status
@@ -1057,5 +1166,16 @@ When `--artifact-type prd` is specified:
 - Launch all 4 PRD judges in a single parallel batch (sub_step=1)
 - Aggregate all 4 CaseScores (sub_step=2) and write to `prd-judges.json`
 - Validate with `--category prd` (sub_step=3)
+
+### Feature Mode Execution Flow
+
+When `--artifact-type feature` is specified:
+- Check `$CLOSEDLOOP_WORKDIR/prd.md` exists; emit WARNING and exit gracefully (code 0) if missing
+- Do NOT launch context-manager-for-judges
+- Build `judge-input.json` with `evaluation_type="feature"` and `primary_artifact=$CLOSEDLOOP_WORKDIR/prd.md`
+- Launch all 3 feature judges in a single parallel batch (sub_step=1): `feature-completeness-judge`, `prd-testability-judge`, `prd-dependency-judge`
+- Aggregate all 3 CaseScores (sub_step=2) and write to `feature-judges.json`
+- Validate with `--category feature` (sub_step=3)
+- Do NOT launch `prd-auditor` or `prd-scope-judge` (excluded for feature mode)
 
 ---

--- a/plugins/judges/skills/run-judges/scripts/test_validate_judge_report.py
+++ b/plugins/judges/skills/run-judges/scripts/test_validate_judge_report.py
@@ -771,6 +771,132 @@ class TestCategoryPrdValidation:
         assert VALID_SUFFIXES["prd"] == ["-prd-judges"]
 
 
+class TestCategoryFeatureValidation:
+    """Tests for the feature category with 3 judges."""
+
+    def test_accepts_valid_3_judge_report(self, tmp_path: Path) -> None:
+        """Valid 3-judge feature report passes validation."""
+        feature_judges = sorted(JUDGE_REGISTRY["feature"])
+        assert len(feature_judges) == 3, "Feature judges count should be 3"
+
+        report = create_evaluation_report("run-20250211-feature-judges", feature_judges)
+
+        report_path = tmp_path / "feature-judges.json"
+        report_path.write_text(json.dumps(report, indent=2))
+
+        valid, message = validate_report(report_path, category="feature")
+        assert valid is True, f"Expected valid feature report, got: {message}"
+        assert "3 judge results" in message
+
+    def test_feature_registry_contains_expected_judges(self) -> None:
+        """Verify feature JUDGE_REGISTRY contains the 3 expected feature judges."""
+        assert JUDGE_REGISTRY["feature"] == {
+            "feature-completeness-judge",
+            "prd-testability-judge",
+            "prd-dependency-judge",
+        }
+
+    def test_feature_report_id_requires_feature_judges_suffix(self, tmp_path: Path) -> None:
+        """Feature report must use -feature-judges suffix in report_id."""
+        feature_judges = sorted(JUDGE_REGISTRY["feature"])
+        report = create_evaluation_report("run-20250211-feature-judges", feature_judges)
+
+        report_path = tmp_path / "feature-judges.json"
+        report_path.write_text(json.dumps(report, indent=2))
+
+        valid, message = validate_report(report_path, category="feature")
+        assert valid is True, (
+            f"Expected valid report with -feature-judges suffix, got: {message}"
+        )
+
+    def test_feature_rejects_wrong_suffix(self, tmp_path: Path) -> None:
+        """Feature report with bare -judges suffix fails validation."""
+        feature_judges = sorted(JUDGE_REGISTRY["feature"])
+        report = create_evaluation_report("run-20250211-judges", feature_judges)
+
+        report_path = tmp_path / "feature-judges.json"
+        report_path.write_text(json.dumps(report, indent=2))
+
+        valid, message = validate_report(report_path, category="feature")
+        assert valid is False, "Expected rejection for wrong suffix"
+        assert "report_id should end with one of" in message
+        assert "-feature-judges" in message
+
+    def test_feature_rejects_prd_suffix(self, tmp_path: Path) -> None:
+        """Feature report using prd-style suffix fails validation."""
+        feature_judges = sorted(JUDGE_REGISTRY["feature"])
+        report = create_evaluation_report("run-20250211-prd-judges", feature_judges)
+
+        report_path = tmp_path / "feature-judges.json"
+        report_path.write_text(json.dumps(report, indent=2))
+
+        valid, message = validate_report(report_path, category="feature")
+        assert valid is False, (
+            "Expected rejection for prd suffix used with feature category"
+        )
+        assert "report_id should end with one of" in message
+
+    def test_feature_rejects_missing_judges(self, tmp_path: Path) -> None:
+        """Feature report missing prd-dependency-judge fails validation."""
+        partial_judges = [
+            j for j in sorted(JUDGE_REGISTRY["feature"]) if j != "prd-dependency-judge"
+        ]
+        assert len(partial_judges) == 2
+
+        report = create_evaluation_report("run-20250211-feature-judges", partial_judges)
+
+        report_path = tmp_path / "feature-judges.json"
+        report_path.write_text(json.dumps(report, indent=2))
+
+        valid, message = validate_report(report_path, category="feature")
+        assert valid is False
+        assert "Missing expected judges for category 'feature'" in message
+        assert "prd-dependency-judge" in message
+
+    def test_feature_report_extra_judge_passes(self, tmp_path: Path) -> None:
+        """Feature report with extra judges beyond the required 3 still passes."""
+        feature_judges = sorted(JUDGE_REGISTRY["feature"])
+        extra_judges = feature_judges + ["extra-custom-judge"]
+
+        report = create_evaluation_report("run-20250211-feature-judges", extra_judges)
+
+        report_path = tmp_path / "feature-judges.json"
+        report_path.write_text(json.dumps(report, indent=2))
+
+        valid, message = validate_report(report_path, category="feature")
+        assert valid is True, "Extra judges should not cause feature validation failure"
+
+    def test_feature_not_accepted_for_prd_category(self, tmp_path: Path) -> None:
+        """Feature judges submitted as a prd report fail because prd-specific judges are missing."""
+        feature_judges = sorted(JUDGE_REGISTRY["feature"])
+        report = create_evaluation_report("run-20250211-prd-judges", feature_judges)
+
+        report_path = tmp_path / "prd-judges.json"
+        report_path.write_text(json.dumps(report, indent=2))
+
+        valid, message = validate_report(report_path, category="prd")
+        assert valid is False, (
+            "Feature judges should not satisfy prd category requirements"
+        )
+        assert "Missing expected judges" in message
+
+    def test_default_filename_for_feature_category(self) -> None:
+        """DEFAULT_FILENAMES produces 'feature-judges.json' for feature category."""
+        from validate_judge_report import (
+            DEFAULT_FILENAMES,  # type: ignore[import-not-found]
+        )
+
+        assert DEFAULT_FILENAMES["feature"] == "feature-judges.json"
+
+    def test_valid_suffixes_for_feature_category(self) -> None:
+        """VALID_SUFFIXES for feature contains only '-feature-judges'."""
+        from validate_judge_report import (
+            VALID_SUFFIXES,  # type: ignore[import-not-found]
+        )
+
+        assert VALID_SUFFIXES["feature"] == ["-feature-judges"]
+
+
 class TestPlanRegistryReconciliation:
     """Tests verifying the reconciled plan JUDGE_REGISTRY (3 new judges added, no phantom entries)."""
 

--- a/plugins/judges/skills/run-judges/scripts/validate_judge_report.py
+++ b/plugins/judges/skills/run-judges/scripts/validate_judge_report.py
@@ -100,12 +100,18 @@ JUDGE_REGISTRY: dict[str, set[str]] = {
         "prd-testability-judge",
         "prd-scope-judge",
     },
+    "feature": {
+        "feature-completeness-judge",
+        "prd-testability-judge",
+        "prd-dependency-judge",
+    },
 }
 
 VALID_SUFFIXES: dict[str, list[str]] = {
     "plan": ["-plan-judges", "-judges"],
     "code": ["-code-judges"],
     "prd": ["-prd-judges"],
+    "feature": ["-feature-judges"],
 }
 
 # Default report filename per category
@@ -113,6 +119,7 @@ DEFAULT_FILENAMES: dict[str, str] = {
     "plan": "plan-judges.json",
     "code": "code-judges.json",
     "prd": "prd-judges.json",
+    "feature": "feature-judges.json",
 }
 
 
@@ -121,7 +128,7 @@ def validate_report(report_path: Path, category: str = "plan") -> tuple[bool, st
 
     Args:
         report_path: Path to the judge report file
-        category: Judge category to validate against ('plan', 'code', or 'prd')
+        category: Judge category to validate against ('plan', 'code', 'prd', or 'feature')
 
     Returns:
         Tuple of (valid: bool, message: str)


### PR DESCRIPTION
## Summary

Adds a new `feature` evaluation mode to the `judges` plugin so feature artifacts (PRD-adjacent but lighter) can be evaluated by a focused judge set without inheriting irrelevant PRD-only structural rubrics.

## Changes

- **New agent**: `plugins/judges/agents/feature-completeness-judge.md` evaluates feature artifacts for completeness against expected criteria.
- **Schema**: `plugins/judges/schemas/judge-input.schema.json` extends `evaluation_type` enum with `"feature"`.
- **Skill**: `plugins/judges/skills/run-judges/SKILL.md` documents feature mode, including the 3-judge batch (`feature-completeness-judge`, `prd-testability-judge`, `prd-dependency-judge`) and the rationale for excluding `prd-auditor` and `prd-scope-judge` (their rubrics assume PRD-specific structure not present in Feature artifacts).
- **Preamble**: `plugins/judges/skills/artifact-type-tailored-context/preambles/feature_preamble.md` provides feature-specific context guidance.
- **Validation**: `plugins/judges/skills/run-judges/scripts/validate_judge_report.py` registers the `feature` category in `JUDGE_REGISTRY`, `VALID_SUFFIXES`, and `DEFAULT_FILENAMES`, with corresponding tests in `test_validate_judge_report.py`.
- **README**: Updates plan/code/prd references throughout to include `feature`.
- **Version bump**: `plugins/judges` 1.5.1 → 1.6.0 (MINOR — new agent + new artifact type).

## Test plan

- [x] `pytest plugins/judges/skills/run-judges/scripts/test_validate_judge_report.py`
- [ ] Run `run-judges --artifact-type feature` against a sample `prd.md` to verify the report writes to `feature-judges.json` and validates cleanly
- [ ] Confirm existing `plan` / `code` / `prd` modes remain unchanged

---
Loop ID: 019dde7c-62a1-7068-9bb8-634d760a6e52
Artifact: https://app.closedloop.ai/implementation-plans/PLN-418
