### PR TITLE
FEA-764: add per-phase telemetry to perf.jsonl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code v1.11.0
+
+#### Added
+- New `record_phase.sh` script that appends a `phase` event to `perf.jsonl` from the current `state.json`. Captures `phase`, `status`, `start_sha`, `started_at`, `run_id`, and `iteration` so per-phase wall-clock durations can be reconstructed across an entire run.
+
+#### Changed
+- Orchestrator State Tracking section in `prompt.md` now instructs the orchestrator to call `record_phase.sh` after every `state.json` write (non-blocking; failures ignored). Phase events stream into the same `perf.jsonl` file as iteration, pipeline_step, and agent timing events.
+
+### self-learning v1.2.0
+
+#### Added
+- New `summarize_phases()` aggregator in `perf_summary.py` that reads `phase` events from `perf.jsonl`, derives per-phase durations from the gap to the next phase event in the same `(run_id, iteration)` (or to the iteration's `ended_at` for the final phase), and reports count/avg/min/max/total. Phases never pair across iteration boundaries.
+- Phases summary table added to `perf_summary.py` text output and `phases` field added to its JSON output, alongside the existing Iterations / Pipeline Steps / Sub-steps / Agents tables.
+- New `--timeline` CLI flag and `phase_timeline()` function in `perf_summary.py` that emits a chronological per-instance view (one row per phase invocation with `run_id`, `iteration`, `started_at`, `ended_at`, `duration_s`). Incomplete final phases (no following phase event AND no iteration `ended_at`) are emitted with `ended_at=""` and `duration_s=null` so in-progress runs remain visible. Works with `--format json` for machine-readable output.
+- Tests for phase summarization and timeline covering iteration boundaries, missing iteration end (final phase skipped vs surfaced), aggregation across iterations, total-time descending sort, and per-row run/iteration provenance.
+
 ### code v1.10.0
 
 #### Added

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/README.md
+++ b/plugins/code/README.md
@@ -500,7 +500,7 @@ After a full run, the work directory will contain:
   code-map.json              # Codebase file map (from pre-explorer)
   state.json                 # Current phase/status for monitoring
   log.md                     # Change log appended each phase
-  perf.jsonl                 # Agent timing events
+  perf.jsonl                 # Phase, iteration, pipeline_step, and agent timing events
   reviews/                   # Critic review files (*.review.json)
   .closedloop-ai/config.env   # Session environment variables
   .learnings/                # Self-learning artifacts

--- a/plugins/code/prompts/prompt.md
+++ b/plugins/code/prompts/prompt.md
@@ -83,6 +83,8 @@ Use this sequence at any hard-stop that requires user action before continuing:
 
 **How to write:** `echo '<json>' > $CLOSEDLOOP_WORKDIR/state.json` (use `$(date -u +%Y-%m-%dT%H:%M:%SZ)` for timestamp)
 
+**Telemetry (after every state.json write):** Run `bash "$CLAUDE_PLUGIN_ROOT/scripts/record_phase.sh" 2>/dev/null || true` to append a `phase` event to `perf.jsonl`. Non-blocking — ignore failures. The event lets `perf_summary.py` derive per-phase wall-clock durations across the run.
+
 **Base schema:** `{"phase": "<name>", "status": "IN_PROGRESS", "timestamp": "..."}`
 
 **Extended fields by context:**

--- a/plugins/code/scripts/record_phase.sh
+++ b/plugins/code/scripts/record_phase.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# record_phase.sh - Append a phase event to perf.jsonl from the current state.json.
+#
+# Called by the orchestrator after every state.json write so workflow.json
+# can derive per-phase wall-clock timings.
+#
+# Usage:
+#   bash record_phase.sh [WORKDIR]
+# WORKDIR defaults to $CLOSEDLOOP_WORKDIR.
+
+set -euo pipefail
+
+WORKDIR="${1:-${CLOSEDLOOP_WORKDIR:-}}"
+if [[ -z "$WORKDIR" ]]; then
+  echo "record_phase.sh: WORKDIR required (pass as $1 or set CLOSEDLOOP_WORKDIR)" >&2
+  exit 1
+fi
+
+STATE_FILE="$WORKDIR/state.json"
+PERF_FILE="$WORKDIR/perf.jsonl"
+
+if [[ ! -f "$STATE_FILE" ]]; then
+  exit 0
+fi
+
+PHASE=$(jq -r '.phase // ""' "$STATE_FILE" 2>/dev/null || echo "")
+STATUS=$(jq -r '.status // ""' "$STATE_FILE" 2>/dev/null || echo "")
+START_SHA=$(jq -r '.startSha // ""' "$STATE_FILE" 2>/dev/null || echo "")
+
+if [[ -z "$PHASE" ]]; then
+  exit 0
+fi
+
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+RUN_ID="${CLOSEDLOOP_RUN_ID:-unknown}"
+ITERATION="${CLOSEDLOOP_ITERATION:-0}"
+
+mkdir -p "$(dirname "$PERF_FILE")"
+
+jq -n -c \
+  --arg event "phase" \
+  --arg run_id "$RUN_ID" \
+  --argjson iteration "$ITERATION" \
+  --arg phase "$PHASE" \
+  --arg status "$STATUS" \
+  --arg start_sha "$START_SHA" \
+  --arg started_at "$TIMESTAMP" \
+  '{event:$event,run_id:$run_id,iteration:$iteration,phase:$phase,status:$status,start_sha:$start_sha,started_at:$started_at}' \
+  >> "$PERF_FILE"

--- a/plugins/code/scripts/record_phase.sh
+++ b/plugins/code/scripts/record_phase.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # record_phase.sh - Append a phase event to perf.jsonl from the current state.json.
 #
-# Called by the orchestrator after every state.json write so workflow.json
+# Called by the orchestrator after every state.json write so perf_summary.py
 # can derive per-phase wall-clock timings.
 #
 # Usage:

--- a/plugins/self-learning/.claude-plugin/plugin.json
+++ b/plugins/self-learning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "self-learning",
   "description": "Self-learning plugin",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/self-learning/README.md
+++ b/plugins/self-learning/README.md
@@ -317,11 +317,11 @@ python3 verify_citations.py --start-sha <git-sha> --workdir /path/to/workdir
 
 ### `perf_summary.py`
 
-Reads `perf.jsonl` and prints timing tables for iterations, pipeline steps, sub-steps, and agents. Useful for identifying bottlenecks in the ClosedLoop loop.
+Reads `perf.jsonl` and prints timing tables for iterations, phases, pipeline steps, sub-steps, and agents. Useful for identifying bottlenecks in the ClosedLoop loop. Pass `--timeline` for a chronological per-instance phase view (one row per phase invocation with start/end timestamps and duration) instead of aggregate stats.
 
 **Usage:**
 ```bash
-python3 perf_summary.py --workdir /path/to/workdir [--run-id 20240115-103000] [--format text|json]
+python3 perf_summary.py --workdir /path/to/workdir [--run-id 20240115-103000] [--format text|json] [--timeline]
 ```
 
 ### `write_merged_patterns.py`

--- a/plugins/self-learning/tools/python/perf_summary.py
+++ b/plugins/self-learning/tools/python/perf_summary.py
@@ -492,13 +492,14 @@ def print_phase_timeline(rows: list[dict[str, object]]) -> None:
         return
     print("=== Phase Timeline ===")
     print(
-        f"{'Iter':<6} {'Phase':<40} {'Started':<22} {'Ended':<22} {'Duration':<10}"
+        f"{'Run':<22} {'Iter':<6} {'Phase':<40} {'Started':<22} {'Ended':<22} {'Duration':<10}"
     )
-    print("-" * 102)
+    print("-" * 124)
     for row in rows:
         dur = row.get("duration_s")
         dur_str = _fmt_duration(float(dur)) if isinstance(dur, (int, float)) else "?"
         print(
+            f"{row.get('run_id', '')!s:<22} "
             f"{row.get('iteration', '')!s:<6} "
             f"{row.get('phase', '')!s:<40} "
             f"{row.get('started_at', '')!s:<22} "

--- a/plugins/self-learning/tools/python/perf_summary.py
+++ b/plugins/self-learning/tools/python/perf_summary.py
@@ -10,6 +10,7 @@ import argparse
 import json
 import sys
 from collections.abc import Hashable
+from datetime import datetime
 from pathlib import Path
 from typing import Callable, TypeVar
 
@@ -21,6 +22,11 @@ K = TypeVar("K", bound=Hashable)
 #                 exit_code, skipped, [sub_step], [sub_step_name]}
 # agent:         {event, run_id, iteration, agent_id, agent_type, agent_name,
 #                 started_at, ended_at, duration_s}
+# phase:         {event, run_id, iteration, phase, status, start_sha, started_at}
+#                Phase events carry only started_at; per-phase durations are derived from
+#                the gap to the next phase event in the same iteration (or to the iteration's
+#                ended_at for the final phase). Use --timeline for a chronological per-instance
+#                view; the default summary aggregates by phase name.
 # Legacy compatibility:
 # pipeline_substep rows are still accepted for historical files and mapped into sub-step summaries.
 
@@ -231,6 +237,149 @@ def summarize_agents(
     return rows
 
 
+def _parse_iso(ts: str) -> float | None:
+    """Parse ISO-8601 timestamp (with optional Z suffix) to a POSIX epoch float."""
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _phase_iter_ends(
+    events: list[dict[str, object]],
+) -> dict[tuple[str, int], str]:
+    """Build (run_id, iteration) -> ended_at lookup from iteration events."""
+    iter_ends: dict[tuple[str, int], str] = {}
+    for e in events:
+        if e.get("event") != "iteration":
+            continue
+        key = (str(e.get("run_id", "")), _get_int(e, "iteration"))
+        ended_at = str(e.get("ended_at", ""))
+        if ended_at:
+            iter_ends[key] = ended_at
+    return iter_ends
+
+
+def _group_phase_events(
+    events: list[dict[str, object]],
+) -> dict[tuple[str, int], list[dict[str, object]]]:
+    """Group phase events by (run_id, iteration)."""
+    grouped: dict[tuple[str, int], list[dict[str, object]]] = {}
+    for e in events:
+        if e.get("event") != "phase":
+            continue
+        key = (str(e.get("run_id", "")), _get_int(e, "iteration"))
+        grouped.setdefault(key, []).append(e)
+    return grouped
+
+
+def summarize_phases(
+    events: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Aggregate phase events by phase name.
+
+    Phase events carry only `started_at`. Duration is derived from the gap to
+    the next phase event in the same (run_id, iteration), or to the iteration's
+    ended_at for the final phase. Returns rows sorted by total time descending.
+    """
+    grouped = _group_phase_events(events)
+    if not grouped:
+        return []
+
+    iter_ends = _phase_iter_ends(events)
+
+    by_phase: dict[str, list[float]] = {}
+    for key, phase_events in grouped.items():
+        sorted_phases = sorted(
+            phase_events, key=lambda x: str(x.get("started_at", ""))
+        )
+        for i, p in enumerate(sorted_phases):
+            start_ts = _parse_iso(str(p.get("started_at", "")))
+            if start_ts is None:
+                continue
+            if i + 1 < len(sorted_phases):
+                end_ts = _parse_iso(
+                    str(sorted_phases[i + 1].get("started_at", ""))
+                )
+            else:
+                end_ts = _parse_iso(iter_ends.get(key, ""))
+            if end_ts is None:
+                continue
+            duration = end_ts - start_ts
+            if duration < 0:
+                continue
+            phase_name = str(p.get("phase", "unknown"))
+            by_phase.setdefault(phase_name, []).append(duration)
+
+    if not by_phase:
+        return []
+
+    rows: list[dict[str, object]] = []
+    for name, durs in by_phase.items():
+        rows.append({"phase": name, **_agg_stats(durs)})
+
+    rows.sort(key=lambda x: x.get("total_s", 0), reverse=True)  # type: ignore[return-value]
+    return rows
+
+
+def phase_timeline(
+    events: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Return chronological per-instance phase rows.
+
+    Unlike summarize_phases (aggregate stats), this emits one row per phase
+    instance with run_id, iteration, started_at, ended_at, and duration_s.
+    Incomplete final phases (no following phase event AND no iteration ended_at)
+    are still emitted with ended_at="" and duration_s=None so in-progress runs
+    are visible. Negative durations from clock skew are filtered. Rows are
+    sorted by started_at ascending.
+    """
+    grouped = _group_phase_events(events)
+    if not grouped:
+        return []
+
+    iter_ends = _phase_iter_ends(events)
+
+    rows: list[dict[str, object]] = []
+    for key, phase_events in grouped.items():
+        run_id, iteration = key
+        sorted_phases = sorted(
+            phase_events, key=lambda x: str(x.get("started_at", ""))
+        )
+        for i, p in enumerate(sorted_phases):
+            started_at = str(p.get("started_at", ""))
+            start_ts = _parse_iso(started_at)
+            if start_ts is None:
+                continue
+            if i + 1 < len(sorted_phases):
+                ended_at = str(sorted_phases[i + 1].get("started_at", ""))
+            else:
+                ended_at = iter_ends.get(key, "")
+            end_ts = _parse_iso(ended_at)
+            duration: float | None
+            if end_ts is None:
+                duration = None
+                ended_at = ""
+            else:
+                raw = end_ts - start_ts
+                if raw < 0:
+                    continue
+                duration = round(raw, 1)
+            rows.append({
+                "run_id": run_id,
+                "iteration": iteration,
+                "phase": str(p.get("phase", "unknown")),
+                "started_at": started_at,
+                "ended_at": ended_at,
+                "duration_s": duration,
+            })
+
+    rows.sort(key=lambda r: str(r.get("started_at", "")))
+    return rows
+
+
 _SECONDS_PER_MINUTE = 60
 _MINUTES_PER_HOUR = 60
 
@@ -265,6 +414,7 @@ def print_text(
     *,
     substeps: list[dict[str, object]],
     agents: list[dict[str, object]],
+    phases: list[dict[str, object]],
 ) -> None:
     """Print human-readable text tables."""
     if iterations:
@@ -288,6 +438,16 @@ def print_text(
                     f"{row.get('status', '')!s:<15} "
                     f"{row.get('started_at', '')!s:<25}"
                 )
+        print()
+
+    if phases:
+        print("=== Phases (by total time) ===")
+        print(f"{'Phase':<40} {_STATS_HEADER}")
+        print("-" * 80)
+        for row in phases:
+            print(
+                f"{row.get('phase', '')!s:<40} {_format_stats_cols(row)}"
+            )
         print()
 
     if pipeline:
@@ -321,8 +481,30 @@ def print_text(
             print(f"{row.get('agent_name', '')!s:<28} {_format_stats_cols(row)}")
         print()
 
-    if not iterations and not pipeline and not substeps and not agents:
+    if not iterations and not pipeline and not substeps and not agents and not phases:
         print("No performance data found.")
+
+
+def print_phase_timeline(rows: list[dict[str, object]]) -> None:
+    """Print one row per phase instance, sorted chronologically."""
+    if not rows:
+        print("No phase events found.")
+        return
+    print("=== Phase Timeline ===")
+    print(
+        f"{'Iter':<6} {'Phase':<40} {'Started':<22} {'Ended':<22} {'Duration':<10}"
+    )
+    print("-" * 102)
+    for row in rows:
+        dur = row.get("duration_s")
+        dur_str = _fmt_duration(float(dur)) if isinstance(dur, (int, float)) else "?"
+        print(
+            f"{row.get('iteration', '')!s:<6} "
+            f"{row.get('phase', '')!s:<40} "
+            f"{row.get('started_at', '')!s:<22} "
+            f"{row.get('ended_at', '')!s:<22} "
+            f"{dur_str:<10}"
+        )
 
 
 def main() -> int:
@@ -345,6 +527,12 @@ def main() -> int:
         default="text",
         help="Output format (default: text)",
     )
+    parser.add_argument(
+        "--timeline",
+        action="store_true",
+        help="Show chronological phase timeline (one row per phase instance) "
+        "instead of aggregate summary tables",
+    )
 
     args = parser.parse_args()
     workdir = Path(args.workdir).resolve()
@@ -359,14 +547,24 @@ def main() -> int:
         print("No events found in perf.jsonl", file=sys.stderr)
         return 0
 
+    if args.timeline:
+        timeline = phase_timeline(events)
+        if args.format == "json":
+            print(json.dumps(timeline, indent=2))
+        else:
+            print_phase_timeline(timeline)
+        return 0
+
     iterations = summarize_iterations(events)
     pipeline = summarize_pipeline(events)
     substeps = summarize_substeps(events)
     agents = summarize_agents(events)
+    phases = summarize_phases(events)
 
     if args.format == "json":
         output = {
             "iterations": iterations,
+            "phases": phases,
             "pipeline_steps": pipeline,
             "pipeline_substeps": substeps,
             "agents": agents,
@@ -378,6 +576,7 @@ def main() -> int:
             pipeline,
             substeps=substeps,
             agents=agents,
+            phases=phases,
         )
 
     return 0

--- a/plugins/self-learning/tools/python/test_perf_summary.py
+++ b/plugins/self-learning/tools/python/test_perf_summary.py
@@ -5,8 +5,10 @@ from pathlib import Path
 
 from perf_summary import (
     load_events,
+    phase_timeline,
     summarize_agents,
     summarize_iterations,
+    summarize_phases,
     summarize_pipeline,
     summarize_substeps,
 )
@@ -292,3 +294,276 @@ class TestSummarizeAgents:
             "mid-agent",
             "fast-agent",
         ]
+
+
+class TestSummarizePhases:
+    def test_empty_events(self) -> None:
+        assert summarize_phases([]) == []
+
+    def test_derives_durations_from_consecutive_phases(self) -> None:
+        events = [
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase 1: Planning",
+                "started_at": "2026-04-30T10:00:00Z",
+            },
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase 3: Implementation",
+                "started_at": "2026-04-30T10:02:30Z",
+            },
+            {
+                "event": "iteration",
+                "run_id": "r1",
+                "iteration": 1,
+                "ended_at": "2026-04-30T10:05:00Z",
+            },
+        ]
+        result = summarize_phases(events)
+        by_name = {row["phase"]: row for row in result}
+        assert by_name["Phase 1: Planning"]["total_s"] == 150.0
+        assert by_name["Phase 3: Implementation"]["total_s"] == 150.0
+
+    def test_skips_final_phase_without_iteration_end(self) -> None:
+        events = [
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase 1: Planning",
+                "started_at": "2026-04-30T10:00:00Z",
+            },
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase 3: Implementation",
+                "started_at": "2026-04-30T10:02:30Z",
+            },
+        ]
+        result = summarize_phases(events)
+        by_name = {row["phase"]: row for row in result}
+        assert "Phase 1: Planning" in by_name
+        assert "Phase 3: Implementation" not in by_name
+
+    def test_does_not_pair_phases_across_iterations(self) -> None:
+        events = [
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase 7: Logging",
+                "started_at": "2026-04-30T10:04:00Z",
+            },
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 2,
+                "phase": "Phase 1: Planning",
+                "started_at": "2026-04-30T10:10:00Z",
+            },
+            {
+                "event": "iteration",
+                "run_id": "r1",
+                "iteration": 1,
+                "ended_at": "2026-04-30T10:05:00Z",
+            },
+            {
+                "event": "iteration",
+                "run_id": "r1",
+                "iteration": 2,
+                "ended_at": "2026-04-30T10:15:00Z",
+            },
+        ]
+        result = summarize_phases(events)
+        by_name = {row["phase"]: row for row in result}
+        assert by_name["Phase 7: Logging"]["total_s"] == 60.0
+        assert by_name["Phase 1: Planning"]["total_s"] == 300.0
+
+    def test_aggregates_repeated_phase_across_iterations(self) -> None:
+        events = [
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase 3: Implementation",
+                "started_at": "2026-04-30T10:00:00Z",
+            },
+            {
+                "event": "iteration",
+                "run_id": "r1",
+                "iteration": 1,
+                "ended_at": "2026-04-30T10:01:00Z",
+            },
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 2,
+                "phase": "Phase 3: Implementation",
+                "started_at": "2026-04-30T10:02:00Z",
+            },
+            {
+                "event": "iteration",
+                "run_id": "r1",
+                "iteration": 2,
+                "ended_at": "2026-04-30T10:05:00Z",
+            },
+        ]
+        result = summarize_phases(events)
+        assert len(result) == 1
+        assert result[0]["count"] == 2
+        assert result[0]["total_s"] == 240.0
+
+    def test_sorts_by_total_time_descending(self) -> None:
+        events = [
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase A",
+                "started_at": "2026-04-30T10:00:00Z",
+            },
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase B",
+                "started_at": "2026-04-30T10:00:10Z",
+            },
+            {
+                "event": "iteration",
+                "run_id": "r1",
+                "iteration": 1,
+                "ended_at": "2026-04-30T10:02:00Z",
+            },
+        ]
+        result = summarize_phases(events)
+        assert [row["phase"] for row in result] == ["Phase B", "Phase A"]
+
+
+class TestPhaseTimeline:
+    def test_empty_events(self) -> None:
+        assert phase_timeline([]) == []
+
+    def test_emits_chronological_rows_with_durations(self) -> None:
+        events = [
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase 3: Implementation",
+                "started_at": "2026-04-30T10:02:30Z",
+            },
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase 1: Planning",
+                "started_at": "2026-04-30T10:00:00Z",
+            },
+            {
+                "event": "iteration",
+                "run_id": "r1",
+                "iteration": 1,
+                "ended_at": "2026-04-30T10:05:00Z",
+            },
+        ]
+        result = phase_timeline(events)
+        assert [row["phase"] for row in result] == [
+            "Phase 1: Planning",
+            "Phase 3: Implementation",
+        ]
+        assert result[0]["started_at"] == "2026-04-30T10:00:00Z"
+        assert result[0]["ended_at"] == "2026-04-30T10:02:30Z"
+        assert result[0]["duration_s"] == 150.0
+        assert result[1]["started_at"] == "2026-04-30T10:02:30Z"
+        assert result[1]["ended_at"] == "2026-04-30T10:05:00Z"
+        assert result[1]["duration_s"] == 150.0
+        for row in result:
+            assert row["run_id"] == "r1"
+            assert row["iteration"] == 1
+
+    def test_emits_incomplete_final_phase_with_null_duration(self) -> None:
+        events = [
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase 1: Planning",
+                "started_at": "2026-04-30T10:00:00Z",
+            },
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase 3: Implementation",
+                "started_at": "2026-04-30T10:02:30Z",
+            },
+        ]
+        result = phase_timeline(events)
+        assert len(result) == 2
+        impl = result[1]
+        assert impl["phase"] == "Phase 3: Implementation"
+        assert impl["ended_at"] == ""
+        assert impl["duration_s"] is None
+
+    def test_does_not_pair_phases_across_iterations(self) -> None:
+        events = [
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 1,
+                "phase": "Phase 7: Logging",
+                "started_at": "2026-04-30T10:04:00Z",
+            },
+            {
+                "event": "phase",
+                "run_id": "r1",
+                "iteration": 2,
+                "phase": "Phase 1: Planning",
+                "started_at": "2026-04-30T10:10:00Z",
+            },
+            {
+                "event": "iteration",
+                "run_id": "r1",
+                "iteration": 1,
+                "ended_at": "2026-04-30T10:05:00Z",
+            },
+            {
+                "event": "iteration",
+                "run_id": "r1",
+                "iteration": 2,
+                "ended_at": "2026-04-30T10:15:00Z",
+            },
+        ]
+        result = phase_timeline(events)
+        by_phase = {row["phase"]: row for row in result}
+        assert by_phase["Phase 7: Logging"]["ended_at"] == "2026-04-30T10:05:00Z"
+        assert by_phase["Phase 7: Logging"]["duration_s"] == 60.0
+        assert by_phase["Phase 1: Planning"]["ended_at"] == "2026-04-30T10:15:00Z"
+        assert by_phase["Phase 1: Planning"]["duration_s"] == 300.0
+
+    def test_includes_run_id_and_iteration_per_row(self) -> None:
+        events = [
+            {
+                "event": "phase",
+                "run_id": "run-a",
+                "iteration": 3,
+                "phase": "Phase 5",
+                "started_at": "2026-04-30T10:00:00Z",
+            },
+            {
+                "event": "iteration",
+                "run_id": "run-a",
+                "iteration": 3,
+                "ended_at": "2026-04-30T10:01:00Z",
+            },
+        ]
+        result = phase_timeline(events)
+        assert len(result) == 1
+        assert result[0]["run_id"] == "run-a"
+        assert result[0]["iteration"] == 3


### PR DESCRIPTION
Wires per-phase wall-clock timing into the existing perf.jsonl event stream so operators can answer "how long is each orchestrator phase taking?" alongside the existing iteration, pipeline_step, and agent events.

- New scripts/record_phase.sh appends a phase event (run_id, iteration, phase, status, start_sha, started_at) from the current state.json. The orchestrator prompt calls it after every state.json write; failures are non-blocking.
- self-learning's perf_summary.py gains summarize_phases() with a Phases summary table, plus a new --timeline flag (phase_timeline()) that emits one row per phase invocation with start/end timestamps. Incomplete final phases keep duration_s=null so in-progress runs stay visible. 11 new tests cover iteration boundaries, missing iteration end, cross-iteration aggregation, and chronological sort.

To run:
```python ~/.claude/plugins/cache/closedloop-ai/self-learning/<latest version>/scripts/perf_summary.py --workdir <directory that contains perf.jsonl> --format text --timeline```

Sample run
```
=== Phase Timeline ===                                                      
Iter   Phase                                   Started                Ended                                  Duration                                                  
-----------------------------------------------------------------------------------------------------                                                  
1      Phase 0.9: Pre-exploration              2026-04-30T10:00:00Z   2026-04-30T10:00:30Z   30s                                                  
1      Phase 1: Planning                       2026-04-30T10:00:30Z.  2026-04-30T10:03:00Z   2.5m                                                 
1      Phase 3: Implementation                 2026-04-30T10:03:00Z   2026-04-30T10:11:00Z   8.0m                                                 
1      Phase 5: Testing and Validation         2026-04-30T10:11:00Z   2026-04-30T10:13:30Z   2.5m                                                 
1      Phase 7: Logging and completion         2026-04-30T10:13:30Z   2026-04-30T10:15:00Z   1.5m   
```