### PR TITLE
FEA-771: add user-visible loop failure marker infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### code v1.11.1
+
+#### Added
+- New runner-side user-visible failure marker infrastructure in `run-loop.sh`. Helpers `write_loop_user_visible_failure()` and `fail_loop_user_visible()` emit a structured `{code, message, result.subcode}` JSON marker to `$CLOSEDLOOP_WORKDIR/loop-error.json` so downstream consumers (e.g. the Electron desktop app's finalizer) can surface actionable runner failures to the user. Inputs are validated: `code` against an allowlist (`RUNNER_ERROR`, `PRE_RUN_VALIDATION_FAILED`, `PLAN_STATE_UNAVAILABLE`), `subcode` against `^[A-Z][A-Z0-9_]{2,63}$`, and `message` length 1-1000 characters. Marker is written atomically (`tmp` then `mv`) under `umask 077`. The bottom-of-file `trap` and `main "$@"` invocation are now guarded by `[[ "${BASH_SOURCE[0]}" == "$0" ]]` so the script can be sourced (e.g. by tests) without launching the loop. New tests in `plugins/code/tools/python/test_run_loop_failure_marker.py` cover the happy path, the unsupported-code rejection, and the fail-and-exit path.
+
 ### code v1.11.0
 
 #### Added

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -27,6 +27,7 @@ NC='\033[0m' # No Color
 # State file location
 STATE_FILE="$CLOSEDLOOP_STATE_DIR/closedloop-loop.local.md"
 PROGRESS_LOG="$CLOSEDLOOP_STATE_DIR/closedloop-progress.log"
+LOOP_USER_VISIBLE_FAILURE_FILE_NAME="loop-error.json"
 
 # Learning system paths
 LOCK_FILE=".learnings/.lock"
@@ -36,6 +37,73 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUN_ID=""
 START_SHA=""
 SELF_LEARNING=false
+
+# Write an intentionally user-visible failure marker for the Electron finalizer.
+#
+# This is an explicit opt-in channel only. Do not call this from ERR traps or
+# generic command-failure handling; ordinary bash failures should stay generic.
+# Usage:
+#   fail_loop_user_visible RUNNER_ERROR XYZ "Loop execution failed because XYZ."
+write_loop_user_visible_failure() {
+  local code="$1"
+  local subcode="$2"
+  local message="$3"
+
+  if [[ -z "${CLOSEDLOOP_WORKDIR:-}" ]]; then
+    echo "Error: CLOSEDLOOP_WORKDIR is required to write loop failure marker" >&2
+    return 1
+  fi
+
+  case "$code" in
+    RUNNER_ERROR|PRE_RUN_VALIDATION_FAILED|PLAN_STATE_UNAVAILABLE)
+      ;;
+    *)
+      echo "Error: unsupported loop failure code: $code" >&2
+      return 1
+      ;;
+  esac
+
+  if [[ ! "$subcode" =~ ^[A-Z][A-Z0-9_]{2,63}$ ]]; then
+    echo "Error: loop failure subcode must match ^[A-Z][A-Z0-9_]{2,63}$" >&2
+    return 1
+  fi
+
+  if [[ -z "$message" || ${#message} -gt 1000 ]]; then
+    echo "Error: loop failure message must be 1-1000 characters" >&2
+    return 1
+  fi
+
+  local failure_file="${CLOSEDLOOP_WORKDIR}/${LOOP_USER_VISIBLE_FAILURE_FILE_NAME}"
+  local tmp_file="${failure_file}.tmp.$$"
+
+  mkdir -p "$(dirname "$failure_file")"
+  umask 077
+  if ! jq -n -c \
+    --arg code "$code" \
+    --arg message "$message" \
+    --arg subcode "$subcode" \
+    '{code:$code,message:$message,result:{subcode:$subcode}}' \
+    > "$tmp_file"; then
+    rm -f "$tmp_file"
+    return 1
+  fi
+  if ! mv "$tmp_file" "$failure_file"; then
+    rm -f "$tmp_file"
+    return 1
+  fi
+}
+
+fail_loop_user_visible() {
+  local code="$1"
+  local subcode="$2"
+  local message="$3"
+
+  if ! write_loop_user_visible_failure "$code" "$subcode" "$message"; then
+    echo "Error: failed to write user-visible loop failure marker" >&2
+  fi
+  echo "CLOSEDLOOP_FATAL[$subcode]: $message" >&2
+  exit 1
+}
 
 # Check for jq dependency (required for learning system)
 check_jq_dependency() {
@@ -1346,6 +1414,7 @@ cleanup_on_interrupt() {
   exit 130
 }
 
-trap cleanup_on_interrupt INT TERM
-
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  trap cleanup_on_interrupt INT TERM
+  main "$@"
+fi

--- a/plugins/code/tools/python/test_run_loop_failure_marker.py
+++ b/plugins/code/tools/python/test_run_loop_failure_marker.py
@@ -1,0 +1,70 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RUN_LOOP = REPO_ROOT / "plugins" / "code" / "scripts" / "run-loop.sh"
+
+
+def run_bash(script: str, workdir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, "CLOSEDLOOP_WORKDIR": str(workdir)},
+    )
+
+
+def test_write_loop_user_visible_failure_writes_marker(tmp_path: Path) -> None:
+    result = run_bash(
+        f"""
+        source {RUN_LOOP}
+        write_loop_user_visible_failure RUNNER_ERROR XYZ_FAILURE 'Loop execution failed because XYZ.'
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    marker = tmp_path / "loop-error.json"
+    assert marker.exists()
+    assert json.loads(marker.read_text()) == {
+        "code": "RUNNER_ERROR",
+        "message": "Loop execution failed because XYZ.",
+        "result": {"subcode": "XYZ_FAILURE"},
+    }
+
+
+def test_write_loop_user_visible_failure_rejects_unknown_code(tmp_path: Path) -> None:
+    result = run_bash(
+        f"""
+        source {RUN_LOOP}
+        write_loop_user_visible_failure PROCESS_FAILED XYZ_FAILURE 'Do not write this.'
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode != 0
+    assert not (tmp_path / "loop-error.json").exists()
+    assert "unsupported loop failure code" in result.stderr
+
+
+def test_fail_loop_user_visible_prints_reason_and_exits(tmp_path: Path) -> None:
+    result = run_bash(
+        f"""
+        source {RUN_LOOP}
+        fail_loop_user_visible PRE_RUN_VALIDATION_FAILED BAD_PLAN_STATE 'Plan state is not loadable.'
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 1
+    assert "CLOSEDLOOP_FATAL[BAD_PLAN_STATE]: Plan state is not loadable." in result.stderr
+    assert json.loads((tmp_path / "loop-error.json").read_text()) == {
+        "code": "PRE_RUN_VALIDATION_FAILED",
+        "message": "Plan state is not loadable.",
+        "result": {"subcode": "BAD_PLAN_STATE"},
+    }


### PR DESCRIPTION
Introduces an explicit, allowlisted failure handoff so run-loop.sh can intentionally provide a user-facing reason a loop run failed. Generic bash failures stay generic via the existing PROCESS_FAILED path; only script-owned failures emit the structured marker.

- write_loop_user_visible_failure(code, subcode, message): validates and atomically writes `$CLOSEDLOOP_WORKDIR/loop-error.json` with shape `{code, message, result.subcode}`. Code allowlist: RUNNER_ERROR, PRE_RUN_VALIDATION_FAILED, PLAN_STATE_UNAVAILABLE. Subcode pattern: ^[A-Z][A-Z0-9_]{2,63}$. Message length: 1-1000 chars. Atomic write: tmp file then mv, under umask 077.
- fail_loop_user_visible(code, subcode, message): writes the marker, prints CLOSEDLOOP_FATAL[subcode] to stderr, exits 1.
- run-loop.sh trap and main "$@" invocation now guarded by [[ "${BASH_SOURCE[0]}" == "$0" ]] so the script can be sourced from tests without launching the loop.
- test_run_loop_failure_marker.py covers happy path, unsupported-code rejection, and fail-and-exit semantics.