### PR TITLE
FEA-872: Improve decision-table skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code v1.11.3
+
+#### Added
+- Four new edge-case sections in the `decision-table` skill's `references/edge-cases.md`: **State propagation across isolation boundaries** (subprocesses, workers, callbacks, transactions, child tasks — require explicit propagation rows for success, validation failure, dependency failure, cancellation/timeout, and partial-output branches, plus a real production-sequencing test); **Finalizer-visible cleanup state** (deferred finalizers, traps, disposers, signal handlers, process-exit hooks — require rows describing handle scope, clearing, and exit-via-error paths, plus a failure-path test that exits through the real finalizer); **Transformed input validation parity** (trim/parse/decode/normalize/canonicalize/default/coerce flows — require rows for raw, transformed, validated, and consumed values plus mutations that prove validation runs against the consumed value); **Canonical value persistence** (paths, identities, endpoints, workspaces, profiles, tenants — require rows distinguishing raw, expanded, normalized, canonical/resolved, and serialized output, plus alternate-spelling tests proving durable output uses the canonical value).
+- Five new common-misses items (8-12) and six new contract-heavy review-surface bullets in the `decision-table` skill's `references/review-prevention.md` covering: cleanup/finalizer state scoped too narrowly for the actual cleanup mechanism; durable output that serializes raw input after validation used a transformed value; validation that checks a different representation than the consumed value; state produced inside an isolated execution context without an explicit propagation mechanism; and distinct modeled states whose observable status/message/affordance/styling/telemetry/response signal is indistinguishable in implementation despite the table treating them as different outcomes.
+
+### code-review v1.5.5
+
+#### Fixed
+- `/start` command now passes `--diff-scope` and `--original-scope` to `code_review_helpers.py` using the `--flag=value` form instead of `--flag "value"` (three call sites: standard-flow `extract-patches`, fast-path `extract-patches`, and `auto-incremental`). The space-separated form caused `argparse` to treat scope values that began with a leading dash as a separate option and fail with `unrecognized arguments`; the `=` form binds the value unambiguously.
+
 ### code v1.11.2
 
 #### Fixed

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -107,12 +107,12 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 - **If `fast_path` is false (standard flow):**
   - Print `CACHE_STATUS_MESSAGE` if non-empty
   - Run Bash: `python3 <HELPERS> partition --diff-data <CR_DIR>/diff_data.json --loc-budget 500 --max-files 25 --max-bha-agents <MAX_BHA_AGENTS> > <CR_DIR>/partitions.json` (use `uncached_diff_data.json` when caching is active)
-  - Run Bash: `python3 <HELPERS> extract-patches --partitions-file <CR_DIR>/partitions.json --diff-scope "<DIFF_SCOPE>" --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>`
+  - Run Bash: `python3 <HELPERS> extract-patches --partitions-file <CR_DIR>/partitions.json --diff-scope=<DIFF_SCOPE> --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>`
 - **If `fast_path` is true:**
   - Print `"Fast path selected: 1 reviewer (<MODEL>)."` where `<MODEL>` = `route.json -> models.fast_path_reviewer`
   - If `CACHE_DIR` is set, print `"BHA Cache: bypassed in fast-path mode."` and delete `<CR_DIR>/agent_cached_bha.json` if it exists
   - Skip partition entirely (no `partitions.json` created)
-  - Run Bash: `python3 <HELPERS> extract-patches --diff-scope "<DIFF_SCOPE>" --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>` (no `--partitions-file` -- only `patches_all.txt` is created)
+  - Run Bash: `python3 <HELPERS> extract-patches --diff-scope=<DIFF_SCOPE> --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>` (no `--partitions-file` -- only `patches_all.txt` is created)
   - Update TodoWrite: replace "Spawn reviewer agents in parallel" with "Run fast-path review"
 - Mark todo as `completed`
 - See: [Step 3](#step-3-assess-scope-and-route-models), [Step 4A](#step-4a-spawn-reviewer-agents-fast_path--false), [Step 4B](#step-4b-fast-path-single-agent-review-fast_path--true)
@@ -313,7 +313,7 @@ python3 <HELPERS> auto-incremental \
   --cache-dir <CACHE_DIR> \
   --key "<REVIEW_BRANCH>:<BASE_REF>" \
   --diff-tip <DIFF_TIP> \
-  --original-scope <DIFF_SCOPE> \
+  --original-scope=<DIFF_SCOPE> \
   --full-review <FULL_REVIEW> \
   --since-last-review <SINCE_LAST_REVIEW> \
   --mode <MODE> \
@@ -578,7 +578,7 @@ When constructing agent prompts, read each entry's `file` field for the path. Do
 After partitioning, extract patches to disk files so agents can Read them without needing Bash permissions. Run this BEFORE spawning any agents:
 
 ```bash
-python3 <HELPERS> extract-patches --partitions-file <CR_DIR>/partitions.json --diff-scope "<DIFF_SCOPE>" --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>
+python3 <HELPERS> extract-patches --partitions-file <CR_DIR>/partitions.json --diff-scope=<DIFF_SCOPE> --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>
 ```
 
 This creates `patches_p{N}.txt` (one per partition) and `patches_all.txt` (full diff from all files in `diff_data.json`). When caching is active, partitions contain only uncached files, but `patches_all.txt` includes ALL files since BHB/Auditor/Premise review the full diff.

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/skills/decision-table/references/edge-cases.md
+++ b/plugins/code/skills/decision-table/references/edge-cases.md
@@ -26,6 +26,14 @@ When a flow can receive a new event/request/callback/file/message/retry while an
 
 **Tests:** require an idle path, an active-processing path, and a drain or terminal-outcome assertion when the implementation queues, coalesces, deduplicates, drops, or rejects repeated work.
 
+## State propagation across isolation boundaries
+
+When one phase computes, validates, or mutates state inside an isolated execution context and a later phase depends on that state, include rows for how the state crosses the boundary. Isolation contexts include subprocesses, workers, job steps, containers, sandboxes, transactions, callbacks, closures, remote commands, child tasks, separate event loops, and separate requests. State whether each required value is returned, emitted, persisted, recomputed in the parent/consumer, passed through an explicit output channel, or intentionally unavailable after the boundary exits.
+
+Include rows for success, validation failure, dependency failure, cancellation/timeout, and partial-output branches. For each branch, state which later side effects must still see the value, which must not run without it, and how missing or stale propagated state is classified.
+
+**Tests:** require at least one test that exercises the real production sequencing across the boundary, not only direct helper calls in a shared context. The test must prove the later phase receives the expected value, rejects the missing value, or records the intended fallback.
+
 ## Terminal-state transition guards
 
 When a flow has terminal/one-way states (approved, denied, expired, consumed, completed, cancelled, revoked, failed), include rows for every mutating action attempted from each terminal state. State which states are mutable, which are no-ops, which return a terminal error, and which durable fields must never be rewritten. Include repeated UI actions (approve-then-deny, deny-then-approve, double-clicks, retries after timeout, stale browser tabs after another actor completed the flow).
@@ -35,6 +43,12 @@ Final verification must prove terminal states cannot be overwritten by later act
 ## Cancellation and shutdown
 
 When a flow waits, sleeps, backs off, schedules a timer, retries, or runs asynchronously, include rows for cancellation/shutdown before the wait, during the wait, after the wait but before the next side effect, and during the side effect when applicable.
+
+## Finalizer-visible cleanup state
+
+When cleanup runs through a deferred finalizer, trap, disposer, signal handler, process-exit hook, framework cleanup callback, or language cleanup block, include rows for the state available at cleanup execution time. State where cleanup handles, mounted resources, temp paths, locks, subscriptions, transactions, or staged artifacts are stored; which scopes can see them when cleanup executes; when each handle is cleared; and what happens if the main flow exits through an error helper, early return, cancellation, signal, or raised/rejected failure branch.
+
+**Tests:** require at least one failure path that exits through the real finalizer mechanism after cleanup state is populated, proving the intended cleanup action runs. A happy-path cleanup assertion alone is not enough.
 
 ## Time-bound credentials, signatures, or payloads
 
@@ -77,6 +91,18 @@ For serverless or edge route handlers, include rows for side effects after the r
 For allowlists, denylists, ownership checks, cache keys, dedupe keys, lock keys, object identifiers, and other policy comparisons, include rows for raw input, normalized form, canonical form, aliases, symbolic references, case/separator variants, parent/child boundaries, empty values, and missing targets where applicable.
 
 **Tests:** require a safe positive control, a blocked canonical control, and at least one equivalent or near-equivalent mutation that could bypass naive string comparison.
+
+## Transformed input validation parity
+
+When a flow trims, parses, decodes, normalizes, canonicalizes, defaults, coerces, or otherwise transforms input from a user, dependency, file, message, request, or environment before a decision or side effect, include rows for the raw input, transformed value, validation target, and final consumed value. State whether validation is intentionally applied before or after transformation, and ensure rejection/acceptance messages match the value actually used. This applies even when the transformed value is not durable.
+
+**Tests:** require at least one mutation where transformation removes harmless input (for example leading/trailing whitespace) and one mutation where invalid content remains after transformation, proving validation accepts/rejects based on the final consumed value rather than an unrelated raw spelling.
+
+## Canonical value persistence
+
+When a validated path, identity, endpoint, workspace, profile, tenant, account, or other policy-bearing value is later written to a durable message, handoff, configuration, state record, command, or file, include rows proving the persisted value is the same canonical value that was validated. Distinguish raw input, expanded input, normalized input, canonical/resolved input, and serialized output. If raw spelling is intentionally preserved for display, keep it separate from the value consumed for policy or execution.
+
+**Tests:** require at least one alternate spelling such as a relative path, parent segment, alias, case/separator variant, or symbolic reference where applicable, and assert that durable output contains the canonical validated value rather than the raw input.
 
 ## Partial update preservation
 

--- a/plugins/code/skills/decision-table/references/review-prevention.md
+++ b/plugins/code/skills/decision-table/references/review-prevention.md
@@ -13,6 +13,11 @@ For every item: fix it, mark it already covered by a named row/test, mark not ap
 5. **Caller or version-skew path** that cannot supply a newly required field, header, proof, or response shape.
 6. **Duplicated policy, helper, constant, or wire-contract logic** that should be shared or parity-tested.
 7. **Test that asserts only that something failed**, without proving the specific invariant, fallback, binding, or diagnostic reason from the table.
+8. **Cleanup/finalizer state scoped too narrowly** for the cleanup mechanism that runs on error, cancellation, signal, trap, retry, process exit, disposal, or a language cleanup block.
+9. **Durable output using raw input** after validation used an expanded, normalized, canonical, resolved, or otherwise transformed value.
+10. **Validation checks a different representation** than the value later consumed by a decision, side effect, output, or boundary payload.
+11. **State produced inside an isolated execution context** that is assumed to be available to a later phase without an explicit return, output, persistence, recomputation, or other propagation mechanism.
+12. **Distinct modeled states with indistinguishable observable output** where the table or user-facing copy treats the states as meaningfully different, but the implemented status, message, action availability, styling, telemetry, or response signal is identical unless that parity is explicitly intentional.
 
 ## Contract-Heavy Review Surface
 
@@ -29,7 +34,12 @@ For contract-heavy work, also explicitly review:
 - retries or replays that reuse resources after delete/consume/rotate/invalidate/acknowledge/commit/upload/lock side effects
 - destructive cleanup that deletes a shared durable resource still referenced by another profile, active runtime identity, fallback identity, retry path, or recovery path
 - path/identity/policy checks comparing raw spelling instead of normalized or canonical equivalents where equivalence matters
+- validation checks that run on raw input while a side effect, command, state transition, policy decision, boundary payload, or user-facing output consumes a trimmed, parsed, normalized, canonicalized, defaulted, or coerced value
+- durable messages, handoffs, configurations, state records, commands, or files that serialize raw path, identity, endpoint, workspace, profile, account, or tenant input instead of the canonical value that validation and policy checks approved
+- deferred cleanup handlers, traps, disposers, process-exit hooks, and finalizers whose cleanup handles live only in a local/callback scope unavailable when cleanup actually runs
+- later phases that depend on values computed inside an isolated execution context without proving the state crosses that boundary through an explicit propagation mechanism
 - partial updates that overwrite unrelated fields when the intended behavior is additive or merge-preserving
+- semantically distinct user-visible states that share the same observable status signal, label, action affordance, or presentation despite the table claiming different outcomes
 - schema indexes/constraints that are redundant, unused by current access paths, mismatched to predicates or sort orders, or added for write-only metadata without a documented read path
 - serverless async side effects that may be dropped unless awaited, scheduled with a platform primitive, or persisted
 - test oracle quality for canonicalization, signing, validation, and compatibility rows


### PR DESCRIPTION
Adds four edge-case sections to the decision-table skill's references/edge-cases.md (state propagation across isolation boundaries, finalizer-visible cleanup state, transformed input validation parity, canonical value persistence) and five common-misses items plus six contract-heavy review-surface bullets in references/review-prevention.md.

Also fixes the code-review /start command to pass --diff-scope and --original-scope to code_review_helpers.py using the --flag=value form (3 call sites: standard-flow extract-patches, fast-path extract-patches, auto-incremental). The space-separated form caused argparse to treat scope values beginning with a leading dash as a separate option and fail with unrecognized arguments.