### PR TITLE
feat(plan-validate): auto-sync markdown answers to JSON

### DIFF
--- a/plugins/code/skills/plan-validate/SKILL.md
+++ b/plugins/code/skills/plan-validate/SKILL.md
@@ -26,7 +26,15 @@ Run the validation script:
 python3 ${CLAUDE_SKILL_DIR}/scripts/validate_plan.py <WORKDIR> --auto-sync
 ```
 
-The `--auto-sync` flag detects questions marked as answered in the markdown `content` (checked `[x]` checkbox) that are still in the `openQuestions` JSON array. It extracts the answer text from the markdown line and moves the question to `answeredQuestions` before validation, writing the updated plan.json back to disk. Answer text is extracted from `**Answer: text**`, `*Answer: text*`, or plain `Answer: text` in the markdown line. If no answer text is found, it falls back to the `recommendedAnswer` field from the JSON entry. Questions with no extractable answer are left in `openQuestions`.
+The `--auto-sync` flag detects questions answered in the markdown `content` that are still in the `openQuestions` JSON array, extracts the answer text, and moves them to `answeredQuestions` before validation — writing the updated plan.json back to disk.
+
+Three answer formats are supported:
+
+1. **Inline with prefix** — `**Answer: text**`, `*Answer: text*`, or plain `Answer: text` on a checked `[x]` question line.
+2. **A-### keyed answer** — a separate `A-001: answer text` line corresponding to `Q-001`. The question checkbox does not need to be checked; the script checks it automatically.
+3. **Inline comment** — extra text appended after the known question text on a checked line, without any `Answer:` prefix. Metadata markers like `(BLOCKING T-X.Y)` and `[Recommended: ...]` are stripped.
+
+If none of these yield answer text, falls back to the `recommendedAnswer` field from the JSON entry. Questions with no extractable answer are left in `openQuestions`.
 
 Always pass `--auto-sync` so that users can answer questions by editing the markdown directly.
 

--- a/plugins/code/skills/plan-validate/SKILL.md
+++ b/plugins/code/skills/plan-validate/SKILL.md
@@ -23,8 +23,12 @@ Activate this skill **instead of** launching `@code:plan-validator` at every pla
 Run the validation script:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/validate_plan.py <WORKDIR>
+python3 ${CLAUDE_SKILL_DIR}/scripts/validate_plan.py <WORKDIR> --auto-sync
 ```
+
+The `--auto-sync` flag detects questions marked as answered in the markdown `content` (checked `[x]` checkbox) that are still in the `openQuestions` JSON array. It extracts the answer text from the markdown line and moves the question to `answeredQuestions` before validation, writing the updated plan.json back to disk. Answer text is extracted from `**Answer: text**`, `*Answer: text*`, or plain `Answer: text` in the markdown line. If no answer text is found, it falls back to the `recommendedAnswer` field from the JSON entry. Questions with no extractable answer are left in `openQuestions`.
+
+Always pass `--auto-sync` so that users can answer questions by editing the markdown directly.
 
 ## Interpreting Output
 

--- a/plugins/code/skills/plan-validate/SKILL.md
+++ b/plugins/code/skills/plan-validate/SKILL.md
@@ -30,9 +30,11 @@ The `--auto-sync` flag detects questions answered in the markdown `content` that
 
 Three answer formats are supported:
 
-1. **Inline with prefix** — `**Answer: text**`, `*Answer: text*`, or plain `Answer: text` on a checked `[x]` question line.
-2. **A-### keyed answer** — a separate `A-001: answer text` line corresponding to `Q-001`. The question checkbox does not need to be checked; the script checks it automatically.
-3. **Inline comment** — extra text appended after the known question text on a checked line, without any `Answer:` prefix. Metadata markers like `(BLOCKING T-X.Y)` and `[Recommended: ...]` are stripped.
+1. **Inline with prefix** — `**Answer: text**`, `*Answer: text*`, or plain `Answer: text` on the question line.
+2. **A-### keyed answer** — a separate `A-001: answer text` line corresponding to `Q-001`.
+3. **Inline comment** — extra text appended after the known question text on the question line, without any `Answer:` prefix. Metadata markers like `(BLOCKING T-X.Y)` and `[Recommended: ...]` are stripped.
+
+The question checkbox does not need to be checked for any format. When a question is migrated from an unchecked `[ ]` line, the script checks it automatically.
 
 If none of these yield answer text, falls back to the `recommendedAnswer` field from the JSON entry. Questions with no extractable answer are left in `openQuestions`.
 

--- a/plugins/code/skills/plan-validate/scripts/conftest.py
+++ b/plugins/code/skills/plan-validate/scripts/conftest.py
@@ -1,0 +1,17 @@
+"""Shared test fixtures for plan-validate scripts."""
+
+
+def make_minimal_data(**overrides: object) -> dict:
+    """Build a base-valid plan dict with empty arrays."""
+    data: dict = {
+        "content": "",
+        "acceptanceCriteria": [],
+        "pendingTasks": [],
+        "completedTasks": [],
+        "openQuestions": [],
+        "answeredQuestions": [],
+        "gaps": [],
+        "manualTasks": [],
+    }
+    data.update(overrides)
+    return data

--- a/plugins/code/skills/plan-validate/scripts/test_auto_sync_answers.py
+++ b/plugins/code/skills/plan-validate/scripts/test_auto_sync_answers.py
@@ -1,29 +1,19 @@
 """Tests for auto_sync_markdown_answers() in validate_plan.py."""
 import copy
-import sys
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "skills" / "plan-validate" / "scripts"))
-
-from validate_plan import auto_sync_markdown_answers  # noqa: E402
+from conftest import make_minimal_data
+from validate_plan import auto_sync_markdown_answers
 
 
 def _base_data(**overrides: object) -> dict:
     """Return a plan dict with one open question and matching content."""
-    data: dict = {
-        "content": "",
-        "acceptanceCriteria": [],
-        "pendingTasks": [],
-        "completedTasks": [],
+    defaults: dict = {
         "openQuestions": [
             {"id": "Q-001", "question": "What model?", "blockingTask": "T-1.1", "recommendedAnswer": None},
         ],
-        "answeredQuestions": [],
-        "gaps": [],
-        "manualTasks": [],
     }
-    data.update(overrides)
-    return data
+    defaults.update(overrides)
+    return make_minimal_data(**defaults)
 
 
 # --- Scenario 2: Inline answer with prefix ---
@@ -66,6 +56,17 @@ def test_plain_answer_after_bracket() -> None:
 
     assert migrated == ["Q-001"]
     assert data["answeredQuestions"][0]["answer"] == "Default to user selection."
+
+
+def test_plain_answer_midline_without_bracket() -> None:
+    """A checked question with plain Answer: after question text (no ] or . preceding) is migrated."""
+    content = "- [x] Q-001: What model? Answer: Use codex."
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Use codex."
 
 
 # --- Scenario 3: A-### keyed answer line ---

--- a/plugins/code/skills/plan-validate/scripts/test_auto_sync_answers.py
+++ b/plugins/code/skills/plan-validate/scripts/test_auto_sync_answers.py
@@ -1,19 +1,25 @@
 """Tests for auto_sync_markdown_answers() in validate_plan.py."""
 import copy
 
-from conftest import make_minimal_data
 from validate_plan import auto_sync_markdown_answers
 
 
 def _base_data(**overrides: object) -> dict:
     """Return a plan dict with one open question and matching content."""
-    defaults: dict = {
+    data: dict = {
+        "content": "",
+        "acceptanceCriteria": [],
+        "pendingTasks": [],
+        "completedTasks": [],
         "openQuestions": [
             {"id": "Q-001", "question": "What model?", "blockingTask": "T-1.1", "recommendedAnswer": None},
         ],
+        "answeredQuestions": [],
+        "gaps": [],
+        "manualTasks": [],
     }
-    defaults.update(overrides)
-    return make_minimal_data(**defaults)
+    data.update(overrides)
+    return data
 
 
 # --- Scenario 2: Inline answer with prefix ---

--- a/plugins/code/skills/plan-validate/scripts/test_auto_sync_answers.py
+++ b/plugins/code/skills/plan-validate/scripts/test_auto_sync_answers.py
@@ -1,17 +1,32 @@
 """Tests for auto_sync_markdown_answers() in validate_plan.py."""
 import copy
 
-from conftest import make_minimal_data
 from validate_plan import auto_sync_markdown_answers
 
 _DEFAULT_QUESTION = {"id": "Q-001", "question": "What model?", "blockingTask": "T-1.1", "recommendedAnswer": None}
 
+# Canonical keys shared with conftest.make_minimal_data — kept in sync by
+# importing there at test-collection time; duplicated here only because
+# Pyright cannot resolve the conftest module.
+_EMPTY_PLAN: dict = {
+    "content": "",
+    "acceptanceCriteria": [],
+    "pendingTasks": [],
+    "completedTasks": [],
+    "openQuestions": [],
+    "answeredQuestions": [],
+    "gaps": [],
+    "manualTasks": [],
+}
+
 
 def _base_data(**overrides: object) -> dict:
     """Return a plan dict with one open question and matching content."""
+    data = copy.deepcopy(_EMPTY_PLAN)
     if "openQuestions" not in overrides:
-        overrides["openQuestions"] = [copy.deepcopy(_DEFAULT_QUESTION)]
-    return make_minimal_data(**overrides)
+        data["openQuestions"] = [copy.deepcopy(_DEFAULT_QUESTION)]
+    data.update(overrides)
+    return data
 
 
 # --- Scenario 2: Inline answer with prefix ---

--- a/plugins/code/skills/plan-validate/scripts/test_auto_sync_answers.py
+++ b/plugins/code/skills/plan-validate/scripts/test_auto_sync_answers.py
@@ -1,25 +1,17 @@
 """Tests for auto_sync_markdown_answers() in validate_plan.py."""
 import copy
 
+from conftest import make_minimal_data
 from validate_plan import auto_sync_markdown_answers
+
+_DEFAULT_QUESTION = {"id": "Q-001", "question": "What model?", "blockingTask": "T-1.1", "recommendedAnswer": None}
 
 
 def _base_data(**overrides: object) -> dict:
     """Return a plan dict with one open question and matching content."""
-    data: dict = {
-        "content": "",
-        "acceptanceCriteria": [],
-        "pendingTasks": [],
-        "completedTasks": [],
-        "openQuestions": [
-            {"id": "Q-001", "question": "What model?", "blockingTask": "T-1.1", "recommendedAnswer": None},
-        ],
-        "answeredQuestions": [],
-        "gaps": [],
-        "manualTasks": [],
-    }
-    data.update(overrides)
-    return data
+    if "openQuestions" not in overrides:
+        overrides["openQuestions"] = [copy.deepcopy(_DEFAULT_QUESTION)]
+    return make_minimal_data(**overrides)
 
 
 # --- Scenario 2: Inline answer with prefix ---

--- a/plugins/code/skills/plan-validate/scripts/validate_plan.py
+++ b/plugins/code/skills/plan-validate/scripts/validate_plan.py
@@ -8,7 +8,7 @@ semantic consistency check (Step 6: storage/query alignment, task/architecture
 contradictions) requires LLM reasoning and is left to the agent.
 
 Usage:
-    python3 validate_plan.py <WORKDIR> [--schema-path <path>]
+    python3 validate_plan.py <WORKDIR> [--auto-sync] [--schema-path <path>]
 
 Output (JSON to stdout):
     Same format as plan-validator agent output.
@@ -58,6 +58,10 @@ MANUAL_TASK_RE = re.compile(r"^\s*- \[ \] \*\*T-(\d+\.\d+)\*\* \[MANUAL\]:")
 OPEN_Q_RE = re.compile(r"^\s*- \[ \] \*{0,2}(Q-\d{3})\*{0,2}:")
 # Answered question line (supports optional bold markers: **Q-001** or Q-001)
 ANSWERED_Q_RE = re.compile(r"^\s*- \[x\] \*{0,2}(Q-\d{3})\*{0,2}:")
+# Extract answer text from a checked question line.
+# Matches **Answer: text**, *Answer: text*, or trailing Answer: text
+ANSWER_TEXT_RE = re.compile(r"\*{1,2}\s*Answer:\s*(.+?)\s*\*{1,2}\s*$")
+ANSWER_TEXT_PLAIN_RE = re.compile(r"(?:^|[\].])\s*Answer:\s*(.+?)\s*$")
 # AC table row pattern
 AC_TABLE_ROW_RE = re.compile(r"\| (AC-\d{3}) \|")
 # Gap content pattern
@@ -70,6 +74,65 @@ AC_ID_RE = re.compile(r"^AC-\d{3}$")
 Q_ID_RE = re.compile(r"^Q-\d{3}$")
 # Gap ID pattern
 GAP_ID_RE = re.compile(r"^GAP-\d{3}$")
+
+
+def auto_sync_markdown_answers(data: dict, content: str) -> tuple[dict, list[str]]:
+    """Migrate questions answered in markdown to the answeredQuestions JSON array.
+
+    Detects questions with a checked ``[x]`` checkbox in the markdown ``content``
+    that are still in the ``openQuestions`` JSON array, extracts the answer text
+    from the markdown line, and moves them to ``answeredQuestions``.
+
+    Returns ``(data, migrated_ids)`` where *migrated_ids* lists the question IDs
+    that were moved.  The caller is responsible for writing the modified *data*
+    back to disk.
+    """
+    migrated: list[str] = []
+
+    open_q_by_id: dict[str, dict] = {}
+    for q in data.get("openQuestions", []):
+        if isinstance(q, dict) and "id" in q:
+            open_q_by_id[q["id"]] = q
+
+    if not open_q_by_id:
+        return data, migrated
+
+    for line in content.splitlines():
+        m = ANSWERED_Q_RE.match(line)
+        if not m:
+            continue
+        qid = m.group(1)
+        if qid not in open_q_by_id:
+            continue  # already in answeredQuestions or unknown
+
+        # Try bold/italic **Answer: …** or *Answer: …* first
+        answer_match = ANSWER_TEXT_RE.search(line)
+        if answer_match:
+            answer_text = answer_match.group(1).strip()
+        else:
+            # Fall back to plain "Answer: …" (after ] or . or start-of-segment)
+            answer_match = ANSWER_TEXT_PLAIN_RE.search(line)
+            answer_text = answer_match.group(1).strip() if answer_match else ""
+
+        # Last resort: use the recommendedAnswer from the JSON entry
+        if not answer_text:
+            answer_text = open_q_by_id[qid].get("recommendedAnswer") or ""
+
+        if not answer_text:
+            continue  # cannot migrate without answer text
+
+        q_obj = open_q_by_id[qid]
+        answered_entry = {
+            "id": qid,
+            "question": q_obj.get("question", ""),
+            "answer": answer_text,
+        }
+
+        data["openQuestions"] = [q for q in data["openQuestions"] if q.get("id") != qid]
+        data.setdefault("answeredQuestions", []).append(answered_entry)
+        migrated.append(qid)
+
+    return data, migrated
 
 
 def empty_result(status: str, issues: list[str] | None = None) -> dict:
@@ -381,10 +444,11 @@ def extract_data(data: dict) -> dict:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print("Usage: validate_plan.py <WORKDIR> [--schema-path <path>]", file=sys.stderr)
+        print("Usage: validate_plan.py <WORKDIR> [--auto-sync] [--schema-path <path>]", file=sys.stderr)
         sys.exit(1)
 
     workdir = sys.argv[1]
+    auto_sync = "--auto-sync" in sys.argv
     plan_path = os.path.join(workdir, "plan.json")
 
     # Check file existence
@@ -408,6 +472,18 @@ def main() -> None:
     if not isinstance(data, dict):
         print(json.dumps(empty_result("INVALID_JSON", ["plan.json root must be an object"])))
         return
+
+    # Auto-sync: migrate markdown-answered questions to JSON before validation
+    if auto_sync and isinstance(data.get("content"), str):
+        data, migrated = auto_sync_markdown_answers(data, data["content"])
+        if migrated:
+            with open(plan_path, "w") as f:
+                json.dump(data, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+            print(
+                f"Auto-synced {len(migrated)} answered question(s) from markdown: {', '.join(migrated)}",
+                file=sys.stderr,
+            )
 
     # Step 1: Schema field validation
     all_issues: list[str] = []

--- a/plugins/code/skills/plan-validate/scripts/validate_plan.py
+++ b/plugins/code/skills/plan-validate/scripts/validate_plan.py
@@ -129,12 +129,15 @@ def auto_sync_markdown_answers(data: dict, content: str) -> tuple[dict, list[str
     Handles three answer formats:
 
     1. **Inline with prefix** — ``**Answer: text**``, ``*Answer: text*``, or
-       plain ``Answer: text`` on a checked ``[x]`` question line.
+       plain ``Answer: text`` on the question line.
     2. **A-### keyed answer** — a separate ``A-001: answer text`` line that
-       corresponds to ``Q-001``.  The question checkbox does not need to be
-       checked; the function updates the markdown content to check it.
+       corresponds to ``Q-001``.
     3. **Inline comment** — extra text appended after the known question text
-       on a checked line (no ``Answer:`` prefix).
+       on the question line (no ``Answer:`` prefix).
+
+    The question checkbox does not need to be checked for any format.  When
+    a question is migrated from an unchecked ``[ ]`` line, the function
+    updates the markdown content to check it automatically.
 
     Returns ``(data, migrated_ids)`` where *migrated_ids* lists the question
     IDs that were moved.  The caller is responsible for writing the modified
@@ -178,18 +181,22 @@ def auto_sync_markdown_answers(data: dict, content: str) -> tuple[dict, list[str
             migrated.append(qid)
             continue
 
-        # Unchecked question lines — only migrate if an A-### answer exists
+        # Unchecked question lines — migrate if answer text is extractable
         m = OPEN_Q_RE.match(line)
         if m:
             qid = m.group(1)
-            if qid in open_q_by_id and qid in a_answers:
-                q_obj = open_q_by_id.pop(qid)
-                data["openQuestions"] = [q for q in data["openQuestions"] if q.get("id") != qid]
-                data.setdefault("answeredQuestions", []).append(
-                    {"id": qid, "question": q_obj.get("question", ""), "answer": a_answers[qid]}
-                )
-                migrated.append(qid)
-                needs_check.add(qid)
+            if qid not in open_q_by_id:
+                continue
+            answer_text = _extract_answer(line, open_q_by_id[qid], a_answers)
+            if not answer_text:
+                continue
+            q_obj = open_q_by_id.pop(qid)
+            data["openQuestions"] = [q for q in data["openQuestions"] if q.get("id") != qid]
+            data.setdefault("answeredQuestions", []).append(
+                {"id": qid, "question": q_obj.get("question", ""), "answer": answer_text}
+            )
+            migrated.append(qid)
+            needs_check.add(qid)
 
     # Update markdown content: check boxes for questions migrated via A-### lines
     if needs_check:

--- a/plugins/code/skills/plan-validate/scripts/validate_plan.py
+++ b/plugins/code/skills/plan-validate/scripts/validate_plan.py
@@ -62,6 +62,11 @@ ANSWERED_Q_RE = re.compile(r"^\s*- \[x\] \*{0,2}(Q-\d{3})\*{0,2}:")
 # Matches **Answer: text**, *Answer: text*, or trailing Answer: text
 ANSWER_TEXT_RE = re.compile(r"\*{1,2}\s*Answer:\s*(.+?)\s*\*{1,2}\s*$")
 ANSWER_TEXT_PLAIN_RE = re.compile(r"(?:^|[\].])\s*Answer:\s*(.+?)\s*$")
+# A-### keyed answer line (flexible: optional list marker, optional checkbox)
+A_ANSWER_RE = re.compile(r"^\s*-?\s*\[?\s*[x ]?\s*\]?\s*A-(\d{3}):\s*(.+)")
+# Metadata markers to strip when extracting inline comments
+BLOCKING_TAG_RE = re.compile(r"\(BLOCKING\s+T-\d+\.\d+\)")
+RECOMMENDED_TAG_RE = re.compile(r"\[Recommended:[^\]]*\]")
 # AC table row pattern
 AC_TABLE_ROW_RE = re.compile(r"\| (AC-\d{3}) \|")
 # Gap content pattern
@@ -76,16 +81,64 @@ Q_ID_RE = re.compile(r"^Q-\d{3}$")
 GAP_ID_RE = re.compile(r"^GAP-\d{3}$")
 
 
+def _extract_answer(line: str, q_obj: dict, a_answers: dict[str, str]) -> str:
+    """Extract answer text from a question line using multiple strategies.
+
+    Tries, in order:
+    1. Bold/italic ``**Answer: text**`` or ``*Answer: text*``
+    2. Plain ``Answer: text`` (after ``]`` or ``.``)
+    3. ``A-###`` keyed answer line (pre-scanned)
+    4. Inline comment — text appended after the known question, stripped of metadata
+    5. ``recommendedAnswer`` from the JSON entry
+    """
+    qid = q_obj.get("id", "")
+
+    # 1. Bold/italic
+    m = ANSWER_TEXT_RE.search(line)
+    if m:
+        return m.group(1).strip()
+
+    # 2. Plain prefix
+    m = ANSWER_TEXT_PLAIN_RE.search(line)
+    if m:
+        return m.group(1).strip()
+
+    # 3. A-### keyed answer
+    if qid in a_answers:
+        return a_answers[qid]
+
+    # 4. Inline comment: find text after the known question, strip metadata
+    question_text = q_obj.get("question", "")
+    if question_text:
+        idx = line.find(question_text)
+        if idx >= 0:
+            after = line[idx + len(question_text) :]
+            after = BLOCKING_TAG_RE.sub("", after)
+            after = RECOMMENDED_TAG_RE.sub("", after)
+            after = after.strip().strip("*").strip()
+            if after:
+                return after
+
+    # 5. recommendedAnswer fallback
+    return q_obj.get("recommendedAnswer") or ""
+
+
 def auto_sync_markdown_answers(data: dict, content: str) -> tuple[dict, list[str]]:
     """Migrate questions answered in markdown to the answeredQuestions JSON array.
 
-    Detects questions with a checked ``[x]`` checkbox in the markdown ``content``
-    that are still in the ``openQuestions`` JSON array, extracts the answer text
-    from the markdown line, and moves them to ``answeredQuestions``.
+    Handles three answer formats:
 
-    Returns ``(data, migrated_ids)`` where *migrated_ids* lists the question IDs
-    that were moved.  The caller is responsible for writing the modified *data*
-    back to disk.
+    1. **Inline with prefix** — ``**Answer: text**``, ``*Answer: text*``, or
+       plain ``Answer: text`` on a checked ``[x]`` question line.
+    2. **A-### keyed answer** — a separate ``A-001: answer text`` line that
+       corresponds to ``Q-001``.  The question checkbox does not need to be
+       checked; the function updates the markdown content to check it.
+    3. **Inline comment** — extra text appended after the known question text
+       on a checked line (no ``Answer:`` prefix).
+
+    Returns ``(data, migrated_ids)`` where *migrated_ids* lists the question
+    IDs that were moved.  The caller is responsible for writing the modified
+    *data* back to disk.
     """
     migrated: list[str] = []
 
@@ -97,40 +150,56 @@ def auto_sync_markdown_answers(data: dict, content: str) -> tuple[dict, list[str
     if not open_q_by_id:
         return data, migrated
 
+    # Pre-scan for A-### answer lines
+    a_answers: dict[str, str] = {}
     for line in content.splitlines():
+        m = A_ANSWER_RE.match(line)
+        if m:
+            a_answers[f"Q-{m.group(1)}"] = m.group(2).strip()
+
+    # Track unchecked questions that need their checkbox flipped in content
+    needs_check: set[str] = set()
+
+    for line in content.splitlines():
+        # Checked question lines
         m = ANSWERED_Q_RE.match(line)
-        if not m:
+        if m:
+            qid = m.group(1)
+            if qid not in open_q_by_id:
+                continue
+            answer_text = _extract_answer(line, open_q_by_id[qid], a_answers)
+            if not answer_text:
+                continue
+            q_obj = open_q_by_id.pop(qid)
+            data["openQuestions"] = [q for q in data["openQuestions"] if q.get("id") != qid]
+            data.setdefault("answeredQuestions", []).append(
+                {"id": qid, "question": q_obj.get("question", ""), "answer": answer_text}
+            )
+            migrated.append(qid)
             continue
-        qid = m.group(1)
-        if qid not in open_q_by_id:
-            continue  # already in answeredQuestions or unknown
 
-        # Try bold/italic **Answer: …** or *Answer: …* first
-        answer_match = ANSWER_TEXT_RE.search(line)
-        if answer_match:
-            answer_text = answer_match.group(1).strip()
-        else:
-            # Fall back to plain "Answer: …" (after ] or . or start-of-segment)
-            answer_match = ANSWER_TEXT_PLAIN_RE.search(line)
-            answer_text = answer_match.group(1).strip() if answer_match else ""
+        # Unchecked question lines — only migrate if an A-### answer exists
+        m = OPEN_Q_RE.match(line)
+        if m:
+            qid = m.group(1)
+            if qid in open_q_by_id and qid in a_answers:
+                q_obj = open_q_by_id.pop(qid)
+                data["openQuestions"] = [q for q in data["openQuestions"] if q.get("id") != qid]
+                data.setdefault("answeredQuestions", []).append(
+                    {"id": qid, "question": q_obj.get("question", ""), "answer": a_answers[qid]}
+                )
+                migrated.append(qid)
+                needs_check.add(qid)
 
-        # Last resort: use the recommendedAnswer from the JSON entry
-        if not answer_text:
-            answer_text = open_q_by_id[qid].get("recommendedAnswer") or ""
-
-        if not answer_text:
-            continue  # cannot migrate without answer text
-
-        q_obj = open_q_by_id[qid]
-        answered_entry = {
-            "id": qid,
-            "question": q_obj.get("question", ""),
-            "answer": answer_text,
-        }
-
-        data["openQuestions"] = [q for q in data["openQuestions"] if q.get("id") != qid]
-        data.setdefault("answeredQuestions", []).append(answered_entry)
-        migrated.append(qid)
+    # Update markdown content: check boxes for questions migrated via A-### lines
+    if needs_check:
+        updated_lines: list[str] = []
+        for line in content.splitlines():
+            m = OPEN_Q_RE.match(line)
+            if m and m.group(1) in needs_check:
+                line = line.replace("- [ ]", "- [x]", 1)
+            updated_lines.append(line)
+        data["content"] = "\n".join(updated_lines)
 
     return data, migrated
 

--- a/plugins/code/skills/plan-validate/scripts/validate_plan.py
+++ b/plugins/code/skills/plan-validate/scripts/validate_plan.py
@@ -61,7 +61,7 @@ ANSWERED_Q_RE = re.compile(r"^\s*- \[x\] \*{0,2}(Q-\d{3})\*{0,2}:")
 # Extract answer text from a checked question line.
 # Matches **Answer: text**, *Answer: text*, or trailing Answer: text
 ANSWER_TEXT_RE = re.compile(r"\*{1,2}\s*Answer:\s*(.+?)\s*\*{1,2}\s*$")
-ANSWER_TEXT_PLAIN_RE = re.compile(r"(?:^|[\].])\s*Answer:\s*(.+?)\s*$")
+ANSWER_TEXT_PLAIN_RE = re.compile(r"(?:^|[\].])\s*Answer:\s*(.+?)\s*$|\bAnswer:\s*(.+?)\s*$")
 # A-### keyed answer line (flexible: optional list marker, optional checkbox)
 A_ANSWER_RE = re.compile(r"^\s*-?\s*\[?\s*[x ]?\s*\]?\s*A-(\d{3}):\s*(.+)")
 # Metadata markers to strip when extracting inline comments
@@ -98,10 +98,10 @@ def _extract_answer(line: str, q_obj: dict, a_answers: dict[str, str]) -> str:
     if m:
         return m.group(1).strip()
 
-    # 2. Plain prefix
+    # 2. Plain prefix (group 1 for ]/. anchor, group 2 for \bAnswer: anywhere)
     m = ANSWER_TEXT_PLAIN_RE.search(line)
     if m:
-        return m.group(1).strip()
+        return (m.group(1) or m.group(2)).strip()
 
     # 3. A-### keyed answer
     if qid in a_answers:
@@ -174,7 +174,7 @@ def auto_sync_markdown_answers(data: dict, content: str) -> tuple[dict, list[str
             if not answer_text:
                 continue
             q_obj = open_q_by_id.pop(qid)
-            data["openQuestions"] = [q for q in data["openQuestions"] if q.get("id") != qid]
+            data["openQuestions"] = [q for q in data["openQuestions"] if not (isinstance(q, dict) and q.get("id") == qid)]
             data.setdefault("answeredQuestions", []).append(
                 {"id": qid, "question": q_obj.get("question", ""), "answer": answer_text}
             )
@@ -191,14 +191,14 @@ def auto_sync_markdown_answers(data: dict, content: str) -> tuple[dict, list[str
             if not answer_text:
                 continue
             q_obj = open_q_by_id.pop(qid)
-            data["openQuestions"] = [q for q in data["openQuestions"] if q.get("id") != qid]
+            data["openQuestions"] = [q for q in data["openQuestions"] if not (isinstance(q, dict) and q.get("id") == qid)]
             data.setdefault("answeredQuestions", []).append(
                 {"id": qid, "question": q_obj.get("question", ""), "answer": answer_text}
             )
             migrated.append(qid)
             needs_check.add(qid)
 
-    # Update markdown content: check boxes for questions migrated via A-### lines
+    # Update markdown content: flip checkboxes for all questions migrated from unchecked lines
     if needs_check:
         updated_lines: list[str] = []
         for line in content.splitlines():

--- a/plugins/code/tools/python/test_auto_sync_answers.py
+++ b/plugins/code/tools/python/test_auto_sync_answers.py
@@ -1,0 +1,162 @@
+"""Tests for auto_sync_markdown_answers() in validate_plan.py."""
+import copy
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "skills" / "plan-validate" / "scripts"))
+
+from validate_plan import auto_sync_markdown_answers  # noqa: E402
+
+
+def _base_data(**overrides: object) -> dict:
+    """Return a plan dict with one open question and matching content."""
+    data: dict = {
+        "content": "",
+        "acceptanceCriteria": [],
+        "pendingTasks": [],
+        "completedTasks": [],
+        "openQuestions": [
+            {"id": "Q-001", "question": "What model?", "blockingTask": "T-1.1", "recommendedAnswer": None},
+        ],
+        "answeredQuestions": [],
+        "gaps": [],
+        "manualTasks": [],
+    }
+    data.update(overrides)
+    return data
+
+
+def test_bold_answer_extracted() -> None:
+    """A checked question with **Answer: text** is migrated."""
+    content = "- [x] Q-001: What model? **Answer: Use gpt-5.3-codex.**"
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["openQuestions"] == []
+    assert len(data["answeredQuestions"]) == 1
+    assert data["answeredQuestions"][0]["answer"] == "Use gpt-5.3-codex."
+    assert data["answeredQuestions"][0]["question"] == "What model?"
+
+
+def test_italic_answer_extracted() -> None:
+    """A checked question with *Answer: text* is migrated."""
+    content = "- [x] Q-001: What model? *Answer: Use the user's selected model.*"
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Use the user's selected model."
+
+
+def test_plain_answer_after_bracket() -> None:
+    """A checked question with plain Answer: after [Recommended: ...] is migrated."""
+    content = (
+        "- [x] Q-001: What model? (BLOCKING T-1.1) "
+        "[Recommended: gpt-5.3-codex] Answer: Default to user selection."
+    )
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Default to user selection."
+
+
+def test_recommended_answer_fallback() -> None:
+    """When no Answer: text in markdown, falls back to recommendedAnswer from JSON."""
+    content = "- [x] Q-001: What model?"
+    data = _base_data(content=content)
+    data["openQuestions"][0]["recommendedAnswer"] = "Use gpt-5.3-codex"
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Use gpt-5.3-codex"
+
+
+def test_no_answer_text_skipped() -> None:
+    """A checked question with no answer text and no recommendedAnswer is NOT migrated."""
+    content = "- [x] Q-001: What model?"
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == []
+    assert len(data["openQuestions"]) == 1
+    assert data["answeredQuestions"] == []
+
+
+def test_already_in_answered_ignored() -> None:
+    """A question already in answeredQuestions is not duplicated."""
+    content = "- [x] Q-001: What model? **Answer: Already answered.**"
+    data = _base_data(
+        content=content,
+        openQuestions=[],
+        answeredQuestions=[{"id": "Q-001", "question": "What model?", "answer": "Previous answer."}],
+    )
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == []
+    assert len(data["answeredQuestions"]) == 1
+    assert data["answeredQuestions"][0]["answer"] == "Previous answer."
+
+
+def test_unchecked_question_not_migrated() -> None:
+    """An unchecked question is left in openQuestions regardless of Answer text."""
+    content = "- [ ] Q-001: What model? **Answer: Some text.**"
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == []
+    assert len(data["openQuestions"]) == 1
+
+
+def test_multiple_questions_mixed() -> None:
+    """Only checked questions with answers are migrated; others stay."""
+    content = (
+        "- [x] Q-001: What model? **Answer: Use codex.**\n"
+        "- [ ] Q-002: What format?\n"
+        "- [x] Q-003: Which env? **Answer: Production.**\n"
+    )
+    data = _base_data(
+        content=content,
+        openQuestions=[
+            {"id": "Q-001", "question": "What model?", "blockingTask": None, "recommendedAnswer": None},
+            {"id": "Q-002", "question": "What format?", "blockingTask": None, "recommendedAnswer": None},
+            {"id": "Q-003", "question": "Which env?", "blockingTask": None, "recommendedAnswer": None},
+        ],
+    )
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert sorted(migrated) == ["Q-001", "Q-003"]
+    assert len(data["openQuestions"]) == 1
+    assert data["openQuestions"][0]["id"] == "Q-002"
+    assert len(data["answeredQuestions"]) == 2
+
+
+def test_data_not_mutated_when_no_matches() -> None:
+    """When no questions need migration, the data dict is unchanged."""
+    content = "- [ ] Q-001: What model?"
+    data = _base_data(content=content)
+    original = copy.deepcopy(data)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == []
+    assert data == original
+
+
+def test_empty_open_questions_short_circuits() -> None:
+    """When openQuestions is empty, returns immediately."""
+    content = "- [x] Q-001: What model? **Answer: foo.**"
+    data = _base_data(content=content, openQuestions=[])
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == []

--- a/plugins/code/tools/python/test_auto_sync_answers.py
+++ b/plugins/code/tools/python/test_auto_sync_answers.py
@@ -26,6 +26,9 @@ def _base_data(**overrides: object) -> dict:
     return data
 
 
+# --- Scenario 2: Inline answer with prefix ---
+
+
 def test_bold_answer_extracted() -> None:
     """A checked question with **Answer: text** is migrated."""
     content = "- [x] Q-001: What model? **Answer: Use gpt-5.3-codex.**"
@@ -63,6 +66,109 @@ def test_plain_answer_after_bracket() -> None:
 
     assert migrated == ["Q-001"]
     assert data["answeredQuestions"][0]["answer"] == "Default to user selection."
+
+
+# --- Scenario 3: A-### keyed answer line ---
+
+
+def test_a_answer_with_checked_question() -> None:
+    """A-001 answer line paired with a checked Q-001 is migrated."""
+    content = "- [x] Q-001: What model?\n- [ ] A-001: Use codex."
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Use codex."
+
+
+def test_a_answer_with_unchecked_question() -> None:
+    """A-001 answer line migrates even when Q-001 is unchecked; checkbox gets updated."""
+    content = "- [ ] Q-001: What model?\n- [ ] A-001: Use codex."
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Use codex."
+    # Markdown content should have the checkbox checked now
+    assert "- [x] Q-001:" in data["content"]
+
+
+def test_a_answer_no_list_marker() -> None:
+    """A-001 answer without list marker or checkbox is detected."""
+    content = "- [ ] Q-001: What model?\nA-001: Use codex."
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Use codex."
+
+
+def test_a_answer_no_matching_question_ignored() -> None:
+    """A-002 with no matching open Q-002 is ignored."""
+    content = "- [ ] Q-001: What model?\nA-002: irrelevant answer"
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == []
+    assert len(data["openQuestions"]) == 1
+
+
+def test_a_answer_preferred_over_recommended() -> None:
+    """A-### answer takes precedence over recommendedAnswer from JSON."""
+    content = "- [x] Q-001: What model?\nA-001: Use codex from A-line."
+    data = _base_data(content=content)
+    data["openQuestions"][0]["recommendedAnswer"] = "recommended fallback"
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Use codex from A-line."
+
+
+# --- Scenario 1: Inline comment without prefix ---
+
+
+def test_inline_comment_after_question() -> None:
+    """Extra text after the known question text is extracted as the answer."""
+    content = "- [x] Q-001: What model? Use the user's selected model."
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Use the user's selected model."
+
+
+def test_inline_comment_strips_metadata() -> None:
+    """Inline comment extraction strips BLOCKING and Recommended markers."""
+    content = (
+        "- [x] Q-001: What model? (BLOCKING T-1.1) "
+        "[Recommended: gpt-5.3-codex] Use user selection instead."
+    )
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Use user selection instead."
+
+
+def test_inline_comment_with_bold_markers() -> None:
+    """Inline comment wrapped in bold markers has them stripped."""
+    content = "- [x] Q-001: What model? **Yes, use codex**"
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Yes, use codex"
+
+
+# --- Fallback and edge cases ---
 
 
 def test_recommended_answer_fallback() -> None:
@@ -105,8 +211,8 @@ def test_already_in_answered_ignored() -> None:
     assert data["answeredQuestions"][0]["answer"] == "Previous answer."
 
 
-def test_unchecked_question_not_migrated() -> None:
-    """An unchecked question is left in openQuestions regardless of Answer text."""
+def test_unchecked_question_without_a_answer_not_migrated() -> None:
+    """An unchecked question without A-### answer stays in openQuestions."""
     content = "- [ ] Q-001: What model? **Answer: Some text.**"
     data = _base_data(content=content)
 
@@ -117,7 +223,7 @@ def test_unchecked_question_not_migrated() -> None:
 
 
 def test_multiple_questions_mixed() -> None:
-    """Only checked questions with answers are migrated; others stay."""
+    """Only questions with answers are migrated; others stay."""
     content = (
         "- [x] Q-001: What model? **Answer: Use codex.**\n"
         "- [ ] Q-002: What format?\n"
@@ -138,6 +244,35 @@ def test_multiple_questions_mixed() -> None:
     assert len(data["openQuestions"]) == 1
     assert data["openQuestions"][0]["id"] == "Q-002"
     assert len(data["answeredQuestions"]) == 2
+
+
+def test_multiple_formats_mixed() -> None:
+    """All three formats coexist: inline prefix, A-### line, inline comment."""
+    content = (
+        "- [x] Q-001: What model? **Answer: Use codex.**\n"
+        "- [ ] Q-002: What format?\n"
+        "A-002: JSON format.\n"
+        "- [x] Q-003: Which env? Production.\n"
+    )
+    data = _base_data(
+        content=content,
+        openQuestions=[
+            {"id": "Q-001", "question": "What model?", "blockingTask": None, "recommendedAnswer": None},
+            {"id": "Q-002", "question": "What format?", "blockingTask": None, "recommendedAnswer": None},
+            {"id": "Q-003", "question": "Which env?", "blockingTask": None, "recommendedAnswer": None},
+        ],
+    )
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert sorted(migrated) == ["Q-001", "Q-002", "Q-003"]
+    assert data["openQuestions"] == []
+    answers = {q["id"]: q["answer"] for q in data["answeredQuestions"]}
+    assert answers["Q-001"] == "Use codex."
+    assert answers["Q-002"] == "JSON format."
+    assert answers["Q-003"] == "Production."
+    # Q-002 checkbox should be checked in content
+    assert "- [x] Q-002:" in data["content"]
 
 
 def test_data_not_mutated_when_no_matches() -> None:

--- a/plugins/code/tools/python/test_auto_sync_answers.py
+++ b/plugins/code/tools/python/test_auto_sync_answers.py
@@ -211,9 +211,33 @@ def test_already_in_answered_ignored() -> None:
     assert data["answeredQuestions"][0]["answer"] == "Previous answer."
 
 
-def test_unchecked_question_without_a_answer_not_migrated() -> None:
-    """An unchecked question without A-### answer stays in openQuestions."""
+def test_unchecked_question_with_prefix_answer_migrated() -> None:
+    """An unchecked question with **Answer:** prefix is migrated and auto-checked."""
     content = "- [ ] Q-001: What model? **Answer: Some text.**"
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Some text."
+    assert "- [x] Q-001:" in data["content"]
+
+
+def test_unchecked_question_with_inline_comment_migrated() -> None:
+    """An unchecked question with inline comment is migrated and auto-checked."""
+    content = "- [ ] Q-001: What model? Use codex."
+    data = _base_data(content=content)
+
+    data, migrated = auto_sync_markdown_answers(data, content)
+
+    assert migrated == ["Q-001"]
+    assert data["answeredQuestions"][0]["answer"] == "Use codex."
+    assert "- [x] Q-001:" in data["content"]
+
+
+def test_unchecked_question_without_answer_not_migrated() -> None:
+    """An unchecked question with no answer text stays in openQuestions."""
+    content = "- [ ] Q-001: What model?"
     data = _base_data(content=content)
 
     data, migrated = auto_sync_markdown_answers(data, content)


### PR DESCRIPTION
## Summary
- Adds `auto_sync_markdown_answers()` to `validate_plan.py` that detects questions marked `[x]` in markdown content but still in the `openQuestions` JSON array, extracts the answer text, and migrates them to `answeredQuestions`
- Supports `**Answer: text**`, `*Answer: text*`, and plain `Answer: text` formats, with fallback to `recommendedAnswer` from the JSON entry
- New `--auto-sync` CLI flag triggers the migration before validation; SKILL.md updated to pass it by default

## Motivation
Previously, users had no way to answer open questions by editing markdown — the only path was manually editing the JSON `answeredQuestions` array. Inline answer text (bold, italic, or `A-###` lines) was invisible to the workflow. This change closes that gap so checking `[x]` and writing `**Answer: ...**` in the markdown actually gets picked up by Phase 1.2.

## Test plan
- [x] 10 new test cases in `test_auto_sync_answers.py` (bold, italic, plain, recommended fallback, no-answer skip, already-migrated, unchecked, multiple mixed, no-mutation, empty short-circuit)
- [x] All existing `test_validate_plan_sync.py` and `test_validate_plan.py` tests pass
- [ ] Manual: edit a plan.json markdown to check a question and add `**Answer: ...**`, run with `--auto-sync`, verify JSON arrays updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)