### PR TITLE
PLN-474: fix(code): handle raw markdown plan.json from older gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code v1.11.5
+
+#### Fixed
+- Phase 1 of the orchestrator prompt (`plugins/code/prompts/prompt.md`) now tolerates a `plan.json` whose contents are raw markdown instead of JSON — a shape produced by older gateway versions that wrote the plan source straight to `plan.json`. Before activating the `code:plan-validate` skill, the orchestrator validates `plan.json` with `python3 -m json.tool`; if parsing fails, it renames the file to `plan-source.md`, sets `CLOSEDLOOP_PLAN_FILE` to that path, marks `plan_was_imported = true`, and routes through `@code:plan-importer`. A new branch in the "plan.json does NOT exist" path also picks up a pre-existing `plan-source.md` for import. This unblocks runs that previously failed at Phase 1 with `EMPTY_FILE`/`FORMAT_ISSUES` against markdown content.
+
 ### code v1.11.4
 
 #### Added

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/prompts/prompt.md
+++ b/plugins/code/prompts/prompt.md
@@ -116,11 +116,14 @@ Here are the key phases you must complete:
 - Check if $CLOSEDLOOP_WORKDIR/plan.json exists (`ls`)
 - **If plan.json does NOT exist:**
   - If `CLOSEDLOOP_PLAN_FILE` is set: Set `plan_was_imported = true`. Launch @code:plan-importer with `WORKDIR`. After completion, activate `code:plan-validate` skill. Proceed to Phase 1.1.
+  - Else if `$CLOSEDLOOP_WORKDIR/plan-source.md` exists (`ls "$CLOSEDLOOP_WORKDIR/plan-source.md"` returns 0): Set `CLOSEDLOOP_PLAN_FILE="$CLOSEDLOOP_WORKDIR/plan-source.md"`. Set `plan_was_imported = true`. Launch @code:plan-importer with `WORKDIR`. After completion, activate `code:plan-validate` skill. Proceed to Phase 1.1.
   - Otherwise: Set `plan_was_created = true`. Launch @code:plan-draft-writer with `WORKDIR=$CLOSEDLOOP_WORKDIR` (mention pre-computed context files if available). Once agent outputs `<promise>PLAN_VALIDATED</promise>`, run **PLAN_VALIDATION_SEQUENCE**.
 - **If plan.json EXISTS:**
-  - Activate `code:plan-validate` skill
-  - `EMPTY_FILE`/`FORMAT_ISSUES`: Fix via haiku subagent (missing checkboxes → add `[ ]`) or @code:plan-writer, then re-validate
-  - `VALID`: Proceed to Phase 1.1
+  - First, check if plan.json contains valid JSON: `python3 -m json.tool "$CLOSEDLOOP_WORKDIR/plan.json" > /dev/null 2>&1`
+  - If plan.json is NOT valid JSON (exit code non-zero — raw markdown written by an older gateway): Run `mv "$CLOSEDLOOP_WORKDIR/plan.json" "$CLOSEDLOOP_WORKDIR/plan-source.md"` to rename it. Set `CLOSEDLOOP_PLAN_FILE="$CLOSEDLOOP_WORKDIR/plan-source.md"`. Set `plan_was_imported = true`. Launch @code:plan-importer with `WORKDIR`. After completion, activate `code:plan-validate` skill. Proceed to Phase 1.1.
+  - If plan.json IS valid JSON: Activate `code:plan-validate` skill
+    - `EMPTY_FILE`/`FORMAT_ISSUES`: Fix via haiku subagent (missing checkboxes → add `[ ]`) or @code:plan-writer, then re-validate
+    - `VALID`: Proceed to Phase 1.1
 
 **PHASE 1.1: PLAN REVIEW CHECKPOINT**
 


### PR DESCRIPTION
## Summary

Hardens the EXECUTE loop's Phase 1 plan-detection logic to handle a corrupted
state where an older gateway version wrote raw markdown content into a file
named `plan.json` instead of valid JSON.

## Changes

- **`plugins/code/prompts/prompt.md`** — Phase 1 plan detection now:
  - Checks whether an existing `plan.json` actually parses as JSON
    (`python3 -m json.tool ... > /dev/null 2>&1`).
  - If it does not, renames it to `plan-source.md`, sets
    `CLOSEDLOOP_PLAN_FILE`, and routes through `@code:plan-importer` instead
    of failing format validation.
  - When `plan.json` is missing and `CLOSEDLOOP_PLAN_FILE` is unset, falls
    back to `plan-source.md` if one already exists in the workdir.

## Why

Earlier gateway versions could persist plan content with the wrong filename
and format, causing the orchestrator to fail validation and stall before any
work began. This recovery path lets the loop self-heal by treating malformed
`plan.json` as raw markdown source for the importer.

## Testing

- Manual diff review of the three new conditional branches in Phase 1.
- Confirmed valid-JSON path is unchanged (still routes to `code:plan-validate`).

## Risks

None identified — additive branches; existing valid-JSON flow is preserved.

---
Loop ID: 019df874-0604-751e-91c7-712596b9ece1
Artifact: https://app.closedloop.ai/implementation-plans/PLN-474
