### PR TITLE
PLN-482: Archive run output and sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code v1.11.7
+
+#### Added
+- Per-run `claude-output.jsonl` archival in `run-loop.sh`. New helpers `sanitize_output_run_id`, `rename_orphan_output_on_start`, and `rename_output_on_exit` rename the live JSONL to `claude-output-<run_id>.jsonl` on every loop exit (including spurious-complete, interrupt, and error paths) and write a `claude-output.name.txt` sidecar pointing at the latest archived file. On startup, any orphaned `claude-output.jsonl` left from a prior run is renamed using the previous `RUN_ID` from `state.json` or the last entry in `runs.log` (or an `orphan-<timestamp>` fallback), and the sidecar is cleared so consumers do not read stale prior-run pointers. Run id values are sanitized (`[^A-Za-z0-9._-]` collapsed to `_`) before being interpolated into the destination filename. New tests in `test_run_loop_failure_marker.py` cover the rename-on-exit, orphan-rename-from-runs.log, and workdir-root `runs.log` paths.
+- Claude session-id capture in `run-loop.sh`. New helpers `extract_claude_session_id` (jq-based extraction across `session_id`/`sessionId`/`message.*`/`item.*` shapes), `record_claude_session_id` (sets `LAST_CLAUDE_COMMAND`/`LAST_CLAUDE_SESSION_ID`, exports `CLOSEDLOOP_SESSION_ID`), and `sanitize_runs_log_field` (strips `\r`/`\n` and replaces `|` with `_`). `record_claude_session_id` writes `$workdir/session-id.txt` only for the `plan_execute` command so post-loop `code_review` and fix sessions do not overwrite the operation-level correlation id consumed by desktop finalization. Plan/execute, post-loop review, and fix invocations now capture session ids and route them into the runs.log entry for that step. New tests cover the primary plan/execute write, the code-review preservation of the primary session, and the runs.log workdir-root location with sanitized command/session fields.
+
+#### Changed
+- `write_runs_log_entry` in `run-loop.sh` now writes to `$workdir/runs.log` instead of `$workdir/.learnings/runs.log`, matching the new `self-learning` `prune-learnings.sh` and `evaluate_goal.py` location. Keeps the runs ledger at the workdir root next to `state.json` and `plan.json` rather than nested inside `.learnings/`.
+- `runs.log` row format extended to `run_id|timestamp|goal|iteration|status|command|last_session_id`. The first five fields are the legacy contract; `command` (e.g. `plan_execute`, `code_review`, `self_learning`) and `last_session_id` are append-only so older self-learning readers stay compatible. `write_runs_log_entry` accepts optional 4th/5th arguments for explicit command/session overrides and falls back to `LAST_CLAUDE_COMMAND`/`LAST_CLAUDE_SESSION_ID` (or `session-id.txt`) otherwise.
+- `--codex-model` default in the `/code:plan-with-codex` README documentation updated from `gpt-5.4` to `gpt-5.3-codex` to match the actual command default.
+
+### self-learning v1.2.2
+
+#### Changed
+- `prune-learnings.sh` and `evaluate_goal.py` now read and rotate `runs.log` from `$WORKDIR/runs.log` instead of `$LEARNINGS_DIR/runs.log` (`<workdir>/.learnings/runs.log`). The runs ledger now lives at the workdir root alongside `state.json` and `plan.json`, matching where `run-loop.sh` writes it. New tests `test_prune_learnings.py` and a `test_reduce_failures_reads_runs_log_from_workdir_root` case in `test_evaluate_goal.py` lock in the new location.
+- `goal-stats` command documentation (`commands/goal-stats.md`) now describes the pipe-delimited `runs.log` row format `run_id|timestamp|goal|iteration|status[|command|last_session_id]` and notes that `command` and `last_session_id` are optional append-only fields so legacy 4+ field rows remain valid. The `runs.log` data-source description was updated to mention the optional command/session correlation columns.
+- `evaluate_goal.py` comment on `RUNS_LOG_MIN_FIELDS` clarifies that reduce-failures only needs `run_id` and `iteration`, so legacy 4+ field rows and newer session-correlated rows are both accepted.
+
+#### Fixed
+- `prune-learnings.sh` session enumeration in `prune_sessions()` no longer relies on `mapfile` piped through `tac`. Replaced `mapfile -t all_sessions < <(ls -1t "$sessions_dir" | tac)` with a `while IFS= read -r ... done < <(ls -1tr ...)` loop, which avoids the `tac` external dependency (not present on default macOS) and keeps the oldest-first ordering needed for FIFO pruning.
+
 ### code v1.11.6
 
 #### Added

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/README.md
+++ b/plugins/code/README.md
@@ -115,7 +115,7 @@ Checks for `.closedloop-ai/closedloop-loop.local.md`, reads the current iteratio
 
 - `--max-rounds N`: Maximum debate rounds (default: 15)
 - `--plan-file PATH`: Output plan file (default: `./debate-plan.md`)
-- `--codex-model MODEL`: Codex model for reviews (default: `gpt-5.4`)
+- `--codex-model MODEL`: Codex model for reviews (default: `gpt-5.3-codex`)
 - `<prompt>`: Description of what to plan (required; can also be read from a `{stem}.prompt` sidecar file)
 
 **What it does:**

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -43,6 +43,8 @@ SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUN_ID=""
 START_SHA=""
 SELF_LEARNING=false
+LAST_CLAUDE_COMMAND=""
+LAST_CLAUDE_SESSION_ID=""
 
 # Write an intentionally user-visible failure marker for the Electron finalizer.
 #
@@ -208,7 +210,8 @@ handle_spurious_complete() {
 
   echo -e "\n${RED}Spurious COMPLETE detected: $message${NC}" >&2
   log_progress "Spurious COMPLETE: $message"
-  write_runs_log_entry "$workdir" "$iteration" "spurious_complete"
+  write_runs_log_entry "$workdir" "$iteration" "spurious_complete" "plan_execute"
+  rename_output_on_exit
   release_lock "$workdir"
   rm -f "$STATE_FILE"
   fail_loop_user_visible "RUNNER_ERROR" "$subcode" "$message"
@@ -370,15 +373,92 @@ create_iteration_marker() {
   echo "$iteration" > "$session_dir/current-iteration"
 }
 
-# Write runs.log entry for goal evaluation
+sanitize_runs_log_field() {
+  local raw="$1"
+  raw="${raw//$'\r'/ }"
+  raw="${raw//$'\n'/ }"
+  raw="${raw//|/_}"
+  echo "$raw"
+}
+
+extract_claude_session_id() {
+  local output_file="$1"
+  if [[ ! -s "$output_file" ]]; then
+    return 0
+  fi
+
+  jq -r '
+    [
+      .session_id?,
+      .sessionId?,
+      .message.session_id?,
+      .message.sessionId?,
+      .item.session_id?,
+      .item.sessionId?
+    ]
+    | map(select(type == "string" and length > 0))
+    | .[0] // empty
+    | select(length > 0)
+  ' "$output_file" 2>/dev/null | tail -n 1
+}
+
+record_claude_session_id() {
+  local workdir="$1"
+  local command="$2"
+  local session_id="$3"
+
+  if [[ -z "$session_id" ]]; then
+    return 0
+  fi
+
+  LAST_CLAUDE_COMMAND="$command"
+  LAST_CLAUDE_SESSION_ID="$session_id"
+  export CLOSEDLOOP_SESSION_ID="$session_id"
+
+  # Desktop finalization reads one session-id.txt. Keep that file scoped to the
+  # primary plan/execute Claude session so post-loop review/fix sessions do not
+  # overwrite the operation-level correlation id.
+  if [[ "$command" == "plan_execute" ]]; then
+    printf '%s\n' "$session_id" > "$workdir/session-id.txt"
+  fi
+}
+
+# Write runs.log entry for goal evaluation and session correlation.
+#
+# Format:
+#   run_id|timestamp|goal|iteration|status|command|last_session_id
+# The first five fields are the legacy contract; append-only fields keep older
+# self-learning readers compatible while allowing command-scoped session lookup.
 write_runs_log_entry() {
   local workdir="$1"
   local iteration="$2"
   local status="${3:-in_progress}"
-  local runs_log="$workdir/.learnings/runs.log"
-  local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local command
+  local session_id
+  local explicit_session_id=false
+  if [[ $# -ge 4 ]]; then
+    command="$4"
+  else
+    command="${LAST_CLAUDE_COMMAND:-self_learning}"
+  fi
+  if [[ $# -ge 5 ]]; then
+    session_id="$5"
+    explicit_session_id=true
+  else
+    session_id="${LAST_CLAUDE_SESSION_ID:-}"
+  fi
+  local runs_log="$workdir/runs.log"
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  if [[ "$explicit_session_id" == "false" && -z "$session_id" && -f "$workdir/session-id.txt" ]]; then
+    session_id=$(tr -d '\r\n' < "$workdir/session-id.txt" 2>/dev/null || true)
+  fi
+
+  command=$(sanitize_runs_log_field "$command")
+  session_id=$(sanitize_runs_log_field "$session_id")
   mkdir -p "$(dirname "$runs_log")"
-  echo "$RUN_ID|$timestamp|${CLOSEDLOOP_ACTIVE_GOAL:-reduce-failures}|$iteration|$status" >> "$runs_log"
+  echo "$RUN_ID|$timestamp|${CLOSEDLOOP_ACTIVE_GOAL:-reduce-failures}|$iteration|$status|$command|$session_id" >> "$runs_log"
 }
 
 # Post-iteration processing: enrichment pipeline, learning capture, citation verification, success rates
@@ -688,10 +768,14 @@ run_post_loop_review() {
     review_exit=$(cat "$review_exit_file" 2>/dev/null || echo 1)
     rm -f "$review_exit_file"
     set -e
+    local review_session_id
+    review_session_id=$(extract_claude_session_id "$review_output")
+    record_claude_session_id "$workdir" "code_review" "$review_session_id"
 
     # Guard: if the review process itself failed, don't consume stale results
     if [[ "$review_exit" -ne 0 ]]; then
       log_progress "Post-loop review failed (exit $review_exit). Skipping fix."
+      write_runs_log_entry "$workdir" "${CLOSEDLOOP_ITERATION:-0}" "review_error" "code_review" "$review_session_id"
       rm -f "$review_output" "$review_stderr"
       return 0
     fi
@@ -719,6 +803,7 @@ run_post_loop_review() {
       --argjson exit_code "$review_exit" \
       '{event:$event,run_id:$run_id,verdict:$verdict,cycle:$cycle,duration_s:$duration_s,exit_code:$exit_code}'
     )"
+    write_runs_log_entry "$workdir" "${CLOSEDLOOP_ITERATION:-0}" "review_${verdict}" "code_review" "$review_session_id"
 
     rm -f "$review_output" "$review_stderr"
 
@@ -765,6 +850,9 @@ run_post_loop_review() {
     fix_exit=$(cat "$fix_exit_file" 2>/dev/null || echo 1)
     rm -f "$fix_exit_file"
     set -e
+    local fix_session_id
+    fix_session_id=$(extract_claude_session_id "$fix_output")
+    record_claude_session_id "$workdir" "code_review" "$fix_session_id"
 
     # Emit perf event for fix
     local fix_end_epoch
@@ -777,6 +865,11 @@ run_post_loop_review() {
       --argjson exit_code "$fix_exit" \
       '{event:$event,run_id:$run_id,cycle:$cycle,duration_s:$duration_s,exit_code:$exit_code}'
     )"
+    local fix_status="fix_completed"
+    if [[ "$fix_exit" -ne 0 ]]; then
+      fix_status="fix_error"
+    fi
+    write_runs_log_entry "$workdir" "${CLOSEDLOOP_ITERATION:-0}" "$fix_status" "code_review" "$fix_session_id"
 
     rm -f "$fix_output" "$fix_stderr"
 
@@ -1153,6 +1246,8 @@ main() {
     # Acquire lock to prevent concurrent loops
     acquire_lock "$WORKDIR"
 
+    rename_orphan_output_on_start
+
     create_state_file
   fi
 
@@ -1275,7 +1370,7 @@ main() {
       log_progress "Loop ended - max iterations reached"
 
       # Write runs.log entry
-      write_runs_log_entry "$effective_workdir" "$iteration" "max_iterations"
+      write_runs_log_entry "$effective_workdir" "$iteration" "max_iterations" "plan_execute"
 
       # Final post-iteration processing
       post_iteration_processing "$effective_workdir" "$iteration"
@@ -1284,6 +1379,7 @@ main() {
       run_post_loop_review "$effective_workdir"
 
       # Clean up
+      rename_output_on_exit
       release_lock "$effective_workdir"
       rm -f "$STATE_FILE"
 
@@ -1350,6 +1446,9 @@ main() {
     claude_exit=$(cat "$exit_code_file" 2>/dev/null || echo 1)
     rm -f "$exit_code_file"
     set -e
+    local plan_session_id
+    plan_session_id=$(extract_claude_session_id "$output_file")
+    record_claude_session_id "$effective_workdir" "plan_execute" "$plan_session_id"
 
     if [[ $claude_exit -eq 0 ]]; then
       local result=$(jq -r "$final_result" "$output_file")
@@ -1363,7 +1462,8 @@ main() {
         echo -e "\n${RED}ERROR: Claude reported is_error=true in result record.${NC}"
         echo -e "${RED}Error text: $error_text${NC}"
         log_progress "Context limit: is_error=true, text=$error_text"
-        write_runs_log_entry "$effective_workdir" "$iteration" "context_limit"
+        write_runs_log_entry "$effective_workdir" "$iteration" "context_limit" "plan_execute"
+        rename_output_on_exit
         release_lock "$effective_workdir"
         rm -f "$STATE_FILE"
         rm -f "$output_file" "$stderr_file" 2>/dev/null || true
@@ -1376,7 +1476,8 @@ main() {
         if [[ $consecutive_empty -ge 3 ]]; then
           echo -e "\n${RED}ERROR: $consecutive_empty consecutive iterations with no output. Aborting to prevent ghost loop.${NC}"
           log_progress "Aborting: ghost loop detected after $consecutive_empty empty iterations"
-          write_runs_log_entry "$effective_workdir" "$iteration" "ghost_loop_abort"
+          write_runs_log_entry "$effective_workdir" "$iteration" "ghost_loop_abort" "plan_execute"
+          rename_output_on_exit
           release_lock "$effective_workdir"
           rm -f "$STATE_FILE"
           rm -f "$output_file" "$stderr_file" 2>/dev/null || true
@@ -1449,12 +1550,13 @@ main() {
         log_progress "Loop completed - promise fulfilled after $iteration iterations"
 
         # Write runs.log entry
-        write_runs_log_entry "$effective_workdir" "$iteration" "completed"
+        write_runs_log_entry "$effective_workdir" "$iteration" "completed" "plan_execute"
 
         # Run post-loop code review
         run_post_loop_review "$effective_workdir"
 
         # Clean up
+        rename_output_on_exit
         release_lock "$effective_workdir"
         rm -f "$STATE_FILE"
 
@@ -1467,7 +1569,7 @@ main() {
       log_progress "Iteration $iteration completed - continuing"
 
       # Write runs.log entry
-      write_runs_log_entry "$effective_workdir" "$iteration" "in_progress"
+      write_runs_log_entry "$effective_workdir" "$iteration" "in_progress" "plan_execute"
 
     else
       echo -e "\n${YELLOW}Warning: Claude exited with non-zero status (exit code: $claude_exit)${NC}"
@@ -1479,7 +1581,8 @@ main() {
         if grep -qiE "prompt is too long|exceed context limit|context limit reached|conversation too long" "$stderr_file"; then
           echo -e "\n${RED}Context limit detected in stderr${NC}"
           log_progress "Context limit: detected in stderr (exit $claude_exit)"
-          write_runs_log_entry "$effective_workdir" "$iteration" "context_limit"
+          write_runs_log_entry "$effective_workdir" "$iteration" "context_limit" "plan_execute"
+          rename_output_on_exit
           release_lock "$effective_workdir"
           rm -f "$STATE_FILE"
           rm -f "$output_file" "$stderr_file" 2>/dev/null || true
@@ -1489,7 +1592,7 @@ main() {
       log_progress "Iteration $iteration - Claude exited with error (code: $claude_exit)"
 
       # Write runs.log entry
-      write_runs_log_entry "$effective_workdir" "$iteration" "error"
+      write_runs_log_entry "$effective_workdir" "$iteration" "error" "plan_execute"
 
       # Non-zero exit resets consecutive_empty -- the guard tracks consecutive
       # exit-0-with-no-output iterations, not intermixed failures.
@@ -1532,6 +1635,104 @@ main() {
   done
 }
 
+sanitize_output_run_id() {
+  local raw="$1"
+  raw="${raw//[^A-Za-z0-9._-]/_}"
+  echo "$raw"
+}
+
+rename_orphan_output_on_start() {
+  local workdir="${CLOSEDLOOP_WORKDIR:-${WORKDIR:-}}"
+  if [[ -z "$workdir" ]]; then
+    return
+  fi
+
+  local sidecar="${workdir}/claude-output.name.txt"
+  if ! : > "$sidecar" 2>/dev/null; then
+    if rm -f "$sidecar" 2>/dev/null; then
+      : > "$sidecar" 2>/dev/null || \
+        echo "Warning: cannot recreate empty sidecar; stale prior-run reads possible" >&2
+    else
+      echo "Warning: cannot clear sidecar; stale prior-run reads possible" >&2
+    fi
+  fi
+
+  local jsonl_file="${workdir}/claude-output.jsonl"
+  if [[ ! -f "$jsonl_file" ]]; then
+    return
+  fi
+
+  local prev_run_id=""
+  if [[ -f "$STATE_FILE" ]]; then
+    prev_run_id=$(get_field "run_id" 2>/dev/null || true)
+  fi
+
+  if [[ -z "$prev_run_id" ]]; then
+    local runs_log="${workdir}/runs.log"
+    if [[ -f "$runs_log" ]]; then
+      local last_run_line
+      last_run_line=$(tail -n 1 "$runs_log" 2>/dev/null || true)
+      prev_run_id="${last_run_line%%|*}"
+    fi
+  fi
+
+  if [[ -z "$prev_run_id" ]]; then
+    prev_run_id="orphan-$(date +%Y%m%d-%H%M%S)"
+  fi
+  prev_run_id=$(sanitize_output_run_id "$prev_run_id")
+  if [[ -z "$prev_run_id" ]]; then
+    prev_run_id="orphan-$(date +%Y%m%d-%H%M%S)"
+  fi
+
+  local dest="${workdir}/claude-output-${prev_run_id}.jsonl"
+  if ! mv "$jsonl_file" "$dest"; then
+    echo "Warning: failed to rename orphaned claude-output.jsonl; truncating" >&2
+    > "$jsonl_file" 2>/dev/null || \
+      echo "Warning: failed to truncate claude-output.jsonl" >&2
+  fi
+}
+
+rename_output_on_exit() {
+  local workdir="${CLOSEDLOOP_WORKDIR:-}"
+  if [[ -z "$workdir" ]]; then
+    workdir=$(get_field "workdir" 2>/dev/null || echo "")
+  fi
+  if [[ -z "$workdir" ]]; then
+    return
+  fi
+
+  local jsonl_file="${workdir}/claude-output.jsonl"
+  if [[ ! -f "$jsonl_file" ]]; then
+    return
+  fi
+
+  local run_id="${RUN_ID:-}"
+  if [[ -z "$run_id" ]]; then
+    run_id=$(get_field "run_id" 2>/dev/null || echo "")
+  fi
+  if [[ -z "$run_id" ]]; then
+    run_id="orphan-$(date +%Y%m%d-%H%M%S)"
+  fi
+  run_id=$(sanitize_output_run_id "$run_id")
+  if [[ -z "$run_id" ]]; then
+    run_id="orphan-$(date +%Y%m%d-%H%M%S)"
+  fi
+
+  local basename="claude-output-${run_id}.jsonl"
+  local dest="${workdir}/${basename}"
+  if mv "$jsonl_file" "$dest"; then
+    local sidecar="${workdir}/claude-output.name.txt"
+    local tmp_sidecar="${sidecar}.tmp.$$"
+    if printf '%s\n' "$basename" > "$tmp_sidecar" && mv "$tmp_sidecar" "$sidecar"; then
+      return
+    fi
+    rm -f "$tmp_sidecar" "$sidecar" 2>/dev/null || true
+    echo "Warning: failed to write claude-output sidecar for $basename" >&2
+  else
+    echo "Warning: failed to rename claude-output.jsonl to $(basename "$dest")" >&2
+  fi
+}
+
 # Handle Ctrl+C gracefully
 # NOTE: The pipeline is run in the background so that `wait` (which IS
 # interruptible by trapped signals) is the foreground operation.  If the
@@ -1557,6 +1758,7 @@ cleanup_on_interrupt() {
   local workdir
   workdir=$(get_field "workdir" 2>/dev/null || echo "")
   if [[ -n "$workdir" ]]; then
+    rename_output_on_exit
     release_lock "$workdir"
   fi
 

--- a/plugins/code/tools/python/test_run_loop_failure_marker.py
+++ b/plugins/code/tools/python/test_run_loop_failure_marker.py
@@ -233,3 +233,139 @@ def test_fail_loop_user_visible_prints_reason_and_exits(tmp_path: Path) -> None:
         "message": "Plan state is not loadable.",
         "result": {"subcode": "BAD_PLAN_STATE"},
     })
+
+
+def test_rename_output_on_exit_moves_jsonl_and_writes_sidecar(tmp_path: Path) -> None:
+    (tmp_path / "claude-output.jsonl").write_text('{"type":"result"}\n')
+
+    result = run_bash(
+        f"""
+        source {RUN_LOOP}
+        RUN_ID='run-exit'
+        rename_output_on_exit
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "claude-output.jsonl").exists()
+    assert (tmp_path / "claude-output-run-exit.jsonl").read_text() == '{"type":"result"}\n'
+    assert (tmp_path / "claude-output.name.txt").read_text() == "claude-output-run-exit.jsonl\n"
+
+
+def test_rename_orphan_output_on_start_clears_sidecar_and_uses_runs_log(tmp_path: Path) -> None:
+    (tmp_path / "claude-output.jsonl").write_text('{"type":"result"}\n')
+    (tmp_path / "claude-output.name.txt").write_text("claude-output-stale.jsonl\n")
+    (tmp_path / "runs.log").write_text("prev-run|2026-05-05T00:00:00Z|reduce-failures|1|error\n")
+
+    result = run_bash(
+        f"""
+        source {RUN_LOOP}
+        WORKDIR="$CLOSEDLOOP_WORKDIR"
+        rename_orphan_output_on_start
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "claude-output.jsonl").exists()
+    assert (tmp_path / "claude-output-prev-run.jsonl").read_text() == '{"type":"result"}\n'
+    assert (tmp_path / "claude-output.name.txt").read_text() == ""
+
+
+def test_write_runs_log_entry_uses_workdir_root(tmp_path: Path) -> None:
+    result = run_bash(
+        f"""
+        source {RUN_LOOP}
+        RUN_ID='run-root-log'
+        write_runs_log_entry "$CLOSEDLOOP_WORKDIR" 2 completed
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "runs.log").exists()
+    fields = (tmp_path / "runs.log").read_text().strip().split("|")
+    assert fields[0] == "run-root-log"
+    assert fields[5] == "self_learning"
+    assert fields[6] == ""
+    assert not (tmp_path / ".learnings" / "runs.log").exists()
+
+
+def test_plan_execute_session_capture_writes_primary_session_and_runs_log(
+    tmp_path: Path,
+) -> None:
+    result = run_bash(
+        f"""
+        source {RUN_LOOP}
+        output_file="$CLOSEDLOOP_WORKDIR/output.jsonl"
+        printf '%s\\n' '{{"type":"system","session_id":"plan-session-123"}}' > "$output_file"
+        printf '%s\\n' '{{"type":"result","subtype":"success"}}' >> "$output_file"
+        session_id=$(extract_claude_session_id "$output_file")
+        RUN_ID='run-plan-session'
+        record_claude_session_id "$CLOSEDLOOP_WORKDIR" plan_execute "$session_id"
+        write_runs_log_entry "$CLOSEDLOOP_WORKDIR" 3 completed plan_execute "$session_id"
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "session-id.txt").read_text() == "plan-session-123\n"
+    fields = (tmp_path / "runs.log").read_text().strip().split("|")
+    assert fields[0] == "run-plan-session"
+    assert fields[3] == "3"
+    assert fields[4] == "completed"
+    assert fields[5] == "plan_execute"
+    assert fields[6] == "plan-session-123"
+
+
+def test_code_review_session_capture_does_not_overwrite_primary_session(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "session-id.txt").write_text("plan-session-123\n")
+
+    result = run_bash(
+        f"""
+        source {RUN_LOOP}
+        output_file="$CLOSEDLOOP_WORKDIR/output.jsonl"
+        printf '%s\\n' '{{"type":"result","sessionId":"review-session-456"}}' > "$output_file"
+        session_id=$(extract_claude_session_id "$output_file")
+        RUN_ID='run-review-session'
+        record_claude_session_id "$CLOSEDLOOP_WORKDIR" code_review "$session_id"
+        write_runs_log_entry "$CLOSEDLOOP_WORKDIR" 3 review_approve code_review "$session_id"
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "session-id.txt").read_text() == "plan-session-123\n"
+    fields = (tmp_path / "runs.log").read_text().strip().split("|")
+    assert fields[0] == "run-review-session"
+    assert fields[4] == "review_approve"
+    assert fields[5] == "code_review"
+    assert fields[6] == "review-session-456"
+
+
+def test_code_review_log_with_no_session_does_not_backfill_plan_session(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "session-id.txt").write_text("plan-session-123\n")
+
+    result = run_bash(
+        f"""
+        source {RUN_LOOP}
+        output_file="$CLOSEDLOOP_WORKDIR/output.jsonl"
+        printf '%s\\n' '{{"type":"result","subtype":"error"}}' > "$output_file"
+        session_id=$(extract_claude_session_id "$output_file")
+        RUN_ID='run-review-empty-session'
+        write_runs_log_entry "$CLOSEDLOOP_WORKDIR" 3 review_error code_review "$session_id"
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    fields = (tmp_path / "runs.log").read_text().strip().split("|")
+    assert fields[0] == "run-review-empty-session"
+    assert fields[4] == "review_error"
+    assert fields[5] == "code_review"
+    assert fields[6] == ""

--- a/plugins/self-learning/.claude-plugin/plugin.json
+++ b/plugins/self-learning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "self-learning",
   "description": "Self-learning plugin",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/self-learning/README.md
+++ b/plugins/self-learning/README.md
@@ -197,7 +197,7 @@ Initializes the learning system directory structure for a new project or run.
 Cleans up old sessions, rotates large log files, and removes stale archived files according to `retention.yaml`. Respects active lock files and protects runs active within the last 30 minutes (configurable).
 
 **Reads:** `$CLOSEDLOOP_WORKDIR/.learnings/retention.yaml`
-**Operates on:** `sessions/`, `runs.log`, `outcomes.log`, `acknowledgments.log`, `pending/archived/`
+**Operates on:** `$WORKDIR/runs.log`, `.learnings/sessions/`, `.learnings/outcomes.log`, `.learnings/acknowledgments.log`, `.learnings/pending/archived/`
 
 ### `scripts/process-chat-learnings.sh`
 
@@ -336,20 +336,21 @@ python3 write_merged_patterns.py --merge-result /path/to/merge-result.json [--to
 ## Directory Structure
 
 ```
-$CLOSEDLOOP_WORKDIR/.learnings/
-  pending/               # Raw JSON learnings from agents (ephemeral)
-    archived/            # Processed pending files (pruned after max_archive_age_days)
-  sessions/              # Classified learning files per run (pruned after max_sessions)
-    run-{ID}/
-      iter-{N}.json
-  org-patterns.toon      # Shared pattern store (committed to version control)
-  goal.yaml              # Goal configuration (committed)
-  retention.yaml         # Pruning policy (committed)
-  outcomes.log           # Pattern application records (local only)
-  runs.log               # Run metadata (local only)
-  acknowledgments.log    # Agent acknowledgment records (local only)
-  goal-outcome.json      # Latest goal evaluation result (local only)
-  pending-closedloop.json # ClosedLoop-specific learnings pending export
+$CLOSEDLOOP_WORKDIR/
+  runs.log               # Run metadata: run_id|timestamp|goal|iteration|status[|command|last_session_id] (local only)
+  .learnings/
+    pending/             # Raw JSON learnings from agents (ephemeral)
+      archived/          # Processed pending files (pruned after max_archive_age_days)
+    sessions/            # Classified learning files per run (pruned after max_sessions)
+      run-{ID}/
+        iter-{N}.json
+    org-patterns.toon    # Shared pattern store (committed to version control)
+    goal.yaml            # Goal configuration (committed)
+    retention.yaml       # Pruning policy (committed)
+    outcomes.log         # Pattern application records (local only)
+    acknowledgments.log  # Agent acknowledgment records (local only)
+    goal-outcome.json    # Latest goal evaluation result (local only)
+    pending-closedloop.json # ClosedLoop-specific learnings pending export
 
 ~/.closedloop-ai/learnings/
   org-patterns.toon      # Global cross-project pattern store

--- a/plugins/self-learning/commands/goal-stats.md
+++ b/plugins/self-learning/commands/goal-stats.md
@@ -16,7 +16,10 @@ Analyzes goal performance by examining runs.log and outcomes.log to compute stat
 
 ## Process
 
-1. Read `runs.log` for run outcomes
+1. Read `runs.log` for run outcomes. Rows are pipe-delimited:
+   `run_id|timestamp|goal|iteration|status[|command|last_session_id]`.
+   Treat `command` and `last_session_id` as optional append-only fields so
+   legacy rows remain valid.
 2. Read `outcomes.log` for pattern applications and goal results
 3. Correlate pattern usage with goal success/failure
 4. Calculate aggregate statistics
@@ -60,7 +63,7 @@ Recommendations:
 
 ## Dependencies
 
-- `runs.log`: Contains run metadata with goal outcomes
+- `runs.log`: Contains run metadata with goal outcomes and optional command/session correlation
 - `outcomes.log`: Contains pattern applications with success tracking
 - `goal.yaml`: Defines active goal for filtering
 

--- a/plugins/self-learning/scripts/prune-learnings.sh
+++ b/plugins/self-learning/scripts/prune-learnings.sh
@@ -123,8 +123,10 @@ prune_sessions() {
     IFS=' ' read -r -a protected <<< "$(get_protected_runs)"
 
     # Get all session directories sorted by modification time (oldest first)
-    local -a all_sessions
-    mapfile -t all_sessions < <(ls -1t "$sessions_dir" 2>/dev/null | tac)
+    local -a all_sessions=()
+    while IFS= read -r session; do
+        all_sessions+=("$session")
+    done < <(ls -1tr "$sessions_dir" 2>/dev/null)
 
     local total=${#all_sessions[@]}
     local to_delete=$((total - MAX_SESSIONS))
@@ -216,7 +218,7 @@ clean_archived() {
 
 # Sync runs.log with existing sessions
 sync_runs_log() {
-    local runs_log="$LEARNINGS_DIR/runs.log"
+    local runs_log="$WORKDIR/runs.log"
     [[ -f "$runs_log" ]] || return 0
 
     local sessions_dir="$LEARNINGS_DIR/sessions"
@@ -265,7 +267,7 @@ main() {
     # Run pruning tasks
     prune_sessions
 
-    rotate_log "$LEARNINGS_DIR/runs.log"
+    rotate_log "$WORKDIR/runs.log"
     rotate_log "$LEARNINGS_DIR/outcomes.log"
     rotate_log "$LEARNINGS_DIR/acknowledgments.log"
 

--- a/plugins/self-learning/scripts/test_prune_learnings.py
+++ b/plugins/self-learning/scripts/test_prune_learnings.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("prune-learnings.sh")
+
+
+def test_prune_syncs_runs_log_from_workdir_root(tmp_path: Path) -> None:
+    workdir = tmp_path / "workdir"
+    (workdir / ".learnings" / "sessions" / "run-keep").mkdir(parents=True)
+    (workdir / "runs.log").write_text(
+        "keep|2026-05-05T00:00:00Z|reduce-failures|1|completed|plan_execute|session-1\n"
+        "drop|2026-05-05T00:00:00Z|reduce-failures|2|error|plan_execute|session-2\n"
+    )
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env={**os.environ, "CLOSEDLOOP_WORKDIR": str(workdir)},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (workdir / "runs.log").read_text() == (
+        "keep|2026-05-05T00:00:00Z|reduce-failures|1|completed|plan_execute|session-1\n"
+    )
+    assert not (workdir / ".learnings" / "runs.log").exists()

--- a/plugins/self-learning/tools/python/evaluate_goal.py
+++ b/plugins/self-learning/tools/python/evaluate_goal.py
@@ -22,8 +22,11 @@ except ImportError:
     sys.path.insert(0, str(Path(__file__).parent))
     from goal_config import load_goal_config, GoalConfig
 
-# Log format field indices
-RUNS_LOG_MIN_FIELDS = 4  # run_id|timestamp|goal_name|iteration|status
+# runs.log is append-only:
+# run_id|timestamp|goal_name|iteration|status[|command|last_session_id]
+# reduce-failures only needs run_id and iteration, so legacy 4+ field rows and
+# newer session-correlated rows are both accepted.
+RUNS_LOG_MIN_FIELDS = 4
 
 
 @dataclass
@@ -44,7 +47,7 @@ def evaluate_reduce_failures(config: GoalConfig, run_id: str, workdir: Path) -> 
     Success criteria: Complete in fewer iterations than target.
     Score: 1.0 - (iterations / (target * 2)), clamped to [0, 1]
     """
-    runs_log = workdir / '.learnings' / 'runs.log'
+    runs_log = workdir / 'runs.log'
 
     # Default values
     iterations = 10

--- a/plugins/self-learning/tools/python/test_evaluate_goal.py
+++ b/plugins/self-learning/tools/python/test_evaluate_goal.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from evaluate_goal import evaluate_minimize_tokens
+from evaluate_goal import evaluate_minimize_tokens, evaluate_reduce_failures
 from goal_config import GoalConfig
 
 
@@ -66,3 +66,20 @@ def test_ignores_repo_local_legacy_session_file(
 
     assert outcome.metrics["error"] == "session_file_not_found"
     assert outcome.score == 0.5
+
+
+def test_reduce_failures_reads_runs_log_from_workdir_root(tmp_path: Path) -> None:
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    (workdir / "runs.log").write_text(
+        "run-1|2026-05-05T00:00:00Z|reduce-failures|2|completed|plan_execute|session-1\n"
+    )
+
+    outcome = evaluate_reduce_failures(
+        GoalConfig(name="reduce-failures", success_criteria={"target": 3}),
+        "run-1",
+        workdir,
+    )
+
+    assert outcome.metrics["iterations"] == 2
+    assert outcome.success is True


### PR DESCRIPTION
- Archive run-loop Claude output per run and capture command-scoped Claude session ids
- Move runs.log to the workdir root and document append-only command/session fields
- Update self-learning pruning and goal evaluation for the root runs.log location

Testing: Focused run-loop and self-learning tests passed

Risks: Keeps legacy runs.log columns append-compatible and leaves primary session-id.txt scoped to plan_execute