### PR TITLE
Enable verification subagent messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 .env.*.local
 .ruff_cache/
 .venv/
+.codex/
 
 # Tests
 **/route-knowledge.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 #### Fixed
 - `run-loop.sh` now fails the loop when `max_iterations` is reached with zero successful iterations, emitting a `RUNNER_ERROR/MAX_ITERATIONS_NO_PROGRESS` user-visible failure and exiting with code 4. A new `successful_iterations` counter is incremented on non-empty results or `COMPLETE` promise detection, and `runs.log` entries gain an optional 8th field (`successful_iterations`) appended only on the max-iterations exit path — older readers that parse the leading 7 fields stay compatible. Covered by new `test_run_loop_failure_marker.py` cases for the no-progress failure path. Also isolates `test_reduce_failures_reads_runs_log_from_workdir_root` from the ambient `CLOSEDLOOP_ITERATION` env var so the test no longer depends on the caller's environment.
 
+#### Changed
+- `verification-subagent` now includes `SendMessage` in its allowed tools so verification flows can send follow-up messages while preserving the existing `Read`, `Glob`, and `Grep` inspection access.
+- Decision-table guidance now includes durable finalization and replay eligibility coverage for flows that persist local terminal state before external acknowledgement. The artifact-format, edge-case, and review-prevention references call out retryable finalization failures, acknowledgement cleanup, restart replay, and retained credential or marker data requirements.
+
 ### code v1.11.11
 
 #### Fixed

--- a/plugins/code/README.md
+++ b/plugins/code/README.md
@@ -265,7 +265,7 @@ Runs Codex to review a plan file and returns structured feedback with a verdict.
 
 ### `decision-table`
 
-Generates a repo-local decision-table artifact that makes control-flow and stateful edge cases reviewable. Used when the user wants a code-grounded table for current behavior, wants to compare current behavior against a plan or work item, or needs a control-flow artifact for recovery, retry, finalization, validation, state-machine, or review-heavy edge cases. Writes one artifact per work item under `.closedloop-ai/decision-tables/` (`<plan-id>.md` for plan-scoped work, `<short-work-name>.md` otherwise) using the format defined in `references/artifact-format.md`. Builds the `Current Code` table from code (not expectations), captures the target behavior in `Intended Change`, and freezes both once implementation begins; post-implementation drift is recorded in append-only `Verification Findings`, `Fixes Applied`, `Final Alignment Status`, and optional `Plan Clarifications` sections. Includes a behavioral edge-case expansion pass that explicitly models structured-result setup failures, library-managed lifecycle re-entry, time-bound credentials/signatures, diagnostic reason taxonomies, and side-effect boundaries for validation failures.
+Generates a repo-local decision-table artifact that makes control-flow and stateful edge cases reviewable. Used when the user wants a code-grounded table for current behavior, wants to compare current behavior against a plan or work item, or needs a control-flow artifact for recovery, retry, finalization, validation, state-machine, or review-heavy edge cases. Writes one artifact per work item under `.closedloop-ai/decision-tables/` (`<plan-id>.md` for plan-scoped work, `<short-work-name>.md` otherwise) using the format defined in `references/artifact-format.md`. Builds the `Current Code` table from code (not expectations), captures the target behavior in `Intended Change`, and freezes both once implementation begins; post-implementation drift is recorded in append-only `Verification Findings`, `Fixes Applied`, `Final Alignment Status`, and optional `Plan Clarifications` sections. Includes a behavioral edge-case expansion pass that explicitly models structured-result setup failures, library-managed lifecycle re-entry, time-bound credentials/signatures, durable finalization and replay eligibility, diagnostic reason taxonomies, and side-effect boundaries for validation failures.
 
 ---
 
@@ -311,6 +311,14 @@ Implements the validation loop for agents registered in `loop-agents.json`. When
 ### `pretooluse-hook.sh` (PreToolUse, matches Read/Bash/Write/Edit)
 
 Injects tool-specific learnings just before tool execution. Filters `org-patterns.toon` by tool type (Bash patterns get build/test tags; Write/Edit patterns get language-specific tags based on file extension). Injects up to 10 matching patterns as `additionalContext`. Also auto-allows tool calls targeting `.closedloop-ai/` workspace paths without prompting.
+
+### `pre-tool-use-hook.sh` (PreToolUse)
+
+Writes per-tool-call sentinel files to `{WORKDIR}/.tool-calls/` so post-tool handling can compute duration and attribution. Emits `spawn` perf events for `Agent` tool calls. Registered separately from `pretooluse-hook.sh` and designed to fail open.
+
+### `post-tool-use-hook.sh` (PostToolUse)
+
+Reads sentinels written by `pre-tool-use-hook.sh`, computes tool-call duration, appends `tool` events to `perf.jsonl`, and emits additional `skill` events for `Skill` tool calls. Deletes the sentinel after successful emission and fails open on internal errors.
 
 ### `plan-review.sh` (not currently registered in `hooks.json`)
 

--- a/plugins/code/agents/verification-subagent.md
+++ b/plugins/code/agents/verification-subagent.md
@@ -2,7 +2,7 @@
 name: verification-subagent
 description: Verifies if a task from the implementation plan has been completed by checking source files.
 model: sonnet
-tools: Read, Glob, Grep
+tools: Read, Glob, Grep, SendMessage
 ---
 
 # Verification Subagent

--- a/plugins/code/skills/decision-table/references/artifact-format.md
+++ b/plugins/code/skills/decision-table/references/artifact-format.md
@@ -30,6 +30,7 @@ Apply every category in [`edge-cases.md`](edge-cases.md). Each must be represent
 - Structured-result setup failures: <rows or non-applicability note>
 - Library-managed lifecycle re-entry: <rows or non-applicability note>
 - Time-bound credentials/signatures: <rows or non-applicability note>
+- Durable finalization and replay eligibility: <rows or non-applicability note>
 - Diagnostic reason/category taxonomy: <rows or non-applicability note>
 - Side-effect boundaries for validation/preparation failures: <rows or non-applicability note>
 - ... (continue with every category from `edge-cases.md`)

--- a/plugins/code/skills/decision-table/references/edge-cases.md
+++ b/plugins/code/skills/decision-table/references/edge-cases.md
@@ -62,6 +62,14 @@ When a flow deletes, consumes, rotates, invalidates, acknowledges, commits, uplo
 
 Require parity rows for invalid and dependency-failure branches, not only valid or happy-path branches.
 
+## Durable finalization and replay eligibility
+
+When a flow writes local terminal state and separately posts, uploads, acknowledges, or finalizes external terminal state, include rows for: before local terminal persistence, after local persistence but before external acknowledgement, retryable external failure, non-retryable external failure, successful external acknowledgement, and recovery/replay after restart.
+
+State which durable fields make the item eligible or ineligible for recovery, which credentials, tokens, signatures, secrets, locks, or marker data must be retained until acknowledgement, which cleanup runs only after acknowledgement, and whether replay emits the same user-visible status, code, message, result, diagnostics, and warning semantics as the live path.
+
+**Tests:** require at least one retryable external failure after local terminal persistence, one successful acknowledgement cleanup path, and one recovery/replay assertion that proves the same terminal user-visible outcome is posted.
+
 ## Shared durable resources
 
 When deleting, rotating, revoking, or clearing persisted keys, credentials, locks, cache entries, files, profiles, identities, or other durable resources, include rows for: no remaining references, another saved/profile reference, active runtime reference, stale reference, and unknown lookup failure. State whether the resource is reference-counted, ownership-scoped, shared, or safe to delete unconditionally.

--- a/plugins/code/skills/decision-table/references/review-prevention.md
+++ b/plugins/code/skills/decision-table/references/review-prevention.md
@@ -24,6 +24,7 @@ For every item: fix it, mark it already covered by a named row/test, mark not ap
 16. **Adapter-variant error metadata mismatch** where code maps a dependency or database error by only one metadata shape even though the dependency may report an equivalent signal as a constraint name, field array, column array, structured object, missing metadata, or legacy/unknown value.
 17. **Existing-data migration blocker** where a new unique constraint or stricter persisted invariant assumes all existing rows already satisfy the invariant instead of cleaning, backfilling, or explicitly preflighting violating rows before the constraint is created.
 18. **Cleanup-induced adjacent constraint failure** where a migration repair satisfies the new invariant but leaves stale identity, reference, or preference state that makes the next normal application update fail on another constraint.
+19. **Terminal local state not recoverable after external finalization failure** where a job, event, marker, status, or artifact is persisted locally but the external post, upload, acknowledgement, or finalization fails, and recovery cannot replay it because eligibility fields are missing or required credentials, tokens, signatures, secrets, locks, or marker data were deleted.
 
 ## Contract-Heavy Review Surface
 
@@ -39,6 +40,7 @@ For contract-heavy work, also explicitly review:
 - replay and continuation paths, including conflict replays, retry callbacks, confirmation callbacks, and deferred command callbacks, that must enforce the same gate or policy as the original entry path
 - owner-keyed pending/loading/disabled UI whose observable state must be scoped to the current owner, command, document, target, or attempt instead of unrelated active work
 - terminal-state guards that fail to preserve approved/denied/expired/consumed/completed/cancelled/revoked/failed state when a later or repeated action arrives
+- terminal local state whose external finalization fails after persistence but before acknowledgement, leaving recovery unable to replay the same user-visible terminal outcome
 - retries or replays that reuse resources after delete/consume/rotate/invalidate/acknowledge/commit/upload/lock side effects
 - payload fields whose omitted, `undefined`, `null`, empty, and explicit values are semantically distinct at the next boundary
 - destructive cleanup that deletes a shared durable resource still referenced by another profile, active runtime identity, fallback identity, retry path, or recovery path


### PR DESCRIPTION
- Add SendMessage to the verification-subagent allowed tools. This allows the agent to participate in agent-teams
- Document durable finalization replay guidance in the decision-table skill

Testing: Ran git diff --check

Risks: Low; agent metadata and documentation-only changes