### PR TITLE
PLN-523: Gate rate_limit_signal on isUsingOverage and refactor envelope matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code v1.11.13
+
+#### Fixed
+- `rate_limit_signal` in `run-loop.sh`'s `detect_claude_terminal_failure` now requires `rate_limit_info.isUsingOverage == true` before a non-`allowed` `overageStatus` counts as a rate-limit failure. Prevents false positives when the org is not actually consuming overage capacity but `overageStatus` is still populated. The `status != allowed`, `status_429`, and error-string match paths remain unchanged, so existing true-positive detection is preserved.
+
+#### Changed
+- Refactored repeated `is_error` / `isApiErrorMessage` envelope-string matching across `rate_limit_signal`, `context_limit_signal`, and `auth_challenge_signal` into a single shared `envelope_text_match(pat)` jq helper. Three near-identical predicate definitions collapse to one helper invocation each — same behavior, less duplication.
+- Removed dead jq helpers (`user_texts`, `error_texts`, `text_blob`, `first_user_text`, `first_error_text`, `error_shaped`) left over from the wider matching scheme that was scoped down in the v1.11.11 source-attribution fix.
+- Expanded `test_rate_limit_event_predicate` parametrization to cover `isUsingOverage` true/false/missing variants, malformed payloads, and bug-reproduction cases (RL-01..RL-17, RL-X2, RL-X4) so the new gating condition is exercised end-to-end.
+
 ### code v1.11.12
 
 #### Fixed

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.11.11",
+  "version": "1.11.12",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.11.12",
+  "version": "1.11.13",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -233,27 +233,8 @@ detect_claude_terminal_failure() {
       def clamp_message:
         if length > 900 then .[0:900] + "..." else . end;
 
-      def user_texts:
-        [
-          (.result? | strings),
-          (.message.content[]?.text? | strings),
-          (.message.content? | strings)
-        ];
-
       def error_string:
         if (.error? | type) == "string" then .error else "" end;
-
-      def error_texts:
-        [error_string | select(length > 0)];
-
-      def text_blob:
-        (user_texts + error_texts) | join("\n");
-
-      def first_user_text($entries):
-        [$entries[] | user_texts[] | select(length > 0)] | .[0] // "";
-
-      def first_error_text($entries):
-        [$entries[] | error_texts[] | select(length > 0)] | .[0] // "";
 
       def rate_event_message($entries):
         [
@@ -270,32 +251,27 @@ detect_claude_terminal_failure() {
         ((.api_error_status? | tostring) == "429")
         or ((.apiErrorStatus? | tostring) == "429");
 
-      def error_shaped:
-        (.is_error? == true)
-        or (.isApiErrorMessage? == true)
-        or (.subtype? == "error")
-        or ((error_string | length) > 0);
+      def envelope_text_match(pat):
+        ((.is_error? == true) and ((.result? | strings | test(pat; "i")) // false))
+        or ((.isApiErrorMessage? == true) and ((.error? | strings | test(pat; "i")) // false));
 
       def rate_limit_signal:
         ((.type? == "rate_limit_event") and (
           (.rate_limit_info? | type) == "object"
           and (
             ((.rate_limit_info.status? // null) != null and (.rate_limit_info.status? != "allowed"))
-            or ((.rate_limit_info.overageStatus? // null) != null and (.rate_limit_info.overageStatus? != "allowed"))
+            or ((.rate_limit_info.isUsingOverage? == true) and ((.rate_limit_info.overageStatus? // null) != null and (.rate_limit_info.overageStatus? != "allowed")))
           )
         ))
         or (error_string | ascii_downcase | test("^rate_limit(_error)?$"))
         or status_429
-        or ((.is_error? == true) and ((.result? | strings | test("you.?ve hit your limit|usage limit|rate[_ -]?limit|rate limit reached"; "i")) // false))
-        or ((.isApiErrorMessage? == true) and ((.error? | strings | test("you.?ve hit your limit|usage limit|rate[_ -]?limit|rate limit reached"; "i")) // false));
+        or envelope_text_match("you.?ve hit your limit|usage limit|rate[_ -]?limit|rate limit reached");
 
       def context_limit_signal:
-        ((.is_error? == true) and ((.result? | strings | test("prompt is too long|exceed context limit|context limit reached|conversation too long"; "i")) // false))
-        or ((.isApiErrorMessage? == true) and ((.error? | strings | test("prompt is too long|exceed context limit|context limit reached|conversation too long"; "i")) // false));
+        envelope_text_match("prompt is too long|exceed context limit|context limit reached|conversation too long");
 
       def auth_challenge_signal:
-        ((.is_error? == true) and ((.result? | strings | test("authentication_error|invalid bearer token|billing_error|permission_error|overloaded_error|api overloaded|unauthorized|token.*expired|not authenticated|please log in|login required"; "i")) // false))
-        or ((.isApiErrorMessage? == true) and ((.error? | strings | test("authentication_error|invalid bearer token|billing_error|permission_error|overloaded_error|api overloaded|unauthorized|token.*expired|not authenticated|please log in|login required"; "i")) // false));
+        envelope_text_match("authentication_error|invalid bearer token|billing_error|permission_error|overloaded_error|api overloaded|unauthorized|token.*expired|not authenticated|please log in|login required");
 
       def entry_message:
         ((.result? | strings) // (.error? | strings) // "");

--- a/plugins/code/tools/python/test_run_loop_failure_marker.py
+++ b/plugins/code/tools/python/test_run_loop_failure_marker.py
@@ -729,37 +729,60 @@ def test_code_review_log_with_no_session_does_not_backfill_plan_session(
 
 
 @pytest.mark.parametrize(
-    "status,overage,expected_subcode",
+    "test_id,status,overage,using_overage,extra_info,expected_subcode",
     [
-        ("allowed", "allowed", None),                # benign single heartbeat
-        (None, None, None),                          # malformed → fail-open
-        ("exceeded", "allowed", "CLAUDE_RATE_LIMIT"),
-        ("allowed", "exceeded", "CLAUDE_RATE_LIMIT"),
-        ("paused", "allowed", "CLAUDE_RATE_LIMIT"),  # any non-allowed
+        ("RL-01-bug-repro",                       "allowed",   "rejected", False, {},                                              None),
+        ("RL-02-bug-repro-with-reason",           "allowed",   "rejected", False, {"overageDisabledReason": "org_level_disabled"}, None),
+        ("RL-03-benign-heartbeat",                "allowed",   "allowed",  False, {},                                              None),
+        ("RL-04-benign-no-overage-fields",        "allowed",   None,       None,  {},                                              None),
+        ("RL-05-status-exceeded",                 "exceeded",  "allowed",  False, {},                                              "CLAUDE_RATE_LIMIT"),
+        ("RL-06-status-paused",                   "paused",    "allowed",  False, {},                                              "CLAUDE_RATE_LIMIT"),
+        ("RL-07-status-throttled",                "throttled", "allowed",  False, {},                                              "CLAUDE_RATE_LIMIT"),
+        ("RL-08-overage-actually-rejected",       "allowed",   "rejected", True,  {},                                              "CLAUDE_RATE_LIMIT"),
+        ("RL-09-overage-actually-exceeded",       "allowed",   "exceeded", True,  {},                                              "CLAUDE_RATE_LIMIT"),
+        ("RL-10-overage-rejected-flag-absent",    "allowed",   "rejected", None,  {},                                              None),
+        ("RL-11-overage-rejected-flag-string-true", "allowed", "rejected", "true", {},                                             None),
+        ("RL-14-both-status-and-overage-bad",     "exceeded",  "rejected", False, {},                                              "CLAUDE_RATE_LIMIT"),
+        ("RL-15-both-bad-with-overage-on",        "exceeded",  "rejected", True,  {},                                              "CLAUDE_RATE_LIMIT"),
+        ("RL-16-malformed-both-missing",          None,        None,       None,  {},                                              None),
+        ("RL-17-overage-exceeded-no-flag",        "allowed",   "exceeded", None,  {},                                              None),
     ],
+    ids=lambda v: v if isinstance(v, str) else None,
 )
-def test_rate_limit_event_status_dispatch(
+def test_rate_limit_event_predicate(
     tmp_path: Path,
+    test_id: str,
     status: str | None,
     overage: str | None,
+    using_overage: bool | str | None,
+    extra_info: dict,
     expected_subcode: str | None,
 ) -> None:
-    info: dict[str, object] = {"rateLimitType": "five_hour", "resetsAt": 1778095200}
+    info: dict[str, object] = {"rateLimitType": "five_hour", "resetsAt": 1778266200, **extra_info}
     if status is not None:
         info["status"] = status
     if overage is not None:
         info["overageStatus"] = overage
+    if using_overage is not None:
+        info["isUsingOverage"] = using_overage
 
     payload = run_detect(
         tmp_path,
-        jsonl=[{"type": "rate_limit_event", "rate_limit_info": info}],
+        jsonl=[{
+            "type": "rate_limit_event",
+            "rate_limit_info": info,
+            "uuid": "9fc896e0-250f-40f4-9022-dfca49a7498f",
+            "session_id": "c80d0b89-7efe-403c-8e7d-439702b89aff",
+        }],
     )
 
     if expected_subcode is None:
-        assert payload == {}
+        assert payload == {}, f"{test_id}: expected no failure, got {payload!r}"
     else:
-        assert payload["status"] == "claude_rate_limit"
-        assert payload["subcode"] == expected_subcode
+        assert payload.get("status")  == "claude_rate_limit",  f"{test_id}: status mismatch"
+        assert payload.get("subcode") == expected_subcode,     f"{test_id}: subcode mismatch"
+        assert "Claude rate limit reached" in payload.get("message", ""), \
+            f"{test_id}: message must mention rate limit"
 
 
 @pytest.mark.parametrize(
@@ -1043,6 +1066,81 @@ def test_context_limit_prose_in_error_with_isapierrormessage_triggers(
     assert payload["status"] == "context_limit"
     assert payload["subcode"] == "CLAUDE_CONTEXT_LIMIT"
     assert "Prompt is too long" in payload["message"]
+
+
+def test_rate_limit_event_malformed_info_null(tmp_path: Path) -> None:
+    """RL-12: rate_limit_info: null → predicate must not fire."""
+    payload = run_detect(
+        tmp_path,
+        jsonl=[{"type": "rate_limit_event", "rate_limit_info": None}],
+    )
+    assert payload == {}
+
+
+def test_rate_limit_event_malformed_info_missing(tmp_path: Path) -> None:
+    """RL-13: rate_limit_event with no rate_limit_info key → predicate must not fire."""
+    payload = run_detect(
+        tmp_path,
+        jsonl=[{"type": "rate_limit_event"}],
+    )
+    assert payload == {}
+
+
+def test_overage_rejected_message_sources_from_event(tmp_path: Path) -> None:
+    """RL-08 detail: when overage is actually rejected, the message must mention rate limit
+    and include the rate event metadata (rateLimitType, resetsAt) — sourced via rate_event_message."""
+    payload = run_detect(
+        tmp_path,
+        jsonl=[{
+            "type": "rate_limit_event",
+            "rate_limit_info": {
+                "status": "allowed",
+                "overageStatus": "rejected",
+                "isUsingOverage": True,
+                "rateLimitType": "five_hour",
+                "resetsAt": 1778266200,
+            },
+        }],
+    )
+    assert payload["subcode"] == "CLAUDE_RATE_LIMIT"
+    assert "five_hour" in payload["message"]
+    assert "1778266200" in payload["message"]
+
+
+def test_rl_x2_isapierrormessage_rate_limit_error_without_429(tmp_path: Path) -> None:
+    """RL-X2: isApiErrorMessage + error:"rate_limit_error" without apiErrorStatus:429.
+
+    The isApiErrorMessage branch of rate_limit_signal must fire on the bare
+    error string alone, independently of whether apiErrorStatus:429 is present.
+    This isolates the error_string pattern match inside the isApiErrorMessage
+    envelope from the status_429 branch.
+    """
+    payload = run_detect(
+        tmp_path,
+        jsonl=[{
+            "type": "assistant",
+            "isApiErrorMessage": True,
+            "error": "rate_limit_error",
+        }],
+    )
+    assert payload["status"] == "claude_rate_limit"
+    assert payload["subcode"] == "CLAUDE_RATE_LIMIT"
+
+
+def test_rl_x4_bare_error_string_rate_limit(tmp_path: Path) -> None:
+    """RL-X4: bare {"error":"rate_limit"} entry with no envelope flags.
+
+    The error_string branch of rate_limit_signal (matching ^rate_limit(_error)?$)
+    must fire on a JSONL entry that carries only the error key, with no
+    isApiErrorMessage, is_error, or apiErrorStatus fields present.
+    This isolates the error_string branch standalone.
+    """
+    payload = run_detect(
+        tmp_path,
+        jsonl=[{"error": "rate_limit"}],
+    )
+    assert payload["status"] == "claude_rate_limit"
+    assert payload["subcode"] == "CLAUDE_RATE_LIMIT"
 
 
 def test_rename_orphan_output_on_start_skips_when_state_workdir_mismatches(

--- a/plugins/self-learning/tools/python/test_evaluate_goal.py
+++ b/plugins/self-learning/tools/python/test_evaluate_goal.py
@@ -76,9 +76,6 @@ def test_reduce_failures_reads_runs_log_from_workdir_root(
         "run-1|2026-05-05T00:00:00Z|reduce-failures|2|completed|plan_execute|session-1\n"
     )
 
-    # Clear CLOSEDLOOP_ITERATION env var to isolate test of runs.log reading
-    monkeypatch.delenv("CLOSEDLOOP_ITERATION", raising=False)
-
     outcome = evaluate_reduce_failures(
         GoalConfig(name="reduce-failures", success_criteria={"target": 3}),
         "run-1",

--- a/plugins/self-learning/tools/python/test_evaluate_goal.py
+++ b/plugins/self-learning/tools/python/test_evaluate_goal.py
@@ -68,12 +68,15 @@ def test_ignores_repo_local_legacy_session_file(
     assert outcome.score == 0.5
 
 
-def test_reduce_failures_reads_runs_log_from_workdir_root(tmp_path: Path) -> None:
+def test_reduce_failures_reads_runs_log_from_workdir_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     workdir = tmp_path / "workdir"
     workdir.mkdir()
     (workdir / "runs.log").write_text(
         "run-1|2026-05-05T00:00:00Z|reduce-failures|2|completed|plan_execute|session-1\n"
     )
+
+    # Clear CLOSEDLOOP_ITERATION env var to isolate test of runs.log reading
+    monkeypatch.delenv("CLOSEDLOOP_ITERATION", raising=False)
 
     outcome = evaluate_reduce_failures(
         GoalConfig(name="reduce-failures", success_criteria={"target": 3}),


### PR DESCRIPTION
## Summary

Tightens the `rate_limit_signal` predicate in `detect_claude_terminal_failure` (plugins/code/scripts/run-loop.sh) and refactors the jq envelope-text matching to remove duplication. Continues the scoping work begun in 873ea8d.

### What changed

- **`envelope_text_match` helper.** Extracts the shared `(is_error AND result.text matches) OR (isApiErrorMessage AND error.text matches)` shape into a single jq function, applied across `rate_limit_signal`, `context_limit_signal`, and `auth_challenge_signal`.
- **`isUsingOverage` gate on rate_limit_signal.** A non-allowed `overageStatus` no longer fires by itself. The signal now requires `isUsingOverage == true` alongside the non-allowed status, preventing false positives when an org reports overage metadata but isn't actually consuming overage capacity. The `status != "allowed"` branch, the `^rate_limit(_error)?$` error-string branch, and the 429 branch are unchanged.
- **Dead-code cleanup.** Removes unused jq helpers (`user_texts`, `error_texts`, `text_blob`, `first_user_text`, `first_error_text`, `error_shaped`) that were left over from the previous, wider matching scheme.
- **Tests.** `test_rate_limit_event_predicate` expands from 5 to 15 parametrized cases (RL-01..RL-17), covering `isUsingOverage` variants (bool, string, missing), malformed payloads, and the previously-misfiring bug repro. Adds standalone tests RL-12, RL-13, RL-X2, RL-X4 for cases that don't fit the parametrize matrix, plus `test_overage_rejected_message_sources_from_event` to verify the rate-event metadata propagates into the failure message.
- **Test isolation.** `test_reduce_failures_reads_runs_log_from_workdir_root` now clears `CLOSEDLOOP_ITERATION` to prevent env-var leakage between tests.
- **Version bump.** `plugins/code` → `1.11.12` (PATCH; bug-fix scope).

### Why

A previous report observed the loop terminating with `claude_rate_limit` on heartbeat events where the org had `overageStatus: "rejected"` but `isUsingOverage: false` — meaning the org-level overage was disabled but not actually being hit. The predicate has now been narrowed to only fire when the overage is genuinely in use.

### Test plan

- [x] `pytest plugins/code/tools/python/test_run_loop_failure_marker.py` — all parametrized + standalone rate-limit cases pass
- [x] `pytest plugins/self-learning/tools/python/test_evaluate_goal.py` — env-var isolation fix verified
- [x] No changes to `status_429`, `auth_challenge_signal`, or `context_limit_signal` semantics — only refactored to use the shared helper

### Risks

None identified. The change narrows the predicate (removes false positives) without altering the known true-positive paths.

---
Loop ID: 019e080f-fc38-748c-bdcf-cda3935f566b
Artifact: https://app.closedloop.ai/implementation-plans/PLN-523
