### PR TITLE
PLN-539: Add slash command telemetry instrumentation

### DIFF
--- a/plugins/bootstrap/.claude-plugin/plugin.json
+++ b/plugins/bootstrap/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap",
   "description": "Bootstrap plugin for ClosedLoop",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/bootstrap/commands/agent-bootstrap.md
+++ b/plugins/bootstrap/commands/agent-bootstrap.md
@@ -82,6 +82,14 @@ Instead of fragile heuristics trying to detect "React + Next.js + Zustand", we:
 - Architecture agents: `postgresql-expert`, `react-component-architect`, etc.
 - Domain specialists: `caching-strategist`, `auth-security-expert`, etc.
 
+## Startup
+
+Before doing anything else, initialise telemetry:
+
+```bash
+source "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh" "agent-bootstrap"
+```
+
 ## Workflow Phases
 
 The bootstrap process runs through 8 phases:
@@ -266,6 +274,14 @@ Bootstrap handles failures gracefully:
 - Transient failures
 
 All errors reported in `bootstrap-report.md` with recommendations for resolution.
+
+## Completion
+
+After all phases are done and bootstrap-report.md is written, run telemetry completion:
+
+```bash
+bash "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh"
+```
 
 ## Next Steps
 

--- a/plugins/bootstrap/scripts/command-telemetry-complete.sh
+++ b/plugins/bootstrap/scripts/command-telemetry-complete.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# command-telemetry-complete.sh — Telemetry finaliser for slash commands.
+#
+# Designed to be called (not sourced) by command markdown files at the end of
+# a command run to emit a `command_complete` event to perf.jsonl.
+#
+# Usage:
+#   bash "${CLAUDE_PLUGIN_ROOT}/scripts/command-telemetry-complete.sh" [exit_status]
+#
+# Arguments:
+#   $1  EXIT_STATUS (optional, default: 0) — the exit status of the command
+#
+# Environment variables consumed (set by command-telemetry-init.sh):
+#   CLOSEDLOOP_START_TIME  — unix epoch when the command started (required for duration)
+#   CLOSEDLOOP_RUN_ID      — unique run identifier
+#   CLOSEDLOOP_WORKDIR     — working directory for perf.jsonl output
+#   CLOSEDLOOP_COMMAND     — slash command name
+#
+# Fail-open guarantee: the entire finalisation is wrapped in a trap so any
+# error is suppressed and the calling command continues unaffected.
+
+# Fail open: any unexpected error exits 0 so the calling command is unaffected.
+trap 'exit 0' ERR
+
+_closedloop_telemetry_complete() {
+  local exit_status="${1:-0}"
+
+  # Resolve working directory. The matching command-telemetry-init.sh exports
+  # CLOSEDLOOP_WORKDIR, but those exports are scoped to the shell that ran
+  # `source` and do not survive across separate Bash tool invocations. When
+  # the env var is unset, fall back to the default workdir init.sh uses
+  # (.closedloop-ai/telemetry) only if a state file exists there — otherwise
+  # the command was never initialised and there is nothing to finalise.
+  local workdir="${CLOSEDLOOP_WORKDIR:-}"
+  if [[ -z "$workdir" ]]; then
+    if [[ -f ".closedloop-ai/telemetry/.cmd-state.env" ]]; then
+      workdir=".closedloop-ai/telemetry"
+    else
+      return 0
+    fi
+  fi
+
+  # If RUN_ID is missing, recover the run context that init.sh persisted to
+  # disk. This bridges the gap between separate Bash tool invocations: init
+  # exported env vars but they died with its source shell.
+  local state_file="$workdir/.cmd-state.env"
+  if [[ -z "${CLOSEDLOOP_RUN_ID:-}" && -f "$state_file" ]]; then
+    # shellcheck source=/dev/null
+    source "$state_file" 2>/dev/null || true
+    workdir="${CLOSEDLOOP_WORKDIR:-$workdir}"
+  fi
+
+  local perf_file="$workdir/perf.jsonl"
+
+  # Capture end time
+  local end_epoch
+  end_epoch=$(date +%s 2>/dev/null) || end_epoch=""
+  local ended_at
+  ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || ended_at=""
+
+  # Resolve start time and calculate duration
+  local start_epoch="${CLOSEDLOOP_START_TIME:-}"
+  local started_at=""
+  local duration_s=0
+
+  if [[ -n "$start_epoch" && -n "$end_epoch" ]]; then
+    duration_s=$(( end_epoch - start_epoch ))
+    # Convert start epoch to ISO-8601 timestamp
+    started_at=$(date -u -r "$start_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+      || started_at=$(date -u -d "@$start_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+      || started_at=""
+  fi
+
+  local run_id="${CLOSEDLOOP_RUN_ID:-unknown}"
+  local command="${CLOSEDLOOP_COMMAND:-interactive}"
+
+  # Ensure perf.jsonl directory exists
+  mkdir -p "$(dirname "$perf_file")" 2>/dev/null || true
+
+  # Build and emit the command_complete JSONL event, injecting command: field
+  # to match the pattern used by emit_perf_event in telemetry-helpers.sh
+  jq -n -c \
+    --arg event "command_complete" \
+    --arg run_id "$run_id" \
+    --arg command "$command" \
+    --arg started_at "$started_at" \
+    --arg ended_at "$ended_at" \
+    --argjson duration_s "$duration_s" \
+    --argjson exit_status "$exit_status" \
+    '{event:$event,run_id:$run_id,command:$command,started_at:$started_at,ended_at:$ended_at,duration_s:$duration_s,exit_status:$exit_status}' \
+    >> "$perf_file" 2>/dev/null || true
+
+  # Drop the recovered state file so stale state cannot leak into a later
+  # command that fails to call init.sh.
+  rm -f "$state_file" 2>/dev/null || true
+}
+
+_closedloop_telemetry_complete "$@"
+exit 0

--- a/plugins/bootstrap/scripts/command-telemetry-init.sh
+++ b/plugins/bootstrap/scripts/command-telemetry-init.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# command-telemetry-init.sh — Telemetry initialiser for slash commands.
+#
+# Designed to be SOURCED (not executed) by command markdown files at startup
+# so that the exported env vars remain visible to subsequent steps in the same
+# Claude Code session:
+#
+#   source "${CLAUDE_PLUGIN_ROOT}/scripts/command-telemetry-init.sh" <command-name> [workdir]
+#
+# Arguments:
+#   $1  COMMAND_NAME (required) — the slash-command name, e.g. "code", "amend-plan"
+#   $2  WORKDIR       (optional) — overrides env var and default
+#
+# Precedence for CLOSEDLOOP_WORKDIR:
+#   1. $2 argument
+#   2. CLOSEDLOOP_WORKDIR env var (already set by the caller / parent loop)
+#   3. Default: .closedloop-ai/telemetry/ (relative to cwd)
+#
+# Fail-open guarantee: the entire initialisation is wrapped in a function.
+# Any error inside that function is caught and suppressed so the calling
+# command continues normally.
+
+_closedloop_telemetry_init() {
+  local command_name="${1:-}"
+  local workdir_arg="${2:-}"
+
+  # Argument validation — COMMAND_NAME is required
+  if [[ -z "$command_name" ]]; then
+    return 0
+  fi
+
+  # Resolve CLOSEDLOOP_WORKDIR
+  local workdir
+  if [[ -n "$workdir_arg" ]]; then
+    workdir="$workdir_arg"
+  elif [[ -n "${CLOSEDLOOP_WORKDIR:-}" ]]; then
+    workdir="$CLOSEDLOOP_WORKDIR"
+  else
+    workdir=".closedloop-ai/telemetry"
+  fi
+
+  # Generate CLOSEDLOOP_RUN_ID (same format as run-loop.sh: timestamp + 4-byte hex)
+  local timestamp
+  timestamp=$(date +%Y%m%d-%H%M%S 2>/dev/null) || timestamp="00000000-000000"
+  local random_suffix
+  random_suffix=$(head -c 4 /dev/urandom 2>/dev/null | xxd -p 2>/dev/null) || random_suffix="00000000"
+  local run_id="${timestamp}-${random_suffix}"
+
+  # Capture start time as unix epoch (for duration calculation in complete script)
+  local start_epoch
+  start_epoch=$(date +%s 2>/dev/null) || start_epoch=""
+
+  # Export env vars for the session
+  export CLOSEDLOOP_WORKDIR="$workdir"
+  export CLOSEDLOOP_RUN_ID="$run_id"
+  export CLOSEDLOOP_COMMAND="$command_name"
+  export CLOSEDLOOP_START_TIME="$start_epoch"
+
+  # Persist state to disk so command-telemetry-complete.sh can recover the run
+  # context when it runs in a separate Bash tool invocation (the export above
+  # only affects the shell that ran `source`).
+  mkdir -p "$workdir" 2>/dev/null || true
+  {
+    printf 'CLOSEDLOOP_WORKDIR=%s\n' "$workdir"
+    printf 'CLOSEDLOOP_RUN_ID=%s\n' "$run_id"
+    printf 'CLOSEDLOOP_COMMAND=%s\n' "$command_name"
+    printf 'CLOSEDLOOP_START_TIME=%s\n' "$start_epoch"
+  } > "$workdir/.cmd-state.env" 2>/dev/null || true
+
+  # Call record_run.sh — locate it relative to this script
+  local scripts_dir
+  scripts_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || scripts_dir=""
+  if [[ -n "$scripts_dir" && -f "$scripts_dir/record_run.sh" ]]; then
+    bash "$scripts_dir/record_run.sh" "$workdir" || true
+  fi
+}
+
+# Invoke with fail-open: any error is suppressed so the calling command
+# continues unaffected.
+_closedloop_telemetry_init "$@" || true

--- a/plugins/bootstrap/scripts/record_run.sh
+++ b/plugins/bootstrap/scripts/record_run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# record_run.sh - Append a run event to perf.jsonl once per Loop.
+#
+# Emits exactly one `run` event containing command, repo, branch, and start
+# time so every perf.jsonl record can be attributed to the slash-command that
+# launched the Loop. Fails open (exits 0) on any error so the caller loop is
+# unaffected.
+#
+# Usage:
+#   bash record_run.sh [WORKDIR]
+# WORKDIR defaults to $CLOSEDLOOP_WORKDIR.
+
+# Fail open: any unexpected error exits 0 so the caller loop is unaffected.
+trap 'exit 0' ERR
+
+WORKDIR="${1:-${CLOSEDLOOP_WORKDIR:-}}"
+if [[ -z "$WORKDIR" ]]; then
+  exit 0
+fi
+
+PERF_FILE="$WORKDIR/perf.jsonl"
+
+RUN_ID="${CLOSEDLOOP_RUN_ID:-unknown}"
+COMMAND="${CLOSEDLOOP_COMMAND:-interactive}"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+
+# Capture repo and branch via git -C. Prefer GNU `timeout` as a hang guard, but
+# fall back to bare `git` when timeout isn't installed (default macOS lacks it),
+# so this never silently drops repo/branch attribution on dev machines.
+if command -v timeout >/dev/null 2>&1; then
+  REPO=$(timeout 5 git -C "$WORKDIR" remote get-url origin 2>/dev/null || echo "")
+  BRANCH=$(timeout 5 git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+else
+  REPO=$(git -C "$WORKDIR" remote get-url origin 2>/dev/null || echo "")
+  BRANCH=$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+fi
+
+mkdir -p "$(dirname "$PERF_FILE")"
+
+jq -n -c \
+  --arg event "run" \
+  --arg run_id "$RUN_ID" \
+  --arg command "$COMMAND" \
+  --arg started_at "$TIMESTAMP" \
+  --arg repo "$REPO" \
+  --arg branch "$BRANCH" \
+  '{event:$event,run_id:$run_id,command:$command,started_at:$started_at,repo:$repo,branch:$branch}' \
+  >> "$PERF_FILE"
+
+exit 0

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "1.5.5",
+  "version": "1.5.7",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -46,6 +46,11 @@ When a task says "Run Bash:", execute the command in a single Bash tool call.
 
 Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e.g., `<HELPERS>`, `<CR_DIR>`, `<CACHE_DIR>`, `<DIFF_SCOPE>`) to mark values you must replace with the resolved literal string before running the command. These are NOT shell variables — they are template tokens. The only real env var is `${CLAUDE_PLUGIN_ROOT}` (resolved once in session setup).
 
+**Before Task 1**, initialise telemetry (always first):
+```bash
+source "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh" "code-review"
+```
+
 ### Task 1: Parse flags and detect mode
 - Parse `$ARGUMENTS` for `--github`, `--hygiene-only`, `--base <ref>`, `--since-last-review`, `--full-review`
 - Check flag incompatibilities — exit with error if any
@@ -1256,6 +1261,16 @@ python3 <HELPERS> verdict --validate-output <CR_DIR>/validate_output.json > <CR_
 ```
 
 Read `<CR_DIR>/verdict.json` and print the `tag` value as the absolute last line of output. This tag is parsed by the ClosedLoop UI to render a verdict banner.
+
+---
+
+## Completion
+
+After all tasks are done, run telemetry completion:
+
+```bash
+bash "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh"
+```
 
 ---
 

--- a/plugins/code-review/scripts/command-telemetry-complete.sh
+++ b/plugins/code-review/scripts/command-telemetry-complete.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# command-telemetry-complete.sh — Telemetry finaliser for slash commands.
+#
+# Designed to be called (not sourced) by command markdown files at the end of
+# a command run to emit a `command_complete` event to perf.jsonl.
+#
+# Usage:
+#   bash "${CLAUDE_PLUGIN_ROOT}/scripts/command-telemetry-complete.sh" [exit_status]
+#
+# Arguments:
+#   $1  EXIT_STATUS (optional, default: 0) — the exit status of the command
+#
+# Environment variables consumed (set by command-telemetry-init.sh):
+#   CLOSEDLOOP_START_TIME  — unix epoch when the command started (required for duration)
+#   CLOSEDLOOP_RUN_ID      — unique run identifier
+#   CLOSEDLOOP_WORKDIR     — working directory for perf.jsonl output
+#   CLOSEDLOOP_COMMAND     — slash command name
+#
+# Fail-open guarantee: the entire finalisation is wrapped in a trap so any
+# error is suppressed and the calling command continues unaffected.
+
+# Fail open: any unexpected error exits 0 so the calling command is unaffected.
+trap 'exit 0' ERR
+
+_closedloop_telemetry_complete() {
+  local exit_status="${1:-0}"
+
+  # Resolve working directory. The matching command-telemetry-init.sh exports
+  # CLOSEDLOOP_WORKDIR, but those exports are scoped to the shell that ran
+  # `source` and do not survive across separate Bash tool invocations. When
+  # the env var is unset, fall back to the default workdir init.sh uses
+  # (.closedloop-ai/telemetry) only if a state file exists there — otherwise
+  # the command was never initialised and there is nothing to finalise.
+  local workdir="${CLOSEDLOOP_WORKDIR:-}"
+  if [[ -z "$workdir" ]]; then
+    if [[ -f ".closedloop-ai/telemetry/.cmd-state.env" ]]; then
+      workdir=".closedloop-ai/telemetry"
+    else
+      return 0
+    fi
+  fi
+
+  # If RUN_ID is missing, recover the run context that init.sh persisted to
+  # disk. This bridges the gap between separate Bash tool invocations: init
+  # exported env vars but they died with its source shell.
+  local state_file="$workdir/.cmd-state.env"
+  if [[ -z "${CLOSEDLOOP_RUN_ID:-}" && -f "$state_file" ]]; then
+    # shellcheck source=/dev/null
+    source "$state_file" 2>/dev/null || true
+    workdir="${CLOSEDLOOP_WORKDIR:-$workdir}"
+  fi
+
+  local perf_file="$workdir/perf.jsonl"
+
+  # Capture end time
+  local end_epoch
+  end_epoch=$(date +%s 2>/dev/null) || end_epoch=""
+  local ended_at
+  ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || ended_at=""
+
+  # Resolve start time and calculate duration
+  local start_epoch="${CLOSEDLOOP_START_TIME:-}"
+  local started_at=""
+  local duration_s=0
+
+  if [[ -n "$start_epoch" && -n "$end_epoch" ]]; then
+    duration_s=$(( end_epoch - start_epoch ))
+    # Convert start epoch to ISO-8601 timestamp
+    started_at=$(date -u -r "$start_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+      || started_at=$(date -u -d "@$start_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+      || started_at=""
+  fi
+
+  local run_id="${CLOSEDLOOP_RUN_ID:-unknown}"
+  local command="${CLOSEDLOOP_COMMAND:-interactive}"
+
+  # Ensure perf.jsonl directory exists
+  mkdir -p "$(dirname "$perf_file")" 2>/dev/null || true
+
+  # Build and emit the command_complete JSONL event, injecting command: field
+  # to match the pattern used by emit_perf_event in telemetry-helpers.sh
+  jq -n -c \
+    --arg event "command_complete" \
+    --arg run_id "$run_id" \
+    --arg command "$command" \
+    --arg started_at "$started_at" \
+    --arg ended_at "$ended_at" \
+    --argjson duration_s "$duration_s" \
+    --argjson exit_status "$exit_status" \
+    '{event:$event,run_id:$run_id,command:$command,started_at:$started_at,ended_at:$ended_at,duration_s:$duration_s,exit_status:$exit_status}' \
+    >> "$perf_file" 2>/dev/null || true
+
+  # Drop the recovered state file so stale state cannot leak into a later
+  # command that fails to call init.sh.
+  rm -f "$state_file" 2>/dev/null || true
+}
+
+_closedloop_telemetry_complete "$@"
+exit 0

--- a/plugins/code-review/scripts/command-telemetry-init.sh
+++ b/plugins/code-review/scripts/command-telemetry-init.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# command-telemetry-init.sh — Telemetry initialiser for slash commands.
+#
+# Designed to be SOURCED (not executed) by command markdown files at startup
+# so that the exported env vars remain visible to subsequent steps in the same
+# Claude Code session:
+#
+#   source "${CLAUDE_PLUGIN_ROOT}/scripts/command-telemetry-init.sh" <command-name> [workdir]
+#
+# Arguments:
+#   $1  COMMAND_NAME (required) — the slash-command name, e.g. "code", "amend-plan"
+#   $2  WORKDIR       (optional) — overrides env var and default
+#
+# Precedence for CLOSEDLOOP_WORKDIR:
+#   1. $2 argument
+#   2. CLOSEDLOOP_WORKDIR env var (already set by the caller / parent loop)
+#   3. Default: .closedloop-ai/telemetry/ (relative to cwd)
+#
+# Fail-open guarantee: the entire initialisation is wrapped in a function.
+# Any error inside that function is caught and suppressed so the calling
+# command continues normally.
+
+_closedloop_telemetry_init() {
+  local command_name="${1:-}"
+  local workdir_arg="${2:-}"
+
+  # Argument validation — COMMAND_NAME is required
+  if [[ -z "$command_name" ]]; then
+    return 0
+  fi
+
+  # Resolve CLOSEDLOOP_WORKDIR
+  local workdir
+  if [[ -n "$workdir_arg" ]]; then
+    workdir="$workdir_arg"
+  elif [[ -n "${CLOSEDLOOP_WORKDIR:-}" ]]; then
+    workdir="$CLOSEDLOOP_WORKDIR"
+  else
+    workdir=".closedloop-ai/telemetry"
+  fi
+
+  # Generate CLOSEDLOOP_RUN_ID (same format as run-loop.sh: timestamp + 4-byte hex)
+  local timestamp
+  timestamp=$(date +%Y%m%d-%H%M%S 2>/dev/null) || timestamp="00000000-000000"
+  local random_suffix
+  random_suffix=$(head -c 4 /dev/urandom 2>/dev/null | xxd -p 2>/dev/null) || random_suffix="00000000"
+  local run_id="${timestamp}-${random_suffix}"
+
+  # Capture start time as unix epoch (for duration calculation in complete script)
+  local start_epoch
+  start_epoch=$(date +%s 2>/dev/null) || start_epoch=""
+
+  # Export env vars for the session
+  export CLOSEDLOOP_WORKDIR="$workdir"
+  export CLOSEDLOOP_RUN_ID="$run_id"
+  export CLOSEDLOOP_COMMAND="$command_name"
+  export CLOSEDLOOP_START_TIME="$start_epoch"
+
+  # Persist state to disk so command-telemetry-complete.sh can recover the run
+  # context when it runs in a separate Bash tool invocation (the export above
+  # only affects the shell that ran `source`).
+  mkdir -p "$workdir" 2>/dev/null || true
+  {
+    printf 'CLOSEDLOOP_WORKDIR=%s\n' "$workdir"
+    printf 'CLOSEDLOOP_RUN_ID=%s\n' "$run_id"
+    printf 'CLOSEDLOOP_COMMAND=%s\n' "$command_name"
+    printf 'CLOSEDLOOP_START_TIME=%s\n' "$start_epoch"
+  } > "$workdir/.cmd-state.env" 2>/dev/null || true
+
+  # Call record_run.sh — locate it relative to this script
+  local scripts_dir
+  scripts_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || scripts_dir=""
+  if [[ -n "$scripts_dir" && -f "$scripts_dir/record_run.sh" ]]; then
+    bash "$scripts_dir/record_run.sh" "$workdir" || true
+  fi
+}
+
+# Invoke with fail-open: any error is suppressed so the calling command
+# continues unaffected.
+_closedloop_telemetry_init "$@" || true

--- a/plugins/code-review/scripts/record_run.sh
+++ b/plugins/code-review/scripts/record_run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# record_run.sh - Append a run event to perf.jsonl once per Loop.
+#
+# Emits exactly one `run` event containing command, repo, branch, and start
+# time so every perf.jsonl record can be attributed to the slash-command that
+# launched the Loop. Fails open (exits 0) on any error so the caller loop is
+# unaffected.
+#
+# Usage:
+#   bash record_run.sh [WORKDIR]
+# WORKDIR defaults to $CLOSEDLOOP_WORKDIR.
+
+# Fail open: any unexpected error exits 0 so the caller loop is unaffected.
+trap 'exit 0' ERR
+
+WORKDIR="${1:-${CLOSEDLOOP_WORKDIR:-}}"
+if [[ -z "$WORKDIR" ]]; then
+  exit 0
+fi
+
+PERF_FILE="$WORKDIR/perf.jsonl"
+
+RUN_ID="${CLOSEDLOOP_RUN_ID:-unknown}"
+COMMAND="${CLOSEDLOOP_COMMAND:-interactive}"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+
+# Capture repo and branch via git -C. Prefer GNU `timeout` as a hang guard, but
+# fall back to bare `git` when timeout isn't installed (default macOS lacks it),
+# so this never silently drops repo/branch attribution on dev machines.
+if command -v timeout >/dev/null 2>&1; then
+  REPO=$(timeout 5 git -C "$WORKDIR" remote get-url origin 2>/dev/null || echo "")
+  BRANCH=$(timeout 5 git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+else
+  REPO=$(git -C "$WORKDIR" remote get-url origin 2>/dev/null || echo "")
+  BRANCH=$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+fi
+
+mkdir -p "$(dirname "$PERF_FILE")"
+
+jq -n -c \
+  --arg event "run" \
+  --arg run_id "$RUN_ID" \
+  --arg command "$COMMAND" \
+  --arg started_at "$TIMESTAMP" \
+  --arg repo "$REPO" \
+  --arg branch "$BRANCH" \
+  '{event:$event,run_id:$run_id,command:$command,started_at:$started_at,repo:$repo,branch:$branch}' \
+  >> "$PERF_FILE"
+
+exit 0

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.11.16",
+  "version": "1.14.5",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/commands/amend-plan.md
+++ b/plugins/code/commands/amend-plan.md
@@ -37,51 +37,57 @@ Use TodoWrite to track your progress through the amendment workflow:
 
 ```json
 TodoWrite([
-  {"content": "Setup: Load state, read plan.json, add user message", "status": "pending", "activeForm": "Setting up amendment context"},
+  {"content": "Setup: Init telemetry, load state, read plan.json, add user message", "status": "pending", "activeForm": "Setting up amendment context"},
   {"content": "Analyze user intent (directive, question, or confirmation)", "status": "pending", "activeForm": "Analyzing user intent"},
   {"content": "Process request and determine response", "status": "pending", "activeForm": "Processing amendment request"},
   {"content": "Save response to state file", "status": "pending", "activeForm": "Saving response to state"},
-  {"content": "Apply changes if confirmed (edit plan.json, regenerate plan.md, run apply)", "status": "pending", "activeForm": "Applying changes"}
+  {"content": "Apply changes if confirmed (edit plan.json, regenerate plan.md, run apply)", "status": "pending", "activeForm": "Applying changes"},
+  {"content": "Complete telemetry", "status": "pending", "activeForm": "Finalizing telemetry"}
 ])
 ```
 
-**Note:** The last todo (Apply changes) only applies if the user gave a directive that was safe to apply, or confirmed a previously discussed change. Skip it if you're just answering a question or raising a concern.
+**Note:** The "Apply changes" todo only applies if the user gave a directive that was safe to apply, or confirmed a previously discussed change. Skip it if you're just answering a question or raising a concern. The "Complete telemetry" todo always runs at the end.
 
 ## Execution Instructions
 
 ### Step 1: Setup
 
-1. **Locate amend_state.py** (required for all Python commands):
+1. **Initialise telemetry** (always first):
+   ```bash
+   source "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh" "amend-plan"
+   ```
+
+2. **Locate amend_state.py** (required for all Python commands):
    Use `code:find-plugin-file` skill to find `tools/python/amend_state.py`:
    ```bash
    # Find the amend_state.py file
    AMEND_STATE_PATH=$(python3 ~/.claude/plugins/cache/closedloop-ai/code/*/skills/find-plugin-file/scripts/find_plugin_file.py tools/python/amend_state.py --plugin code)
    ```
 
-2. **Determine workdir**:
+3. **Determine workdir**:
    - If `--workdir` provided, use it
    - Else if `$CLOSEDLOOP_WORKDIR` env var is set, use it
    - Otherwise, default to `.closedloop-ai/work`
 
-3. **Set state file path**:
+4. **Set state file path**:
    - If `--state-file` provided, use it
    - Otherwise, use `{workdir}/amend-session.json`
 
-4. **Load session state**:
+5. **Load session state**:
    ```bash
    python3 "$AMEND_STATE_PATH" load \
      --state-file {state_file} \
      --run-dir {workdir}
    ```
 
-5. **Determine and read the implementation plan**:
+6. **Determine and read the implementation plan**:
    - Check if `{workdir}/plan.json` exists (required for experimental workflow)
    - If not found, error: "No plan.json found in {workdir}"
    - Read `plan.json` to get the full plan structure including `content` field
    - Also read `{workdir}/plan.md` for human-readable version (if it exists)
    - Store `PLAN_FILE=plan.json`
 
-6. **Add user message to conversation**:
+7. **Add user message to conversation**:
    ```bash
    python3 "$AMEND_STATE_PATH" add-message \
      --state-file {state_file} \
@@ -410,3 +416,11 @@ The `amend-session.json` file tracks:
 Status values:
 - `discussing` - Active conversation
 - `applied` - Changes have been applied, validation running
+
+## Completion
+
+After all steps are done (state saved, apply called if applicable), run telemetry completion:
+
+```bash
+bash "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh"
+```

--- a/plugins/code/commands/cancel-code.md
+++ b/plugins/code/commands/cancel-code.md
@@ -1,6 +1,6 @@
 ---
 description: "Cancel active ClosedLoop Loop"
-allowed-tools: ["Bash(test -f .closedloop-ai/closedloop-loop.local.md:*)", "Bash(rm .closedloop-ai/closedloop-loop.local.md)", "Read(.closedloop-ai/closedloop-loop.local.md)"]
+allowed-tools: ["Bash(test -f .closedloop-ai/closedloop-loop.local.md:*)", "Bash(rm .closedloop-ai/closedloop-loop.local.md)", "Bash(source $CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh:*)", "Bash(bash $CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh:*)", "Read(.closedloop-ai/closedloop-loop.local.md)"]
 hide-from-slash-command-tool: "true"
 ---
 
@@ -8,11 +8,21 @@ hide-from-slash-command-tool: "true"
 
 To cancel the ClosedLoop loop:
 
-1. Check if `.closedloop-ai/closedloop-loop.local.md` exists using Bash: `test -f .closedloop-ai/closedloop-loop.local.md && echo "EXISTS" || echo "NOT_FOUND"`
+1. **Initialise telemetry** (always first):
+   ```bash
+   source "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh" "cancel-code"
+   ```
 
-2. **If NOT_FOUND**: Say "No active ClosedLoop loop found."
+2. Check if `.closedloop-ai/closedloop-loop.local.md` exists using Bash: `test -f .closedloop-ai/closedloop-loop.local.md && echo "EXISTS" || echo "NOT_FOUND"`
 
-3. **If EXISTS**:
+3. **If NOT_FOUND**: Say "No active ClosedLoop loop found."
+
+4. **If EXISTS**:
    - Read `.closedloop-ai/closedloop-loop.local.md` to get the current iteration number from the `iteration:` field
    - Remove the file using Bash: `rm .closedloop-ai/closedloop-loop.local.md`
    - Report: "Cancelled ClosedLoop loop (was at iteration N)" where N is the iteration value
+
+5. **Complete telemetry**:
+   ```bash
+   bash "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh"
+   ```

--- a/plugins/code/commands/plan-with-codex.md
+++ b/plugins/code/commands/plan-with-codex.md
@@ -66,7 +66,14 @@ Valid phases: `user_review`, `codex_review`, `claude_revision`
 
 </templates>
 
-## Step 0: Parse Arguments
+## Step 0: Telemetry Init
+
+Run at startup before any other work:
+```bash
+source "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh" "plan-with-codex"
+```
+
+## Step 0.1: Parse Arguments
 
 Arguments: $ARGUMENTS
 
@@ -301,4 +308,11 @@ find ~/.closedloop-ai/plan-with-codex -name "*.jsonl" -mtime +30 2>/dev/null
 If found, ask user whether to delete them via AskUserQuestion. If yes:
 ```bash
 find ~/.closedloop-ai/plan-with-codex -name "*.jsonl" -mtime +30 -delete 2>/dev/null
+```
+
+### Telemetry completion
+
+Run after all work is done:
+```bash
+bash "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh"
 ```

--- a/plugins/code/scripts/command-telemetry-complete.sh
+++ b/plugins/code/scripts/command-telemetry-complete.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# command-telemetry-complete.sh — Telemetry finaliser for slash commands.
+#
+# Designed to be called (not sourced) by command markdown files at the end of
+# a command run to emit a `command_complete` event to perf.jsonl.
+#
+# Usage:
+#   bash "${CLAUDE_PLUGIN_ROOT}/scripts/command-telemetry-complete.sh" [exit_status]
+#
+# Arguments:
+#   $1  EXIT_STATUS (optional, default: 0) — the exit status of the command
+#
+# Environment variables consumed (set by command-telemetry-init.sh):
+#   CLOSEDLOOP_START_TIME  — unix epoch when the command started (required for duration)
+#   CLOSEDLOOP_RUN_ID      — unique run identifier
+#   CLOSEDLOOP_WORKDIR     — working directory for perf.jsonl output
+#   CLOSEDLOOP_COMMAND     — slash command name
+#
+# Fail-open guarantee: the entire finalisation is wrapped in a trap so any
+# error is suppressed and the calling command continues unaffected.
+
+# Fail open: any unexpected error exits 0 so the calling command is unaffected.
+trap 'exit 0' ERR
+
+_closedloop_telemetry_complete() {
+  local exit_status="${1:-0}"
+
+  # Resolve working directory. The matching command-telemetry-init.sh exports
+  # CLOSEDLOOP_WORKDIR, but those exports are scoped to the shell that ran
+  # `source` and do not survive across separate Bash tool invocations. When
+  # the env var is unset, fall back to the default workdir init.sh uses
+  # (.closedloop-ai/telemetry) only if a state file exists there — otherwise
+  # the command was never initialised and there is nothing to finalise.
+  local workdir="${CLOSEDLOOP_WORKDIR:-}"
+  if [[ -z "$workdir" ]]; then
+    if [[ -f ".closedloop-ai/telemetry/.cmd-state.env" ]]; then
+      workdir=".closedloop-ai/telemetry"
+    else
+      return 0
+    fi
+  fi
+
+  # If RUN_ID is missing, recover the run context that init.sh persisted to
+  # disk. This bridges the gap between separate Bash tool invocations: init
+  # exported env vars but they died with its source shell.
+  local state_file="$workdir/.cmd-state.env"
+  if [[ -z "${CLOSEDLOOP_RUN_ID:-}" && -f "$state_file" ]]; then
+    # shellcheck source=/dev/null
+    source "$state_file" 2>/dev/null || true
+    workdir="${CLOSEDLOOP_WORKDIR:-$workdir}"
+  fi
+
+  local perf_file="$workdir/perf.jsonl"
+
+  # Capture end time
+  local end_epoch
+  end_epoch=$(date +%s 2>/dev/null) || end_epoch=""
+  local ended_at
+  ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || ended_at=""
+
+  # Resolve start time and calculate duration
+  local start_epoch="${CLOSEDLOOP_START_TIME:-}"
+  local started_at=""
+  local duration_s=0
+
+  if [[ -n "$start_epoch" && -n "$end_epoch" ]]; then
+    duration_s=$(( end_epoch - start_epoch ))
+    # Convert start epoch to ISO-8601 timestamp
+    started_at=$(date -u -r "$start_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+      || started_at=$(date -u -d "@$start_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+      || started_at=""
+  fi
+
+  local run_id="${CLOSEDLOOP_RUN_ID:-unknown}"
+  local command="${CLOSEDLOOP_COMMAND:-interactive}"
+
+  # Ensure perf.jsonl directory exists
+  mkdir -p "$(dirname "$perf_file")" 2>/dev/null || true
+
+  # Build and emit the command_complete JSONL event, injecting command: field
+  # to match the pattern used by emit_perf_event in telemetry-helpers.sh
+  jq -n -c \
+    --arg event "command_complete" \
+    --arg run_id "$run_id" \
+    --arg command "$command" \
+    --arg started_at "$started_at" \
+    --arg ended_at "$ended_at" \
+    --argjson duration_s "$duration_s" \
+    --argjson exit_status "$exit_status" \
+    '{event:$event,run_id:$run_id,command:$command,started_at:$started_at,ended_at:$ended_at,duration_s:$duration_s,exit_status:$exit_status}' \
+    >> "$perf_file" 2>/dev/null || true
+
+  # Drop the recovered state file so stale state cannot leak into a later
+  # command that fails to call init.sh.
+  rm -f "$state_file" 2>/dev/null || true
+}
+
+_closedloop_telemetry_complete "$@"
+exit 0

--- a/plugins/code/scripts/command-telemetry-init.sh
+++ b/plugins/code/scripts/command-telemetry-init.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# command-telemetry-init.sh — Telemetry initialiser for slash commands.
+#
+# Designed to be SOURCED (not executed) by command markdown files at startup
+# so that the exported env vars remain visible to subsequent steps in the same
+# Claude Code session:
+#
+#   source "${CLAUDE_PLUGIN_ROOT}/scripts/command-telemetry-init.sh" <command-name> [workdir]
+#
+# Arguments:
+#   $1  COMMAND_NAME (required) — the slash-command name, e.g. "code", "amend-plan"
+#   $2  WORKDIR       (optional) — overrides env var and default
+#
+# Precedence for CLOSEDLOOP_WORKDIR:
+#   1. $2 argument
+#   2. CLOSEDLOOP_WORKDIR env var (already set by the caller / parent loop)
+#   3. Default: .closedloop-ai/telemetry/ (relative to cwd)
+#
+# Fail-open guarantee: the entire initialisation is wrapped in a function.
+# Any error inside that function is caught and suppressed so the calling
+# command continues normally.
+
+_closedloop_telemetry_init() {
+  local command_name="${1:-}"
+  local workdir_arg="${2:-}"
+
+  # Argument validation — COMMAND_NAME is required
+  if [[ -z "$command_name" ]]; then
+    return 0
+  fi
+
+  # Resolve CLOSEDLOOP_WORKDIR
+  local workdir
+  if [[ -n "$workdir_arg" ]]; then
+    workdir="$workdir_arg"
+  elif [[ -n "${CLOSEDLOOP_WORKDIR:-}" ]]; then
+    workdir="$CLOSEDLOOP_WORKDIR"
+  else
+    workdir=".closedloop-ai/telemetry"
+  fi
+
+  # Generate CLOSEDLOOP_RUN_ID (same format as run-loop.sh: timestamp + 4-byte hex)
+  local timestamp
+  timestamp=$(date +%Y%m%d-%H%M%S 2>/dev/null) || timestamp="00000000-000000"
+  local random_suffix
+  random_suffix=$(head -c 4 /dev/urandom 2>/dev/null | xxd -p 2>/dev/null) || random_suffix="00000000"
+  local run_id="${timestamp}-${random_suffix}"
+
+  # Capture start time as unix epoch (for duration calculation in complete script)
+  local start_epoch
+  start_epoch=$(date +%s 2>/dev/null) || start_epoch=""
+
+  # Export env vars for the session
+  export CLOSEDLOOP_WORKDIR="$workdir"
+  export CLOSEDLOOP_RUN_ID="$run_id"
+  export CLOSEDLOOP_COMMAND="$command_name"
+  export CLOSEDLOOP_START_TIME="$start_epoch"
+
+  # Persist state to disk so command-telemetry-complete.sh can recover the run
+  # context when it runs in a separate Bash tool invocation (the export above
+  # only affects the shell that ran `source`).
+  mkdir -p "$workdir" 2>/dev/null || true
+  {
+    printf 'CLOSEDLOOP_WORKDIR=%s\n' "$workdir"
+    printf 'CLOSEDLOOP_RUN_ID=%s\n' "$run_id"
+    printf 'CLOSEDLOOP_COMMAND=%s\n' "$command_name"
+    printf 'CLOSEDLOOP_START_TIME=%s\n' "$start_epoch"
+  } > "$workdir/.cmd-state.env" 2>/dev/null || true
+
+  # Call record_run.sh — locate it relative to this script
+  local scripts_dir
+  scripts_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || scripts_dir=""
+  if [[ -n "$scripts_dir" && -f "$scripts_dir/record_run.sh" ]]; then
+    bash "$scripts_dir/record_run.sh" "$workdir" || true
+  fi
+}
+
+# Invoke with fail-open: any error is suppressed so the calling command
+# continues unaffected.
+_closedloop_telemetry_init "$@" || true

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -1246,83 +1246,8 @@ log_progress() {
 }
 
 # --- Performance instrumentation helpers ---
-
-# Append a single-line JSON event to perf.jsonl. The `command:` field is added
-# to every event row so it can be filtered by slash command in Datadog.
-emit_perf_event() {
-  local json_line="$1"
-  # Empty input → no-op. Two reasons: (1) historically (older jq + set -euo
-  # pipefail) an empty stdin to jq propagated a non-zero exit and killed the
-  # Loop; (2) even on modern jq (1.8+) which silently exits 0, the resulting
-  # blank line would still get appended to perf.jsonl and corrupt downstream
-  # JSONL parsers (the desktop watcher emits loop.perf.parse_failure on
-  # malformed lines). Any caller that passes empty input has its own bug;
-  # this guard prevents either failure mode (FEA-936 fix 2).
-  if [[ -z "$json_line" ]]; then
-    return 0
-  fi
-  local perf_file="${CLOSEDLOOP_WORKDIR:-.}/perf.jsonl"
-  json_line=$(echo "$json_line" | jq -c --arg command "${CLOSEDLOOP_COMMAND:-interactive}" '. + {command:$command}')
-  echo "$json_line" >> "$perf_file"
-}
-
-# Run a command with timing, emit a pipeline_step perf event, return original exit code
-run_timed_step() {
-  local step_num="$1"
-  local step_name="$2"
-  shift 2
-  local step_start_epoch
-  step_start_epoch=$(date +%s)
-  local step_started_at
-  step_started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-  local step_exit=0
-  "$@" || step_exit=$?
-
-  local step_end_epoch
-  step_end_epoch=$(date +%s)
-  local step_ended_at
-  step_ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  local step_duration=$((step_end_epoch - step_start_epoch))
-
-  emit_perf_event "$(jq -n -c \
-    --arg event "pipeline_step" \
-    --arg run_id "$RUN_ID" \
-    --argjson iteration "${CLOSEDLOOP_ITERATION:-0}" \
-    --argjson step "$step_num" \
-    --arg step_name "$step_name" \
-    --arg started_at "$step_started_at" \
-    --arg ended_at "$step_ended_at" \
-    --argjson duration_s "$step_duration" \
-    --argjson exit_code "$step_exit" \
-    --argjson skipped false \
-    '{event:$event,run_id:$run_id,iteration:$iteration,step:$step,step_name:$step_name,started_at:$started_at,ended_at:$ended_at,duration_s:$duration_s,exit_code:$exit_code,skipped:$skipped}'
-  )"
-
-  return "$step_exit"
-}
-
-# Emit a skipped pipeline_step event
-emit_skipped_step() {
-  local step_num="$1"
-  local step_name="$2"
-  local now
-  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-  emit_perf_event "$(jq -n -c \
-    --arg event "pipeline_step" \
-    --arg run_id "$RUN_ID" \
-    --argjson iteration "${CLOSEDLOOP_ITERATION:-0}" \
-    --argjson step "$step_num" \
-    --arg step_name "$step_name" \
-    --arg started_at "$now" \
-    --arg ended_at "$now" \
-    --argjson duration_s 0 \
-    --argjson exit_code 0 \
-    --argjson skipped true \
-    '{event:$event,run_id:$run_id,iteration:$iteration,step:$step,step_name:$step_name,started_at:$started_at,ended_at:$ended_at,duration_s:$duration_s,exit_code:$exit_code,skipped:$skipped}'
-  )"
-}
+# shellcheck source=telemetry-helpers.sh
+source "${SCRIPTS_DIR}/telemetry-helpers.sh"
 
 # Update iteration in state file
 update_iteration() {

--- a/plugins/code/scripts/telemetry-helpers.sh
+++ b/plugins/code/scripts/telemetry-helpers.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# telemetry-helpers.sh — Sourceable performance instrumentation helpers
+#
+# Extracted from run-loop.sh (lines 1248-1325). These functions emit JSONL
+# events to perf.jsonl for Datadog / desktop-watcher consumption.
+#
+# Environment variables consumed (no enclosing-scope globals required):
+#   CLOSEDLOOP_RUN_ID      — unique run identifier (falls back to RUN_ID for
+#                            backward-compat when sourced inside run-loop.sh)
+#   CLOSEDLOOP_ITERATION   — current iteration counter (default: 0)
+#   CLOSEDLOOP_WORKDIR     — working directory for perf.jsonl output (default: .)
+#   CLOSEDLOOP_COMMAND     — slash command name for event filtering (default: interactive)
+
+# Append a single-line JSON event to perf.jsonl. The `command:` field is added
+# to every event row so it can be filtered by slash command in Datadog.
+emit_perf_event() {
+  local json_line="$1"
+  # Empty input → no-op. Two reasons: (1) historically (older jq + set -euo
+  # pipefail) an empty stdin to jq propagated a non-zero exit and killed the
+  # Loop; (2) even on modern jq (1.8+) which silently exits 0, the resulting
+  # blank line would still get appended to perf.jsonl and corrupt downstream
+  # JSONL parsers (the desktop watcher emits loop.perf.parse_failure on
+  # malformed lines). Any caller that passes empty input has its own bug;
+  # this guard prevents either failure mode (FEA-936 fix 2).
+  if [[ -z "$json_line" ]]; then
+    return 0
+  fi
+  local perf_file="${CLOSEDLOOP_WORKDIR:-.}/perf.jsonl"
+  json_line=$(echo "$json_line" | jq -c --arg command "${CLOSEDLOOP_COMMAND:-interactive}" '. + {command:$command}')
+  echo "$json_line" >> "$perf_file"
+}
+
+# Run a command with timing, emit a pipeline_step perf event, return original exit code
+run_timed_step() {
+  local step_num="$1"
+  local step_name="$2"
+  shift 2
+  local step_start_epoch
+  step_start_epoch=$(date +%s)
+  local step_started_at
+  step_started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  local step_exit=0
+  "$@" || step_exit=$?
+
+  local step_end_epoch
+  step_end_epoch=$(date +%s)
+  local step_ended_at
+  step_ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  local step_duration=$((step_end_epoch - step_start_epoch))
+
+  # Resolve run ID: prefer exported CLOSEDLOOP_RUN_ID, fall back to RUN_ID
+  # (set as a shell global when sourced inside run-loop.sh).
+  local _run_id="${CLOSEDLOOP_RUN_ID:-${RUN_ID:-}}"
+
+  emit_perf_event "$(jq -n -c \
+    --arg event "pipeline_step" \
+    --arg run_id "$_run_id" \
+    --argjson iteration "${CLOSEDLOOP_ITERATION:-0}" \
+    --argjson step "$step_num" \
+    --arg step_name "$step_name" \
+    --arg started_at "$step_started_at" \
+    --arg ended_at "$step_ended_at" \
+    --argjson duration_s "$step_duration" \
+    --argjson exit_code "$step_exit" \
+    --argjson skipped false \
+    '{event:$event,run_id:$run_id,iteration:$iteration,step:$step,step_name:$step_name,started_at:$started_at,ended_at:$ended_at,duration_s:$duration_s,exit_code:$exit_code,skipped:$skipped}'
+  )"
+
+  return "$step_exit"
+}
+
+# Emit a skipped pipeline_step event
+emit_skipped_step() {
+  local step_num="$1"
+  local step_name="$2"
+  local now
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Resolve run ID: prefer exported CLOSEDLOOP_RUN_ID, fall back to RUN_ID
+  # (set as a shell global when sourced inside run-loop.sh).
+  local _run_id="${CLOSEDLOOP_RUN_ID:-${RUN_ID:-}}"
+
+  emit_perf_event "$(jq -n -c \
+    --arg event "pipeline_step" \
+    --arg run_id "$_run_id" \
+    --argjson iteration "${CLOSEDLOOP_ITERATION:-0}" \
+    --argjson step "$step_num" \
+    --arg step_name "$step_name" \
+    --arg started_at "$now" \
+    --arg ended_at "$now" \
+    --argjson duration_s 0 \
+    --argjson exit_code 0 \
+    --argjson skipped true \
+    '{event:$event,run_id:$run_id,iteration:$iteration,step:$step,step_name:$step_name,started_at:$started_at,ended_at:$ended_at,duration_s:$duration_s,exit_code:$exit_code,skipped:$skipped}'
+  )"
+}

--- a/plugins/code/scripts/tests/test_command_telemetry_complete.sh
+++ b/plugins/code/scripts/tests/test_command_telemetry_complete.sh
@@ -1,0 +1,724 @@
+#!/usr/bin/env bash
+# Tests for command-telemetry-complete.sh
+#
+# Validates:
+#   - Emitted JSONL event has correct fields: event type "command_complete",
+#     run_id, command, started_at, ended_at, duration_s, exit_status
+#   - duration_s is a non-negative number
+#   - exit_status is recorded accurately
+#   - Fail-open behaviour: script exits 0 even when env vars are missing
+#     or CLOSEDLOOP_WORKDIR doesn't exist
+#   - Multiple fields are numeric/string types as expected
+#
+# Usage:
+#   bash plugins/code/scripts/tests/test_command_telemetry_complete.sh
+#
+# Exit code: 0 if all tests pass, 1 if any test fails.
+
+set -uo pipefail  # -e dropped: tests use explicit ||-capture and assertion reporters
+
+# ---- Paths ---------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPLETE_SCRIPT="$SCRIPT_DIR/../command-telemetry-complete.sh"
+
+# ---- Counters ------------------------------------------------------------
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ---- Reporters -----------------------------------------------------------
+pass() {
+    local name="$1"
+    echo "  PASS: $name"
+    PASS_COUNT=$(( PASS_COUNT + 1 ))
+}
+
+fail() {
+    local name="$1"
+    local reason="$2"
+    echo "  FAIL: $name -- $reason"
+    FAIL_COUNT=$(( FAIL_COUNT + 1 ))
+}
+
+# ---- JSON field assertions -----------------------------------------------
+assert_field_present() {
+    local test_name="$1"
+    local json="$2"
+    local field="$3"
+    local value
+    value=$(echo "$json" | jq -r --arg f "$field" 'if has($f) then "present" else empty end' 2>/dev/null || echo "")
+    if [[ "$value" == "present" ]]; then
+        pass "$test_name: field '$field' present"
+    else
+        fail "$test_name: field '$field' present" "missing in: $json"
+    fi
+}
+
+assert_field_equals() {
+    local test_name="$1"
+    local json="$2"
+    local field="$3"
+    local expected="$4"
+    local actual
+    actual=$(echo "$json" | jq -r --arg f "$field" '.[$f] | tostring' 2>/dev/null || echo "")
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$test_name: field '$field' = '$expected'"
+    else
+        fail "$test_name: field '$field'" "expected '$expected' but got '$actual'"
+    fi
+}
+
+assert_field_type() {
+    local test_name="$1"
+    local json="$2"
+    local field="$3"
+    local expected_type="$4"
+    local actual_type
+    actual_type=$(echo "$json" | jq -r --arg f "$field" '.[$f] | type' 2>/dev/null || echo "")
+    if [[ "$actual_type" == "$expected_type" ]]; then
+        pass "$test_name: field '$field' is $expected_type"
+    else
+        fail "$test_name: field '$field' type" "expected '$expected_type' but got '$actual_type'"
+    fi
+}
+
+assert_field_nonempty() {
+    local test_name="$1"
+    local json="$2"
+    local field="$3"
+    local value
+    value=$(echo "$json" | jq -r --arg f "$field" '.[$f] // empty' 2>/dev/null || echo "")
+    if [[ -n "$value" ]] && [[ "$value" != "null" ]]; then
+        pass "$test_name: field '$field' is non-empty"
+    else
+        fail "$test_name: field '$field' is non-empty" "was empty or null in: $json"
+    fi
+}
+
+# ---- Setup helpers -------------------------------------------------------
+setup_temp_workdir() {
+    mktemp -d
+}
+
+run_complete_script() {
+    # Runs command-telemetry-complete.sh with the given env and args in a subshell.
+    # All environment variables are passed as bash -c assignments to keep isolation.
+    # $1 = exit_status arg (optional, may be empty)
+    # $2 = CLOSEDLOOP_WORKDIR value (empty = unset)
+    # $3 = CLOSEDLOOP_RUN_ID value  (empty = unset)
+    # $4 = CLOSEDLOOP_COMMAND value (empty = unset)
+    # $5 = CLOSEDLOOP_START_TIME value (empty = unset)
+    local exit_arg="${1:-}"
+    local workdir="${2:-}"
+    local run_id="${3:-}"
+    local command="${4:-}"
+    local start_time="${5:-}"
+
+    bash -c "
+        $([ -n '$workdir' ]    && echo "export CLOSEDLOOP_WORKDIR='$workdir'"    || echo "unset CLOSEDLOOP_WORKDIR")
+        $([ -n '$run_id' ]     && echo "export CLOSEDLOOP_RUN_ID='$run_id'"      || echo "unset CLOSEDLOOP_RUN_ID")
+        $([ -n '$command' ]    && echo "export CLOSEDLOOP_COMMAND='$command'"    || echo "unset CLOSEDLOOP_COMMAND")
+        $([ -n '$start_time' ] && echo "export CLOSEDLOOP_START_TIME='$start_time'" || echo "unset CLOSEDLOOP_START_TIME")
+        bash '$COMPLETE_SCRIPT' $exit_arg
+    "
+}
+
+# ---- Tests ---------------------------------------------------------------
+
+echo "Running tests for command-telemetry-complete.sh"
+echo ""
+
+# ------------------------------------------------------------------
+# Test 1: Script exits 0 when all env vars are set correctly
+# ------------------------------------------------------------------
+echo "Test 1: Script exits 0 with all env vars set"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(date +%s)
+
+    actual_exit=0
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-test-001'
+        export CLOSEDLOOP_COMMAND='test-command'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 0
+    " ; actual_exit=$?
+
+    if [[ "$actual_exit" -eq 0 ]]; then
+        pass "exits 0 with all env vars set"
+    else
+        fail "exits 0 with all env vars set" "got exit $actual_exit"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 2: Emitted event has event type "command_complete"
+# ------------------------------------------------------------------
+echo "Test 2: Emitted event has event type 'command_complete'"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(date +%s)
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-test-002'
+        export CLOSEDLOOP_COMMAND='my-command'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 0
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        pass "perf.jsonl was created"
+        line=$(tail -1 "$perf_file")
+
+        if echo "$line" | jq empty 2>/dev/null; then
+            pass "event type test: perf.jsonl line is valid JSON"
+        else
+            fail "event type test: perf.jsonl line is valid JSON" "not valid JSON: $line"
+        fi
+
+        assert_field_equals "event type" "$line" "event" "command_complete"
+    else
+        fail "perf.jsonl was created" "file not found at $perf_file"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 3: Emitted event contains all required fields
+# ------------------------------------------------------------------
+echo "Test 3: Emitted event contains all required fields"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(date +%s)
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-test-003'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 0
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+
+        required_keys=("event" "run_id" "command" "started_at" "ended_at" "duration_s" "exit_status")
+        for key in "${required_keys[@]}"; do
+            val=$(echo "$line" | jq -r --arg k "$key" 'if has($k) then "present" else empty end' 2>/dev/null || echo "")
+            if [[ "$val" == "present" ]]; then
+                pass "required fields: key '$key' present"
+            else
+                fail "required fields: key '$key' present" "missing from: $line"
+            fi
+        done
+    else
+        fail "required fields" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 4: run_id field matches CLOSEDLOOP_RUN_ID
+# ------------------------------------------------------------------
+echo "Test 4: run_id field matches CLOSEDLOOP_RUN_ID"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(date +%s)
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='my-unique-run-id'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 0
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "run_id field" "$line" "run_id" "my-unique-run-id"
+    else
+        fail "run_id field" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 5: command field matches CLOSEDLOOP_COMMAND
+# ------------------------------------------------------------------
+echo "Test 5: command field matches CLOSEDLOOP_COMMAND"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(date +%s)
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-test-005'
+        export CLOSEDLOOP_COMMAND='plan-execute'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 0
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "command field" "$line" "command" "plan-execute"
+    else
+        fail "command field" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 6: exit_status field matches the argument passed to the script
+# ------------------------------------------------------------------
+echo "Test 6: exit_status field is recorded accurately"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(date +%s)
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-test-006'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 42
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "exit_status 42" "$line" "exit_status" "42"
+    else
+        fail "exit_status 42" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 7: exit_status defaults to 0 when no argument is passed
+# ------------------------------------------------------------------
+echo "Test 7: exit_status defaults to 0 when no argument passed"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(date +%s)
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-test-007'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT'
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "exit_status default 0" "$line" "exit_status" "0"
+    else
+        fail "exit_status default 0" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 8: duration_s is a non-negative number
+# ------------------------------------------------------------------
+echo "Test 8: duration_s is a non-negative number"
+{
+    tmpdir=$(setup_temp_workdir)
+    # Use a start time 5 seconds in the past to guarantee non-zero duration
+    start_time=$(( $(date +%s) - 5 ))
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-test-008'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 0
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+
+        assert_field_type "duration_s type" "$line" "duration_s" "number"
+
+        duration=$(echo "$line" | jq -r '.duration_s' 2>/dev/null || echo "")
+        if [[ -n "$duration" ]] && [[ "$duration" -ge 0 ]] 2>/dev/null; then
+            pass "duration_s is non-negative (value: $duration)"
+        else
+            fail "duration_s is non-negative" "got: $duration"
+        fi
+    else
+        fail "duration_s type" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 9: duration_s calculation is reasonable (>= elapsed time - 1)
+# ------------------------------------------------------------------
+echo "Test 9: duration_s calculation is reasonable"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(( $(date +%s) - 10 ))
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-test-009'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 0
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        duration=$(echo "$line" | jq -r '.duration_s' 2>/dev/null || echo "")
+
+        # Should be at least 9 seconds (10s start_time offset - 1 for rounding)
+        if [[ -n "$duration" ]] && [[ "$duration" -ge 9 ]] 2>/dev/null; then
+            pass "duration_s is reasonable (>= 9s, got: $duration)"
+        else
+            fail "duration_s is reasonable" "expected >= 9 but got: $duration"
+        fi
+    else
+        fail "duration_s calculation" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 10: started_at and ended_at are non-empty ISO-8601 timestamps
+# ------------------------------------------------------------------
+echo "Test 10: started_at and ended_at are ISO-8601 timestamps"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(( $(date +%s) - 2 ))
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-test-010'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 0
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+
+        assert_field_nonempty "timestamps" "$line" "started_at"
+        assert_field_nonempty "timestamps" "$line" "ended_at"
+
+        # Both must look like ISO-8601: YYYY-MM-DDTHH:MM:SSZ
+        started_at=$(echo "$line" | jq -r '.started_at' 2>/dev/null || echo "")
+        ended_at=$(echo "$line"   | jq -r '.ended_at'   2>/dev/null || echo "")
+
+        iso_pattern='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
+        if [[ "$started_at" =~ $iso_pattern ]]; then
+            pass "timestamps: started_at matches ISO-8601 pattern"
+        else
+            fail "timestamps: started_at matches ISO-8601 pattern" "got: $started_at"
+        fi
+
+        if [[ "$ended_at" =~ $iso_pattern ]]; then
+            pass "timestamps: ended_at matches ISO-8601 pattern"
+        else
+            fail "timestamps: ended_at matches ISO-8601 pattern" "got: $ended_at"
+        fi
+    else
+        fail "timestamps" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 11: exit_status and duration_s are JSON numbers, not strings
+# ------------------------------------------------------------------
+echo "Test 11: exit_status and duration_s are JSON numbers"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(date +%s)
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-test-011'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 1
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_type "numeric fields" "$line" "exit_status" "number"
+        assert_field_type "numeric fields" "$line" "duration_s"  "number"
+    else
+        fail "numeric fields" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 12: Fail-open — script exits 0 when CLOSEDLOOP_WORKDIR is unset
+# ------------------------------------------------------------------
+echo "Test 12: Fail-open — exits 0 when CLOSEDLOOP_WORKDIR is unset"
+{
+    actual_exit=0
+    bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        export CLOSEDLOOP_RUN_ID='run-fail-open'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$(date +%s)'
+        bash '$COMPLETE_SCRIPT' 0
+    " ; actual_exit=$?
+
+    if [[ "$actual_exit" -eq 0 ]]; then
+        pass "fail-open: exits 0 when CLOSEDLOOP_WORKDIR unset"
+    else
+        fail "fail-open: exits 0 when CLOSEDLOOP_WORKDIR unset" "got exit $actual_exit"
+    fi
+}
+
+# ------------------------------------------------------------------
+# Test 13: Fail-open — script exits 0 when all env vars are missing
+# ------------------------------------------------------------------
+echo "Test 13: Fail-open — exits 0 when all env vars are missing"
+{
+    actual_exit=0
+    bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        unset CLOSEDLOOP_RUN_ID
+        unset CLOSEDLOOP_COMMAND
+        unset CLOSEDLOOP_START_TIME
+        bash '$COMPLETE_SCRIPT' 0
+    " ; actual_exit=$?
+
+    if [[ "$actual_exit" -eq 0 ]]; then
+        pass "fail-open: exits 0 with all env vars missing"
+    else
+        fail "fail-open: exits 0 with all env vars missing" "got exit $actual_exit"
+    fi
+}
+
+# ------------------------------------------------------------------
+# Test 14: Fail-open — script exits 0 when CLOSEDLOOP_WORKDIR points
+#          to a non-existent directory
+# ------------------------------------------------------------------
+echo "Test 14: Fail-open — exits 0 when CLOSEDLOOP_WORKDIR doesn't exist"
+{
+    actual_exit=0
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='/tmp/does-not-exist-closedloop-test-$$'
+        export CLOSEDLOOP_RUN_ID='run-fail-open'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$(date +%s)'
+        bash '$COMPLETE_SCRIPT' 0
+    " ; actual_exit=$?
+
+    if [[ "$actual_exit" -eq 0 ]]; then
+        pass "fail-open: exits 0 when CLOSEDLOOP_WORKDIR doesn't exist"
+    else
+        fail "fail-open: exits 0 when CLOSEDLOOP_WORKDIR doesn't exist" "got exit $actual_exit"
+    fi
+}
+
+# ------------------------------------------------------------------
+# Test 15: Fail-open — script exits 0 when CLOSEDLOOP_START_TIME is missing
+#          (duration calculation should degrade gracefully)
+# ------------------------------------------------------------------
+echo "Test 15: Fail-open — exits 0 when CLOSEDLOOP_START_TIME is unset"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    actual_exit=0
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-no-start-time'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        unset CLOSEDLOOP_START_TIME
+        bash '$COMPLETE_SCRIPT' 0
+    " ; actual_exit=$?
+
+    if [[ "$actual_exit" -eq 0 ]]; then
+        pass "fail-open: exits 0 when CLOSEDLOOP_START_TIME unset"
+    else
+        fail "fail-open: exits 0 when CLOSEDLOOP_START_TIME unset" "got exit $actual_exit"
+    fi
+
+    # Event should still be emitted with duration_s=0
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        if echo "$line" | jq empty 2>/dev/null; then
+            pass "no start time: event is valid JSON"
+            assert_field_equals "no start time" "$line" "duration_s" "0"
+        else
+            fail "no start time: event is valid JSON" "not valid JSON: $line"
+        fi
+    else
+        fail "no start time: perf.jsonl created" "file not found"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 16: CLOSEDLOOP_RUN_ID defaults to "unknown" when unset
+# ------------------------------------------------------------------
+echo "Test 16: run_id defaults to 'unknown' when CLOSEDLOOP_RUN_ID is unset"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(date +%s)
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        unset CLOSEDLOOP_RUN_ID
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 0
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "run_id default" "$line" "run_id" "unknown"
+    else
+        fail "run_id default" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 17: CLOSEDLOOP_COMMAND defaults to "interactive" when unset
+# ------------------------------------------------------------------
+echo "Test 17: command defaults to 'interactive' when CLOSEDLOOP_COMMAND is unset"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(date +%s)
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        export CLOSEDLOOP_RUN_ID='run-test-017'
+        unset CLOSEDLOOP_COMMAND
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 0
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "command default" "$line" "command" "interactive"
+    else
+        fail "command default" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 18: perf.jsonl is created even when the directory doesn't exist yet
+# ------------------------------------------------------------------
+echo "Test 18: perf.jsonl directory is created if it doesn't exist"
+{
+    tmpdir=$(setup_temp_workdir)
+    # Use a nested path that doesn't exist yet
+    nested_workdir="$tmpdir/nested/path/work"
+    start_time=$(date +%s)
+
+    bash -c "
+        export CLOSEDLOOP_WORKDIR='$nested_workdir'
+        export CLOSEDLOOP_RUN_ID='run-test-018'
+        export CLOSEDLOOP_COMMAND='test-cmd'
+        export CLOSEDLOOP_START_TIME='$start_time'
+        bash '$COMPLETE_SCRIPT' 0
+    "
+
+    perf_file="$nested_workdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        pass "nested directory: perf.jsonl created in new nested directory"
+        line=$(tail -1 "$perf_file")
+        if echo "$line" | jq empty 2>/dev/null; then
+            pass "nested directory: emitted event is valid JSON"
+        else
+            fail "nested directory: emitted event is valid JSON" "not valid JSON: $line"
+        fi
+    else
+        fail "nested directory: perf.jsonl created in new nested directory" \
+             "file not found at $perf_file"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 19: Multiple invocations append separate JSONL lines
+# ------------------------------------------------------------------
+echo "Test 19: Multiple invocations append separate JSONL lines"
+{
+    tmpdir=$(setup_temp_workdir)
+    start_time=$(date +%s)
+
+    for i in 1 2 3; do
+        bash -c "
+            export CLOSEDLOOP_WORKDIR='$tmpdir'
+            export CLOSEDLOOP_RUN_ID='run-multi-$i'
+            export CLOSEDLOOP_COMMAND='test-cmd'
+            export CLOSEDLOOP_START_TIME='$start_time'
+            bash '$COMPLETE_SCRIPT' $i
+        "
+    done
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line_count=$(wc -l < "$perf_file" | tr -d ' ')
+        if [[ "$line_count" -eq 3 ]]; then
+            pass "multiple invocations: 3 lines in perf.jsonl"
+        else
+            fail "multiple invocations: 3 lines in perf.jsonl" "got $line_count lines"
+        fi
+
+        bad=0
+        while IFS= read -r l; do
+            if [[ -n "$l" ]] && ! echo "$l" | jq empty 2>/dev/null; then
+                bad=$(( bad + 1 ))
+            fi
+        done < "$perf_file"
+        if [[ "$bad" -eq 0 ]]; then
+            pass "multiple invocations: all lines are valid JSON"
+        else
+            fail "multiple invocations: all lines are valid JSON" "$bad invalid line(s)"
+        fi
+    else
+        fail "multiple invocations" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ---- Summary -------------------------------------------------------------
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/plugins/code/scripts/tests/test_command_telemetry_init.sh
+++ b/plugins/code/scripts/tests/test_command_telemetry_init.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env bash
+# Tests for command-telemetry-init.sh
+#
+# Validates:
+#   - CLOSEDLOOP_WORKDIR detection: from $2 argument, CLOSEDLOOP_WORKDIR env var, or default
+#   - CLOSEDLOOP_RUN_ID generation: format YYYYMMDD-HHMMSS-HEXHEX
+#   - CLOSEDLOOP_COMMAND export
+#   - CLOSEDLOOP_START_TIME export
+#   - Fail-open behaviour: errors inside the init do not abort the caller
+#
+# Usage:
+#   bash plugins/code/scripts/tests/test_command_telemetry_init.sh
+#
+# Exit code: 0 if all tests pass, 1 if any test fails.
+
+set -uo pipefail  # -e dropped: tests use explicit ||-capture and assertion reporters
+
+# ---- Paths ---------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INIT_SCRIPT="$SCRIPT_DIR/../command-telemetry-init.sh"
+
+# ---- Counters ------------------------------------------------------------
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ---- Reporters -----------------------------------------------------------
+pass() {
+    local name="$1"
+    echo "  PASS: $name"
+    PASS_COUNT=$(( PASS_COUNT + 1 ))
+}
+
+fail() {
+    local name="$1"
+    local reason="$2"
+    echo "  FAIL: $name -- $reason"
+    FAIL_COUNT=$(( FAIL_COUNT + 1 ))
+}
+
+assert_equals() {
+    local test_name="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$test_name"
+    else
+        fail "$test_name" "expected '$expected' but got '$actual'"
+    fi
+}
+
+assert_nonempty() {
+    local test_name="$1"
+    local value="$2"
+    if [[ -n "$value" ]]; then
+        pass "$test_name"
+    else
+        fail "$test_name" "value was empty"
+    fi
+}
+
+assert_matches() {
+    local test_name="$1"
+    local pattern="$2"
+    local value="$3"
+    if [[ "$value" =~ $pattern ]]; then
+        pass "$test_name"
+    else
+        fail "$test_name" "value '$value' did not match pattern '$pattern'"
+    fi
+}
+
+# ---- Helper: source the init script in a clean subshell and print env vars ---
+# Invocation: run_init [arg1] [arg2] [env_overrides...]
+# Prints one line per exported var: NAME=VALUE
+run_init_and_dump() {
+    # $1 = command_name arg (may be empty string)
+    # $2 = workdir arg     (may be empty string)
+    # $3 = CLOSEDLOOP_WORKDIR env override (may be empty string)
+    local cmd_arg="${1:-}"
+    local workdir_arg="${2:-}"
+    local env_workdir="${3:-}"
+
+    bash -c "
+        $([ -n '$env_workdir' ] && echo "export CLOSEDLOOP_WORKDIR='$env_workdir'" || echo "unset CLOSEDLOOP_WORKDIR")
+        source '$INIT_SCRIPT' '$cmd_arg' '$workdir_arg'
+        echo \"CLOSEDLOOP_WORKDIR=\$CLOSEDLOOP_WORKDIR\"
+        echo \"CLOSEDLOOP_RUN_ID=\$CLOSEDLOOP_RUN_ID\"
+        echo \"CLOSEDLOOP_COMMAND=\$CLOSEDLOOP_COMMAND\"
+        echo \"CLOSEDLOOP_START_TIME=\$CLOSEDLOOP_START_TIME\"
+    "
+}
+
+# ---- Setup helpers -------------------------------------------------------
+setup_temp_workdir() {
+    mktemp -d
+}
+
+# ---- Tests ---------------------------------------------------------------
+
+echo "Running tests for command-telemetry-init.sh"
+echo ""
+
+# ------------------------------------------------------------------
+# Test 1: WORKDIR from $2 argument overrides everything
+# ------------------------------------------------------------------
+echo "Test 1: WORKDIR detection — from \$2 argument"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    # Pass workdir as $2; also set env var to ensure $2 wins
+    output=$(bash -c "
+        export CLOSEDLOOP_WORKDIR='/should/not/be/used'
+        source '$INIT_SCRIPT' 'test-cmd' '$tmpdir'
+        echo \"\$CLOSEDLOOP_WORKDIR\"
+    ")
+
+    assert_equals "WORKDIR from \$2 argument" "$tmpdir" "$output"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 2: WORKDIR from CLOSEDLOOP_WORKDIR env var when no $2 argument
+# ------------------------------------------------------------------
+echo "Test 2: WORKDIR detection — from CLOSEDLOOP_WORKDIR env var"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    output=$(bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        source '$INIT_SCRIPT' 'test-cmd'
+        echo \"\$CLOSEDLOOP_WORKDIR\"
+    ")
+
+    assert_equals "WORKDIR from env var" "$tmpdir" "$output"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 3: WORKDIR defaults to .closedloop-ai/telemetry when neither arg nor env var
+# ------------------------------------------------------------------
+echo "Test 3: WORKDIR detection — default fallback"
+{
+    output=$(bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$INIT_SCRIPT' 'test-cmd'
+        echo \"\$CLOSEDLOOP_WORKDIR\"
+    ")
+
+    assert_equals "WORKDIR default" ".closedloop-ai/telemetry" "$output"
+}
+
+# ------------------------------------------------------------------
+# Test 4: $2 argument takes precedence over CLOSEDLOOP_WORKDIR env var
+# ------------------------------------------------------------------
+echo "Test 4: WORKDIR precedence — \$2 arg wins over env var"
+{
+    tmpdir_arg=$(setup_temp_workdir)
+    tmpdir_env=$(setup_temp_workdir)
+
+    output=$(bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir_env'
+        source '$INIT_SCRIPT' 'test-cmd' '$tmpdir_arg'
+        echo \"\$CLOSEDLOOP_WORKDIR\"
+    ")
+
+    assert_equals "WORKDIR arg beats env var" "$tmpdir_arg" "$output"
+
+    rm -rf "$tmpdir_arg" "$tmpdir_env"
+}
+
+# ------------------------------------------------------------------
+# Test 5: CLOSEDLOOP_COMMAND is exported with the value of $1
+# ------------------------------------------------------------------
+echo "Test 5: CLOSEDLOOP_COMMAND is exported"
+{
+    output=$(bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$INIT_SCRIPT' 'my-slash-command'
+        echo \"\$CLOSEDLOOP_COMMAND\"
+    ")
+
+    assert_equals "CLOSEDLOOP_COMMAND set" "my-slash-command" "$output"
+}
+
+# ------------------------------------------------------------------
+# Test 6: CLOSEDLOOP_RUN_ID is generated and non-empty
+# ------------------------------------------------------------------
+echo "Test 6: CLOSEDLOOP_RUN_ID is generated and non-empty"
+{
+    output=$(bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$INIT_SCRIPT' 'test-cmd'
+        echo \"\$CLOSEDLOOP_RUN_ID\"
+    ")
+
+    assert_nonempty "CLOSEDLOOP_RUN_ID non-empty" "$output"
+}
+
+# ------------------------------------------------------------------
+# Test 7: CLOSEDLOOP_RUN_ID matches YYYYMMDD-HHMMSS-HEXHEX format
+# ------------------------------------------------------------------
+echo "Test 7: CLOSEDLOOP_RUN_ID format matches YYYYMMDD-HHMMSS-<hex>"
+{
+    output=$(bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$INIT_SCRIPT' 'test-cmd'
+        echo \"\$CLOSEDLOOP_RUN_ID\"
+    ")
+
+    # Format: 8 digits - 6 digits - hex chars (8 hex chars from 4-byte xxd)
+    assert_matches "CLOSEDLOOP_RUN_ID format" \
+        '^[0-9]{8}-[0-9]{6}-[0-9a-f]+$' \
+        "$output"
+}
+
+# ------------------------------------------------------------------
+# Test 8: CLOSEDLOOP_RUN_ID timestamp portion matches today's date (YYYYMMDD)
+# ------------------------------------------------------------------
+echo "Test 8: CLOSEDLOOP_RUN_ID date portion matches today"
+{
+    today=$(date +%Y%m%d)
+    output=$(bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$INIT_SCRIPT' 'test-cmd'
+        echo \"\$CLOSEDLOOP_RUN_ID\"
+    ")
+
+    date_part="${output:0:8}"
+    assert_equals "CLOSEDLOOP_RUN_ID date portion" "$today" "$date_part"
+}
+
+# ------------------------------------------------------------------
+# Test 9: CLOSEDLOOP_START_TIME is exported and non-empty
+# ------------------------------------------------------------------
+echo "Test 9: CLOSEDLOOP_START_TIME is exported and non-empty"
+{
+    output=$(bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$INIT_SCRIPT' 'test-cmd'
+        echo \"\$CLOSEDLOOP_START_TIME\"
+    ")
+
+    assert_nonempty "CLOSEDLOOP_START_TIME non-empty" "$output"
+}
+
+# ------------------------------------------------------------------
+# Test 10: CLOSEDLOOP_START_TIME is a unix epoch integer
+# ------------------------------------------------------------------
+echo "Test 10: CLOSEDLOOP_START_TIME is a unix epoch integer"
+{
+    output=$(bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$INIT_SCRIPT' 'test-cmd'
+        echo \"\$CLOSEDLOOP_START_TIME\"
+    ")
+
+    # Must be all digits and greater than a fixed past epoch (2020-01-01 = 1577836800)
+    if [[ "$output" =~ ^[0-9]+$ ]] && [[ "$output" -gt 1577836800 ]]; then
+        pass "CLOSEDLOOP_START_TIME is a valid epoch"
+    else
+        fail "CLOSEDLOOP_START_TIME is a valid epoch" "got '$output'"
+    fi
+}
+
+# ------------------------------------------------------------------
+# Test 11: Missing COMMAND_NAME (empty $1) — script still exits 0,
+#          env vars are NOT set (init bails early)
+# ------------------------------------------------------------------
+echo "Test 11: Empty command name — script exits 0 (fail-open)"
+{
+    actual_exit=0
+    bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$INIT_SCRIPT' ''
+    " ; actual_exit=$?
+
+    if [[ "$actual_exit" -eq 0 ]]; then
+        pass "empty command name: exits 0"
+    else
+        fail "empty command name: exits 0" "got exit $actual_exit"
+    fi
+}
+
+# ------------------------------------------------------------------
+# Test 12: Fail-open — record_run.sh missing does not abort the caller
+#
+# We override PATH to a temp dir where record_run.sh does not exist,
+# but the script should still exit 0.
+# ------------------------------------------------------------------
+echo "Test 12: Fail-open — missing record_run.sh does not abort"
+{
+    # Create a temp scripts dir that has command-telemetry-init.sh but no record_run.sh
+    tmpscripts=$(setup_temp_workdir)
+    cp "$INIT_SCRIPT" "$tmpscripts/command-telemetry-init.sh"
+    # Note: we do NOT copy record_run.sh — it won't be found
+
+    actual_exit=0
+    bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$tmpscripts/command-telemetry-init.sh' 'test-cmd'
+    " ; actual_exit=$?
+
+    if [[ "$actual_exit" -eq 0 ]]; then
+        pass "missing record_run.sh: exits 0"
+    else
+        fail "missing record_run.sh: exits 0" "got exit $actual_exit"
+    fi
+
+    rm -rf "$tmpscripts"
+}
+
+# ------------------------------------------------------------------
+# Test 13: Fail-open — record_run.sh failing does not abort the caller
+# ------------------------------------------------------------------
+echo "Test 13: Fail-open — failing record_run.sh does not abort"
+{
+    # Create a temp scripts dir with a record_run.sh that exits non-zero
+    tmpscripts=$(setup_temp_workdir)
+    cp "$INIT_SCRIPT" "$tmpscripts/command-telemetry-init.sh"
+    cat > "$tmpscripts/record_run.sh" <<'INNER'
+#!/usr/bin/env bash
+exit 99
+INNER
+    chmod +x "$tmpscripts/record_run.sh"
+
+    actual_exit=0
+    bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$tmpscripts/command-telemetry-init.sh' 'test-cmd'
+    " ; actual_exit=$?
+
+    if [[ "$actual_exit" -eq 0 ]]; then
+        pass "failing record_run.sh: exits 0"
+    else
+        fail "failing record_run.sh: exits 0" "got exit $actual_exit"
+    fi
+
+    rm -rf "$tmpscripts"
+}
+
+# ------------------------------------------------------------------
+# Test 14: All four env vars are exported together in one invocation
+# ------------------------------------------------------------------
+echo "Test 14: All four env vars exported together"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    output=$(bash -c "
+        export CLOSEDLOOP_WORKDIR='$tmpdir'
+        source '$INIT_SCRIPT' 'combined-test'
+        echo \"WORKDIR=\$CLOSEDLOOP_WORKDIR\"
+        echo \"RUN_ID=\$CLOSEDLOOP_RUN_ID\"
+        echo \"COMMAND=\$CLOSEDLOOP_COMMAND\"
+        echo \"START_TIME=\$CLOSEDLOOP_START_TIME\"
+    ")
+
+    workdir_val=$(echo "$output" | grep '^WORKDIR=' | cut -d= -f2-)
+    run_id_val=$(echo "$output" | grep '^RUN_ID=' | cut -d= -f2-)
+    command_val=$(echo "$output" | grep '^COMMAND=' | cut -d= -f2-)
+    start_time_val=$(echo "$output" | grep '^START_TIME=' | cut -d= -f2-)
+
+    assert_equals  "combined: CLOSEDLOOP_WORKDIR"    "$tmpdir"         "$workdir_val"
+    assert_equals  "combined: CLOSEDLOOP_COMMAND"    "combined-test"   "$command_val"
+    assert_nonempty "combined: CLOSEDLOOP_RUN_ID"    "$run_id_val"
+    assert_nonempty "combined: CLOSEDLOOP_START_TIME" "$start_time_val"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 15: CLOSEDLOOP_RUN_ID is unique across two successive invocations
+# ------------------------------------------------------------------
+echo "Test 15: CLOSEDLOOP_RUN_ID is unique per invocation"
+{
+    run_id_1=$(bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$INIT_SCRIPT' 'test-cmd'
+        echo \"\$CLOSEDLOOP_RUN_ID\"
+    ")
+
+    # Small sleep to ensure different timestamp (1 second resolution)
+    sleep 1
+
+    run_id_2=$(bash -c "
+        unset CLOSEDLOOP_WORKDIR
+        source '$INIT_SCRIPT' 'test-cmd'
+        echo \"\$CLOSEDLOOP_RUN_ID\"
+    ")
+
+    if [[ "$run_id_1" != "$run_id_2" ]]; then
+        pass "CLOSEDLOOP_RUN_ID uniqueness across invocations"
+    else
+        # IDs could technically collide on a fast machine; report but don't hard-fail
+        # (the random suffix makes this extremely unlikely)
+        fail "CLOSEDLOOP_RUN_ID uniqueness across invocations" \
+             "both runs produced '$run_id_1' (may be timing issue)"
+    fi
+}
+
+# ---- Summary -------------------------------------------------------------
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/plugins/code/scripts/tests/test_telemetry_helpers.sh
+++ b/plugins/code/scripts/tests/test_telemetry_helpers.sh
@@ -1,0 +1,620 @@
+#!/usr/bin/env bash
+# Tests for telemetry-helpers.sh
+#
+# Validates that the three functions extracted from run-loop.sh produce correct
+# JSONL output:
+#   emit_perf_event  — appends a single-line JSON event to perf.jsonl
+#   run_timed_step   — wraps a command, emits a pipeline_step event with timing
+#   emit_skipped_step — emits a pipeline_step event with skipped=true
+#
+# Also validates that the env-var-based approach (CLOSEDLOOP_RUN_ID,
+# CLOSEDLOOP_ITERATION, CLOSEDLOOP_WORKDIR, CLOSEDLOOP_COMMAND) works correctly
+# when the helpers are sourced in an isolated context (no run-loop.sh globals).
+#
+# Usage:
+#   bash plugins/code/scripts/tests/test_telemetry_helpers.sh
+#
+# Exit code: 0 if all tests pass, 1 if any test fails.
+
+set -uo pipefail  # -e dropped: tests use explicit ||-capture and assertion reporters
+
+# ---- Paths ---------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS="$SCRIPT_DIR/../telemetry-helpers.sh"
+
+# ---- Counters ------------------------------------------------------------
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ---- Reporters -----------------------------------------------------------
+pass() {
+    local name="$1"
+    echo "  PASS: $name"
+    PASS_COUNT=$(( PASS_COUNT + 1 ))
+}
+
+fail() {
+    local name="$1"
+    local reason="$2"
+    echo "  FAIL: $name -- $reason"
+    FAIL_COUNT=$(( FAIL_COUNT + 1 ))
+}
+
+# ---- JSON field assertions -----------------------------------------------
+assert_field_present() {
+    local test_name="$1"
+    local json="$2"
+    local field="$3"
+    local value
+    value=$(echo "$json" | jq -r --arg f "$field" '.[$f] // empty' 2>/dev/null || echo "")
+    if [[ -n "$value" ]] && [[ "$value" != "null" ]]; then
+        pass "$test_name: field '$field' present (value: $value)"
+    else
+        fail "$test_name: field '$field' present" "missing or null in: $json"
+    fi
+}
+
+assert_field_equals() {
+    local test_name="$1"
+    local json="$2"
+    local field="$3"
+    local expected="$4"
+    local actual
+    actual=$(echo "$json" | jq -r --arg f "$field" '.[$f] | tostring' 2>/dev/null || echo "")
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$test_name: field '$field' = '$expected'"
+    else
+        fail "$test_name: field '$field'" "expected '$expected' but got '$actual'"
+    fi
+}
+
+assert_field_type() {
+    # Asserts that a JSON field has the given jq type string.
+    local test_name="$1"
+    local json="$2"
+    local field="$3"
+    local expected_type="$4"
+    local actual_type
+    actual_type=$(echo "$json" | jq -r --arg f "$field" '.[$f] | type' 2>/dev/null || echo "")
+    if [[ "$actual_type" == "$expected_type" ]]; then
+        pass "$test_name: field '$field' is $expected_type"
+    else
+        fail "$test_name: field '$field' type" "expected '$expected_type' but got '$actual_type'"
+    fi
+}
+
+# ---- Setup helpers -------------------------------------------------------
+setup_temp_workdir() {
+    # Creates an isolated temp directory that acts as CLOSEDLOOP_WORKDIR.
+    # Returns the path via stdout.
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    echo "$tmpdir"
+}
+
+# ---- Tests ---------------------------------------------------------------
+
+echo "Running tests for telemetry-helpers.sh"
+echo ""
+
+# ------------------------------------------------------------------
+# Test 1: emit_perf_event appends valid JSONL to perf.jsonl
+# ------------------------------------------------------------------
+echo "Test 1: emit_perf_event appends valid JSONL to perf.jsonl"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="test-command"
+    # Source helpers in a subshell to avoid polluting the outer environment
+    actual_exit=0
+    bash -c "
+        source '$HELPERS'
+        emit_perf_event '{\"event\":\"test_event\",\"run_id\":\"run-123\"}'
+    " ; actual_exit=$?
+
+    if [[ "$actual_exit" -eq 0 ]]; then
+        pass "emit_perf_event exits 0"
+    else
+        fail "emit_perf_event exits 0" "got exit $actual_exit"
+    fi
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        pass "perf.jsonl was created"
+        line=$(tail -1 "$perf_file")
+
+        if echo "$line" | jq empty 2>/dev/null; then
+            pass "emit_perf_event: perf.jsonl line is valid JSON"
+        else
+            fail "emit_perf_event: perf.jsonl line is valid JSON" "not valid JSON: $line"
+        fi
+
+        assert_field_equals "emit_perf_event" "$line" "event" "test_event"
+        assert_field_equals "emit_perf_event" "$line" "run_id" "run-123"
+        # command field is injected by emit_perf_event
+        assert_field_equals "emit_perf_event" "$line" "command" "test-command"
+    else
+        fail "perf.jsonl was created" "file not found at $perf_file"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 2: emit_perf_event is a no-op for empty input (does not corrupt perf.jsonl)
+# ------------------------------------------------------------------
+echo "Test 2: emit_perf_event no-op on empty input"
+{
+    tmpdir=$(setup_temp_workdir)
+    perf_file="$tmpdir/perf.jsonl"
+
+    # Pre-populate with a valid line
+    echo '{"event":"existing"}' > "$perf_file"
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="test"
+    bash -c "
+        source '$HELPERS'
+        emit_perf_event ''
+    "
+
+    # File must still have exactly one line (no blank line appended)
+    line_count=$(wc -l < "$perf_file" | tr -d ' ')
+    if [[ "$line_count" -eq 1 ]]; then
+        pass "emit_perf_event: empty input does not append to perf.jsonl"
+    else
+        fail "emit_perf_event: empty input does not append to perf.jsonl" \
+             "expected 1 line but got $line_count"
+    fi
+
+    # Existing content must be untouched
+    existing=$(head -1 "$perf_file")
+    if echo "$existing" | jq empty 2>/dev/null; then
+        pass "emit_perf_event: existing perf.jsonl content not corrupted"
+    else
+        fail "emit_perf_event: existing perf.jsonl content not corrupted" \
+             "first line is invalid JSON: $existing"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 3: emit_perf_event uses CLOSEDLOOP_COMMAND default "interactive"
+#         when CLOSEDLOOP_COMMAND is unset
+# ------------------------------------------------------------------
+echo "Test 3: emit_perf_event defaults command to 'interactive' when CLOSEDLOOP_COMMAND unset"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    bash -c "
+        unset CLOSEDLOOP_COMMAND
+        source '$HELPERS'
+        emit_perf_event '{\"event\":\"probe\"}'
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "emit_perf_event default command" "$line" "command" "interactive"
+    else
+        fail "emit_perf_event default command" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 4: run_timed_step emits a pipeline_step event with all required fields
+# ------------------------------------------------------------------
+echo "Test 4: run_timed_step emits a pipeline_step event with all required fields"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="plan_execute"
+    export CLOSEDLOOP_RUN_ID="run-timed-test"
+    export CLOSEDLOOP_ITERATION="2"
+
+    bash -c "
+        source '$HELPERS'
+        run_timed_step 3 'test_step' true
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ ! -f "$perf_file" ]]; then
+        fail "run_timed_step: perf.jsonl was created" "file not found"
+    else
+        pass "run_timed_step: perf.jsonl was created"
+        line=$(tail -1 "$perf_file")
+
+        if echo "$line" | jq empty 2>/dev/null; then
+            pass "run_timed_step: perf.jsonl line is valid JSON"
+        else
+            fail "run_timed_step: perf.jsonl line is valid JSON" "not valid JSON: $line"
+        fi
+
+        assert_field_equals "run_timed_step" "$line" "event" "pipeline_step"
+        assert_field_equals "run_timed_step" "$line" "run_id" "run-timed-test"
+        assert_field_equals "run_timed_step" "$line" "iteration" "2"
+        assert_field_equals "run_timed_step" "$line" "step" "3"
+        assert_field_equals "run_timed_step" "$line" "step_name" "test_step"
+        assert_field_equals "run_timed_step" "$line" "skipped" "false"
+        assert_field_equals "run_timed_step" "$line" "exit_code" "0"
+        assert_field_equals "run_timed_step" "$line" "command" "plan_execute"
+        assert_field_present "run_timed_step" "$line" "started_at"
+        assert_field_present "run_timed_step" "$line" "ended_at"
+        assert_field_type "run_timed_step" "$line" "duration_s" "number"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 5: run_timed_step preserves the exit code of the wrapped command
+# ------------------------------------------------------------------
+echo "Test 5: run_timed_step preserves exit code of wrapped command"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="test"
+    export CLOSEDLOOP_RUN_ID="run-exit-test"
+    export CLOSEDLOOP_ITERATION="0"
+
+    actual_exit=0
+    bash -c "
+        source '$HELPERS'
+        run_timed_step 1 'failing_step' bash -c 'exit 42'
+    " ; actual_exit=$?
+
+    if [[ "$actual_exit" -eq 42 ]]; then
+        pass "run_timed_step: preserves exit code 42"
+    else
+        fail "run_timed_step: preserves exit code 42" "got exit $actual_exit"
+    fi
+
+    # Also verify the exit_code field in the emitted event
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "run_timed_step exit_code field" "$line" "exit_code" "42"
+    else
+        fail "run_timed_step exit_code field" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 6: run_timed_step uses CLOSEDLOOP_RUN_ID (env-var approach)
+#         and falls back to RUN_ID shell global for backward-compat
+# ------------------------------------------------------------------
+echo "Test 6: run_timed_step run_id fallback to RUN_ID shell global"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="test"
+    export CLOSEDLOOP_ITERATION="0"
+    # Explicitly unset CLOSEDLOOP_RUN_ID — the helper should fall back to RUN_ID
+    unset CLOSEDLOOP_RUN_ID 2>/dev/null || true
+
+    bash -c "
+        RUN_ID='fallback-run-id'
+        source '$HELPERS'
+        run_timed_step 1 'fallback_step' true
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "run_timed_step RUN_ID fallback" "$line" "run_id" "fallback-run-id"
+    else
+        fail "run_timed_step RUN_ID fallback" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 7: emit_skipped_step emits a pipeline_step event with skipped=true
+# ------------------------------------------------------------------
+echo "Test 7: emit_skipped_step emits correct pipeline_step event"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="plan_execute"
+    export CLOSEDLOOP_RUN_ID="run-skip-test"
+    export CLOSEDLOOP_ITERATION="5"
+
+    bash -c "
+        source '$HELPERS'
+        emit_skipped_step 7 'merge_build_result'
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ ! -f "$perf_file" ]]; then
+        fail "emit_skipped_step: perf.jsonl was created" "file not found"
+    else
+        pass "emit_skipped_step: perf.jsonl was created"
+        line=$(tail -1 "$perf_file")
+
+        if echo "$line" | jq empty 2>/dev/null; then
+            pass "emit_skipped_step: perf.jsonl line is valid JSON"
+        else
+            fail "emit_skipped_step: perf.jsonl line is valid JSON" "not valid JSON: $line"
+        fi
+
+        assert_field_equals "emit_skipped_step" "$line" "event" "pipeline_step"
+        assert_field_equals "emit_skipped_step" "$line" "run_id" "run-skip-test"
+        assert_field_equals "emit_skipped_step" "$line" "iteration" "5"
+        assert_field_equals "emit_skipped_step" "$line" "step" "7"
+        assert_field_equals "emit_skipped_step" "$line" "step_name" "merge_build_result"
+        assert_field_equals "emit_skipped_step" "$line" "skipped" "true"
+        assert_field_equals "emit_skipped_step" "$line" "duration_s" "0"
+        assert_field_equals "emit_skipped_step" "$line" "exit_code" "0"
+        assert_field_equals "emit_skipped_step" "$line" "command" "plan_execute"
+        assert_field_present "emit_skipped_step" "$line" "started_at"
+        assert_field_present "emit_skipped_step" "$line" "ended_at"
+
+        # started_at and ended_at must be equal for a skipped step (no elapsed time)
+        started_at=$(echo "$line" | jq -r '.started_at')
+        ended_at=$(echo "$line" | jq -r '.ended_at')
+        if [[ "$started_at" == "$ended_at" ]]; then
+            pass "emit_skipped_step: started_at == ended_at"
+        else
+            fail "emit_skipped_step: started_at == ended_at" \
+                 "started_at=$started_at ended_at=$ended_at"
+        fi
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 8: emit_skipped_step uses CLOSEDLOOP_RUN_ID env var
+# ------------------------------------------------------------------
+echo "Test 8: emit_skipped_step uses CLOSEDLOOP_RUN_ID env var"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="test"
+    export CLOSEDLOOP_RUN_ID="env-run-id"
+    export CLOSEDLOOP_ITERATION="3"
+
+    bash -c "
+        source '$HELPERS'
+        emit_skipped_step 2 'pattern_relevance'
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "emit_skipped_step CLOSEDLOOP_RUN_ID" "$line" "run_id" "env-run-id"
+    else
+        fail "emit_skipped_step CLOSEDLOOP_RUN_ID" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 9: emit_skipped_step falls back to RUN_ID shell global
+# ------------------------------------------------------------------
+echo "Test 9: emit_skipped_step run_id fallback to RUN_ID shell global"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="test"
+    export CLOSEDLOOP_ITERATION="0"
+    unset CLOSEDLOOP_RUN_ID 2>/dev/null || true
+
+    bash -c "
+        RUN_ID='global-run-id'
+        source '$HELPERS'
+        emit_skipped_step 4 'evaluate_goal'
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "emit_skipped_step RUN_ID fallback" "$line" "run_id" "global-run-id"
+    else
+        fail "emit_skipped_step RUN_ID fallback" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 10: CLOSEDLOOP_ITERATION defaults to 0 when unset
+# ------------------------------------------------------------------
+echo "Test 10: CLOSEDLOOP_ITERATION defaults to 0 when unset"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="test"
+    export CLOSEDLOOP_RUN_ID="run-iter-default"
+    unset CLOSEDLOOP_ITERATION 2>/dev/null || true
+
+    bash -c "
+        unset CLOSEDLOOP_ITERATION
+        source '$HELPERS'
+        emit_skipped_step 1 'changed_files'
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+        assert_field_equals "CLOSEDLOOP_ITERATION default" "$line" "iteration" "0"
+    else
+        fail "CLOSEDLOOP_ITERATION default" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 11: multiple events are appended as separate JSONL lines
+# ------------------------------------------------------------------
+echo "Test 11: multiple emit calls produce separate JSONL lines"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="test"
+    export CLOSEDLOOP_RUN_ID="run-multi"
+    export CLOSEDLOOP_ITERATION="1"
+
+    bash -c "
+        source '$HELPERS'
+        emit_skipped_step 1 'step_one'
+        emit_skipped_step 2 'step_two'
+        emit_skipped_step 3 'step_three'
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line_count=$(wc -l < "$perf_file" | tr -d ' ')
+        if [[ "$line_count" -eq 3 ]]; then
+            pass "multiple emit calls: 3 lines in perf.jsonl"
+        else
+            fail "multiple emit calls: 3 lines in perf.jsonl" "got $line_count lines"
+        fi
+
+        # Every line must be valid JSON
+        bad=0
+        while IFS= read -r l; do
+            if [[ -n "$l" ]] && ! echo "$l" | jq empty 2>/dev/null; then
+                bad=$(( bad + 1 ))
+            fi
+        done < "$perf_file"
+        if [[ "$bad" -eq 0 ]]; then
+            pass "multiple emit calls: all lines are valid JSON"
+        else
+            fail "multiple emit calls: all lines are valid JSON" "$bad invalid line(s)"
+        fi
+    else
+        fail "multiple emit calls" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 12: run_timed_step output matches the schema produced by
+#          the original inline jq block in run-loop.sh (structural
+#          equivalence: same keys, same field types)
+# ------------------------------------------------------------------
+echo "Test 12: run_timed_step schema matches run-loop.sh inline block schema"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="plan_execute"
+    export CLOSEDLOOP_RUN_ID="run-schema-check"
+    export CLOSEDLOOP_ITERATION="1"
+
+    bash -c "
+        source '$HELPERS'
+        run_timed_step 1 'changed_files' true
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+
+        # Required keys from the original inline jq block in post_iteration_processing
+        required_keys=("event" "run_id" "iteration" "step" "step_name" "started_at" "ended_at" "duration_s" "exit_code" "skipped" "command")
+        all_present=true
+        for key in "${required_keys[@]}"; do
+            val=$(echo "$line" | jq -r --arg k "$key" '.[$k] // empty' 2>/dev/null || echo "")
+            if [[ -z "$val" ]] && [[ "$val" != "0" ]] && [[ "$val" != "false" ]]; then
+                # Re-check with tostring to catch 0 / false
+                val=$(echo "$line" | jq -r --arg k "$key" 'if has($k) then "present" else empty end' 2>/dev/null || echo "")
+                if [[ "$val" != "present" ]]; then
+                    fail "schema check: key '$key' present" "missing from: $line"
+                    all_present=false
+                fi
+            fi
+        done
+        if [[ "$all_present" == "true" ]]; then
+            pass "run_timed_step schema: all required keys present"
+        fi
+
+        # Numeric fields must be numbers
+        assert_field_type "run_timed_step schema" "$line" "duration_s" "number"
+        assert_field_type "run_timed_step schema" "$line" "exit_code" "number"
+        assert_field_type "run_timed_step schema" "$line" "iteration" "number"
+        assert_field_type "run_timed_step schema" "$line" "step" "number"
+
+        # Boolean fields must be boolean
+        assert_field_type "run_timed_step schema" "$line" "skipped" "boolean"
+    else
+        fail "run_timed_step schema" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 13: emit_skipped_step schema matches run-loop.sh inline block schema
+# ------------------------------------------------------------------
+echo "Test 13: emit_skipped_step schema matches run-loop.sh inline block schema"
+{
+    tmpdir=$(setup_temp_workdir)
+
+    export CLOSEDLOOP_WORKDIR="$tmpdir"
+    export CLOSEDLOOP_COMMAND="plan_execute"
+    export CLOSEDLOOP_RUN_ID="run-skip-schema"
+    export CLOSEDLOOP_ITERATION="2"
+
+    bash -c "
+        source '$HELPERS'
+        emit_skipped_step 6 'verify_citations'
+    "
+
+    perf_file="$tmpdir/perf.jsonl"
+    if [[ -f "$perf_file" ]]; then
+        line=$(tail -1 "$perf_file")
+
+        required_keys=("event" "run_id" "iteration" "step" "step_name" "started_at" "ended_at" "duration_s" "exit_code" "skipped" "command")
+        all_present=true
+        for key in "${required_keys[@]}"; do
+            val=$(echo "$line" | jq -r --arg k "$key" 'if has($k) then "present" else empty end' 2>/dev/null || echo "")
+            if [[ "$val" != "present" ]]; then
+                fail "skip schema: key '$key' present" "missing from: $line"
+                all_present=false
+            fi
+        done
+        if [[ "$all_present" == "true" ]]; then
+            pass "emit_skipped_step schema: all required keys present"
+        fi
+
+        assert_field_type "emit_skipped_step schema" "$line" "duration_s" "number"
+        assert_field_type "emit_skipped_step schema" "$line" "exit_code" "number"
+        assert_field_type "emit_skipped_step schema" "$line" "iteration" "number"
+        assert_field_type "emit_skipped_step schema" "$line" "step" "number"
+        assert_field_type "emit_skipped_step schema" "$line" "skipped" "boolean"
+    else
+        fail "emit_skipped_step schema" "perf.jsonl not created"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ---- Summary -------------------------------------------------------------
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/plugins/code/tools/python/test_run_loop_failure_marker.py
+++ b/plugins/code/tools/python/test_run_loop_failure_marker.py
@@ -677,6 +677,7 @@ def test_write_runs_log_entry_uses_workdir_root(tmp_path: Path) -> None:
     result = run_bash(
         f"""
         source {RUN_LOOP}
+        unset LAST_CLAUDE_COMMAND CLOSEDLOOP_COMMAND
         RUN_ID='run-root-log'
         write_runs_log_entry "$CLOSEDLOOP_WORKDIR" 2 completed
         """,

--- a/plugins/self-learning/.claude-plugin/plugin.json
+++ b/plugins/self-learning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "self-learning",
   "description": "Self-learning plugin",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/self-learning/commands/export-closedloop-learnings.md
+++ b/plugins/self-learning/commands/export-closedloop-learnings.md
@@ -85,11 +85,21 @@ claude -p "/self-learning:export-closedloop-learnings $WORKDIR"
 ## Instructions
 
 When invoked:
-1. Determine the workdir from the first argument or use current directory
-2. Check if `$workdir/.learnings/pending-closedloop.json` exists - if not, output "No pending closedloop learnings" and exit
-3. Read the pending file
-4. Read or create `~/.closedloop-ai/learnings/closedloop-learnings.json` with empty learnings array
-5. For each pending learning, apply deduplication logic
-6. If any new learnings were added, write the updated global file with `last_updated` timestamp
-7. Delete `$workdir/.learnings/pending-closedloop.json`
-8. Report: "Exported N new learnings, skipped M duplicates"
+
+1. **Initialise telemetry** (always first):
+   ```bash
+   source "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh" "export-closedloop-learnings"
+   ```
+
+2. Determine the workdir from the first argument or use current directory
+3. Check if `$workdir/.learnings/pending-closedloop.json` exists - if not, output "No pending closedloop learnings" and exit
+4. Read the pending file
+5. Read or create `~/.closedloop-ai/learnings/closedloop-learnings.json` with empty learnings array
+6. For each pending learning, apply deduplication logic
+7. If any new learnings were added, write the updated global file with `last_updated` timestamp
+8. Delete `$workdir/.learnings/pending-closedloop.json`
+9. Report: "Exported N new learnings, skipped M duplicates"
+10. **Complete telemetry**:
+    ```bash
+    bash "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh"
+    ```

--- a/plugins/self-learning/commands/goal-stats.md
+++ b/plugins/self-learning/commands/goal-stats.md
@@ -16,14 +16,23 @@ Analyzes goal performance by examining runs.log and outcomes.log to compute stat
 
 ## Process
 
-1. Read `runs.log` for run outcomes. Rows are pipe-delimited:
+1. **Initialise telemetry** (always first):
+   ```bash
+   source "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh" "goal-stats"
+   ```
+
+2. Read `runs.log` for run outcomes. Rows are pipe-delimited:
    `run_id|timestamp|goal|iteration|status[|command|last_session_id]`.
    Treat `command` and `last_session_id` as optional append-only fields so
    legacy rows remain valid.
-2. Read `outcomes.log` for pattern applications and goal results
-3. Correlate pattern usage with goal success/failure
-4. Calculate aggregate statistics
-5. Identify patterns to review or promote
+3. Read `outcomes.log` for pattern applications and goal results
+4. Correlate pattern usage with goal success/failure
+5. Calculate aggregate statistics
+6. Identify patterns to review or promote
+7. **Complete telemetry**:
+   ```bash
+   bash "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh"
+   ```
 
 ## Output Format
 

--- a/plugins/self-learning/commands/process-learnings.md
+++ b/plugins/self-learning/commands/process-learnings.md
@@ -31,6 +31,12 @@ This command processes learnings captured during ClosedLoop runs and merges them
 
 Execute these steps in order:
 
+### Step 0: Initialise Telemetry
+
+```bash
+source "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh" "process-learnings"
+```
+
 ### Step 1: Determine Working Directory
 
 Parse the argument to identify CLOSEDLOOP_WORKDIR:
@@ -318,6 +324,12 @@ def is_duplicate(existing, new):
 def merge_patterns(existing, new):
     existing.seen_count += 1
     existing.confidence = recalculate_confidence(existing)
+```
+
+### Step 6: Complete Telemetry
+
+```bash
+bash "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh"
 ```
 
 ### Success Rate Calculation

--- a/plugins/self-learning/commands/prune-learnings.md
+++ b/plugins/self-learning/commands/prune-learnings.md
@@ -65,6 +65,27 @@ protected_window_minutes: 30
 # This is automatically run after each completed run
 ```
 
+## Instructions
+
+When invoked:
+
+1. **Initialise telemetry** (always first):
+   ```bash
+   source "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh" "prune-learnings"
+   ```
+
+2. Run the pruning script:
+   ```bash
+   bash "$CLAUDE_PLUGIN_ROOT/scripts/prune-learnings.sh"
+   ```
+
+3. Report the output to the user (sessions pruned, log lines rotated, archived files cleaned, any errors).
+
+4. **Complete telemetry**:
+   ```bash
+   bash "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh"
+   ```
+
 ## Automatic Pruning
 
 Pruning runs automatically:

--- a/plugins/self-learning/commands/pull-learnings.md
+++ b/plugins/self-learning/commands/pull-learnings.md
@@ -14,11 +14,20 @@ Imports organization patterns from a shared repository into local TOON format.
 
 ## Process
 
-1. **Read shared patterns**: Load `$CLOSEDLOOP_WORKDIR/.closedloop-ai/learnings/org-patterns.json`
-2. **Convert JSON → TOON**: For LLM consumption
-3. **Regenerate local IDs**: Maintain unique IDs within local file
-4. **Skip echo patterns**: Exclude patterns that originated from this project
-5. **Merge into local**: Update `$CLOSEDLOOP_WORKDIR/.learnings/org-patterns.toon`
+1. **Initialise telemetry** (always first):
+   ```bash
+   source "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh" "pull-learnings"
+   ```
+
+2. **Read shared patterns**: Load `$CLOSEDLOOP_WORKDIR/.closedloop-ai/learnings/org-patterns.json`
+3. **Convert JSON → TOON**: For LLM consumption
+4. **Regenerate local IDs**: Maintain unique IDs within local file
+5. **Skip echo patterns**: Exclude patterns that originated from this project
+6. **Merge into local**: Update `$CLOSEDLOOP_WORKDIR/.learnings/org-patterns.toon`
+7. **Complete telemetry**:
+   ```bash
+   bash "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh"
+   ```
 
 ## Echo Prevention
 

--- a/plugins/self-learning/commands/push-learnings.md
+++ b/plugins/self-learning/commands/push-learnings.md
@@ -14,12 +14,21 @@ Exports local organization patterns to a shared repository for team-wide distrib
 
 ## Process
 
-1. **Read local patterns**: Load `$CLOSEDLOOP_WORKDIR/.learnings/org-patterns.toon`
-2. **Convert TOON → JSON**: For cross-project compatibility
-3. **Regenerate pattern IDs**: Resolve collisions (P-001 might exist in target)
-4. **Merge with shared patterns**: Read `$CLOSEDLOOP_WORKDIR/.closedloop-ai/learnings/org-patterns.json`
-5. **Track source project**: Update `sources.json` with origin metadata
-6. **Write merged output**: Save to shared location
+1. **Initialise telemetry** (always first):
+   ```bash
+   source "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-init.sh" "push-learnings"
+   ```
+
+2. **Read local patterns**: Load `$CLOSEDLOOP_WORKDIR/.learnings/org-patterns.toon`
+3. **Convert TOON → JSON**: For cross-project compatibility
+4. **Regenerate pattern IDs**: Resolve collisions (P-001 might exist in target)
+5. **Merge with shared patterns**: Read `$CLOSEDLOOP_WORKDIR/.closedloop-ai/learnings/org-patterns.json`
+6. **Track source project**: Update `sources.json` with origin metadata
+7. **Write merged output**: Save to shared location
+8. **Complete telemetry**:
+   ```bash
+   bash "$CLAUDE_PLUGIN_ROOT/scripts/command-telemetry-complete.sh"
+   ```
 
 ## ID Collision Resolution
 

--- a/plugins/self-learning/scripts/command-telemetry-complete.sh
+++ b/plugins/self-learning/scripts/command-telemetry-complete.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# command-telemetry-complete.sh — Telemetry finaliser for slash commands.
+#
+# Designed to be called (not sourced) by command markdown files at the end of
+# a command run to emit a `command_complete` event to perf.jsonl.
+#
+# Usage:
+#   bash "${CLAUDE_PLUGIN_ROOT}/scripts/command-telemetry-complete.sh" [exit_status]
+#
+# Arguments:
+#   $1  EXIT_STATUS (optional, default: 0) — the exit status of the command
+#
+# Environment variables consumed (set by command-telemetry-init.sh):
+#   CLOSEDLOOP_START_TIME  — unix epoch when the command started (required for duration)
+#   CLOSEDLOOP_RUN_ID      — unique run identifier
+#   CLOSEDLOOP_WORKDIR     — working directory for perf.jsonl output
+#   CLOSEDLOOP_COMMAND     — slash command name
+#
+# Fail-open guarantee: the entire finalisation is wrapped in a trap so any
+# error is suppressed and the calling command continues unaffected.
+
+# Fail open: any unexpected error exits 0 so the calling command is unaffected.
+trap 'exit 0' ERR
+
+_closedloop_telemetry_complete() {
+  local exit_status="${1:-0}"
+
+  # Resolve working directory. The matching command-telemetry-init.sh exports
+  # CLOSEDLOOP_WORKDIR, but those exports are scoped to the shell that ran
+  # `source` and do not survive across separate Bash tool invocations. When
+  # the env var is unset, fall back to the default workdir init.sh uses
+  # (.closedloop-ai/telemetry) only if a state file exists there — otherwise
+  # the command was never initialised and there is nothing to finalise.
+  local workdir="${CLOSEDLOOP_WORKDIR:-}"
+  if [[ -z "$workdir" ]]; then
+    if [[ -f ".closedloop-ai/telemetry/.cmd-state.env" ]]; then
+      workdir=".closedloop-ai/telemetry"
+    else
+      return 0
+    fi
+  fi
+
+  # If RUN_ID is missing, recover the run context that init.sh persisted to
+  # disk. This bridges the gap between separate Bash tool invocations: init
+  # exported env vars but they died with its source shell.
+  local state_file="$workdir/.cmd-state.env"
+  if [[ -z "${CLOSEDLOOP_RUN_ID:-}" && -f "$state_file" ]]; then
+    # shellcheck source=/dev/null
+    source "$state_file" 2>/dev/null || true
+    workdir="${CLOSEDLOOP_WORKDIR:-$workdir}"
+  fi
+
+  local perf_file="$workdir/perf.jsonl"
+
+  # Capture end time
+  local end_epoch
+  end_epoch=$(date +%s 2>/dev/null) || end_epoch=""
+  local ended_at
+  ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || ended_at=""
+
+  # Resolve start time and calculate duration
+  local start_epoch="${CLOSEDLOOP_START_TIME:-}"
+  local started_at=""
+  local duration_s=0
+
+  if [[ -n "$start_epoch" && -n "$end_epoch" ]]; then
+    duration_s=$(( end_epoch - start_epoch ))
+    # Convert start epoch to ISO-8601 timestamp
+    started_at=$(date -u -r "$start_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+      || started_at=$(date -u -d "@$start_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+      || started_at=""
+  fi
+
+  local run_id="${CLOSEDLOOP_RUN_ID:-unknown}"
+  local command="${CLOSEDLOOP_COMMAND:-interactive}"
+
+  # Ensure perf.jsonl directory exists
+  mkdir -p "$(dirname "$perf_file")" 2>/dev/null || true
+
+  # Build and emit the command_complete JSONL event, injecting command: field
+  # to match the pattern used by emit_perf_event in telemetry-helpers.sh
+  jq -n -c \
+    --arg event "command_complete" \
+    --arg run_id "$run_id" \
+    --arg command "$command" \
+    --arg started_at "$started_at" \
+    --arg ended_at "$ended_at" \
+    --argjson duration_s "$duration_s" \
+    --argjson exit_status "$exit_status" \
+    '{event:$event,run_id:$run_id,command:$command,started_at:$started_at,ended_at:$ended_at,duration_s:$duration_s,exit_status:$exit_status}' \
+    >> "$perf_file" 2>/dev/null || true
+
+  # Drop the recovered state file so stale state cannot leak into a later
+  # command that fails to call init.sh.
+  rm -f "$state_file" 2>/dev/null || true
+}
+
+_closedloop_telemetry_complete "$@"
+exit 0

--- a/plugins/self-learning/scripts/command-telemetry-init.sh
+++ b/plugins/self-learning/scripts/command-telemetry-init.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# command-telemetry-init.sh — Telemetry initialiser for slash commands.
+#
+# Designed to be SOURCED (not executed) by command markdown files at startup
+# so that the exported env vars remain visible to subsequent steps in the same
+# Claude Code session:
+#
+#   source "${CLAUDE_PLUGIN_ROOT}/scripts/command-telemetry-init.sh" <command-name> [workdir]
+#
+# Arguments:
+#   $1  COMMAND_NAME (required) — the slash-command name, e.g. "code", "amend-plan"
+#   $2  WORKDIR       (optional) — overrides env var and default
+#
+# Precedence for CLOSEDLOOP_WORKDIR:
+#   1. $2 argument
+#   2. CLOSEDLOOP_WORKDIR env var (already set by the caller / parent loop)
+#   3. Default: .closedloop-ai/telemetry/ (relative to cwd)
+#
+# Fail-open guarantee: the entire initialisation is wrapped in a function.
+# Any error inside that function is caught and suppressed so the calling
+# command continues normally.
+
+_closedloop_telemetry_init() {
+  local command_name="${1:-}"
+  local workdir_arg="${2:-}"
+
+  # Argument validation — COMMAND_NAME is required
+  if [[ -z "$command_name" ]]; then
+    return 0
+  fi
+
+  # Resolve CLOSEDLOOP_WORKDIR
+  local workdir
+  if [[ -n "$workdir_arg" ]]; then
+    workdir="$workdir_arg"
+  elif [[ -n "${CLOSEDLOOP_WORKDIR:-}" ]]; then
+    workdir="$CLOSEDLOOP_WORKDIR"
+  else
+    workdir=".closedloop-ai/telemetry"
+  fi
+
+  # Generate CLOSEDLOOP_RUN_ID (same format as run-loop.sh: timestamp + 4-byte hex)
+  local timestamp
+  timestamp=$(date +%Y%m%d-%H%M%S 2>/dev/null) || timestamp="00000000-000000"
+  local random_suffix
+  random_suffix=$(head -c 4 /dev/urandom 2>/dev/null | xxd -p 2>/dev/null) || random_suffix="00000000"
+  local run_id="${timestamp}-${random_suffix}"
+
+  # Capture start time as unix epoch (for duration calculation in complete script)
+  local start_epoch
+  start_epoch=$(date +%s 2>/dev/null) || start_epoch=""
+
+  # Export env vars for the session
+  export CLOSEDLOOP_WORKDIR="$workdir"
+  export CLOSEDLOOP_RUN_ID="$run_id"
+  export CLOSEDLOOP_COMMAND="$command_name"
+  export CLOSEDLOOP_START_TIME="$start_epoch"
+
+  # Persist state to disk so command-telemetry-complete.sh can recover the run
+  # context when it runs in a separate Bash tool invocation (the export above
+  # only affects the shell that ran `source`).
+  mkdir -p "$workdir" 2>/dev/null || true
+  {
+    printf 'CLOSEDLOOP_WORKDIR=%s\n' "$workdir"
+    printf 'CLOSEDLOOP_RUN_ID=%s\n' "$run_id"
+    printf 'CLOSEDLOOP_COMMAND=%s\n' "$command_name"
+    printf 'CLOSEDLOOP_START_TIME=%s\n' "$start_epoch"
+  } > "$workdir/.cmd-state.env" 2>/dev/null || true
+
+  # Call record_run.sh — locate it relative to this script
+  local scripts_dir
+  scripts_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || scripts_dir=""
+  if [[ -n "$scripts_dir" && -f "$scripts_dir/record_run.sh" ]]; then
+    bash "$scripts_dir/record_run.sh" "$workdir" || true
+  fi
+}
+
+# Invoke with fail-open: any error is suppressed so the calling command
+# continues unaffected.
+_closedloop_telemetry_init "$@" || true

--- a/plugins/self-learning/scripts/record_run.sh
+++ b/plugins/self-learning/scripts/record_run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# record_run.sh - Append a run event to perf.jsonl once per Loop.
+#
+# Emits exactly one `run` event containing command, repo, branch, and start
+# time so every perf.jsonl record can be attributed to the slash-command that
+# launched the Loop. Fails open (exits 0) on any error so the caller loop is
+# unaffected.
+#
+# Usage:
+#   bash record_run.sh [WORKDIR]
+# WORKDIR defaults to $CLOSEDLOOP_WORKDIR.
+
+# Fail open: any unexpected error exits 0 so the caller loop is unaffected.
+trap 'exit 0' ERR
+
+WORKDIR="${1:-${CLOSEDLOOP_WORKDIR:-}}"
+if [[ -z "$WORKDIR" ]]; then
+  exit 0
+fi
+
+PERF_FILE="$WORKDIR/perf.jsonl"
+
+RUN_ID="${CLOSEDLOOP_RUN_ID:-unknown}"
+COMMAND="${CLOSEDLOOP_COMMAND:-interactive}"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+
+# Capture repo and branch via git -C. Prefer GNU `timeout` as a hang guard, but
+# fall back to bare `git` when timeout isn't installed (default macOS lacks it),
+# so this never silently drops repo/branch attribution on dev machines.
+if command -v timeout >/dev/null 2>&1; then
+  REPO=$(timeout 5 git -C "$WORKDIR" remote get-url origin 2>/dev/null || echo "")
+  BRANCH=$(timeout 5 git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+else
+  REPO=$(git -C "$WORKDIR" remote get-url origin 2>/dev/null || echo "")
+  BRANCH=$(git -C "$WORKDIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+fi
+
+mkdir -p "$(dirname "$PERF_FILE")"
+
+jq -n -c \
+  --arg event "run" \
+  --arg run_id "$RUN_ID" \
+  --arg command "$COMMAND" \
+  --arg started_at "$TIMESTAMP" \
+  --arg repo "$REPO" \
+  --arg branch "$BRANCH" \
+  '{event:$event,run_id:$run_id,command:$command,started_at:$started_at,repo:$repo,branch:$branch}' \
+  >> "$PERF_FILE"
+
+exit 0


### PR DESCRIPTION
## Summary

Adds matched start/complete telemetry instrumentation to every public slash command across `bootstrap`, `code`, `code-review`, and `self-learning`, so each command run emits structured events to `perf.jsonl` with `run_id`, `command`, `duration`, and `exit_status` — enabling Datadog rollups per slash command.

## Changes

- **New per-plugin scripts** (in `plugins/<plugin>/scripts/`):
  - `command-telemetry-init.sh` — sourceable initialiser that exports `CLOSEDLOOP_RUN_ID`, `CLOSEDLOOP_COMMAND`, `CLOSEDLOOP_WORKDIR`, `CLOSEDLOOP_START_TIME`, persists a `.cmd-state.env` so a later Bash invocation can recover context, and triggers `record_run.sh`.
  - `command-telemetry-complete.sh` — finaliser that emits a `command_complete` JSONL event and cleans up the recovered state.
  - `record_run.sh` — added to `bootstrap`, `code-review`, and `self-learning` (already present in `code`).
- **`plugins/code/scripts/telemetry-helpers.sh`** — new sourceable module that lifts `emit_perf_event`, `run_timed_step`, and `emit_skipped_step` out of `run-loop.sh` (net `-77 / +2` in `run-loop.sh`). The helpers now resolve `CLOSEDLOOP_RUN_ID` first, falling back to `RUN_ID` for backward-compat when sourced inside the loop.
- **Slash command instrumentation** — added init/complete bookends to:
  - `bootstrap`: `agent-bootstrap`
  - `code`: `amend-plan`, `cancel-code`, `plan-with-codex` (plus `allowed-tools` updates where required)
  - `code-review`: `start`
  - `self-learning`: `export-closedloop-learnings`, `goal-stats`, `process-learnings`, `prune-learnings`, `pull-learnings`, `push-learnings`
- **Tests** under `plugins/code/scripts/tests/`:
  - `test_telemetry_helpers.sh` — covers the extracted helpers with an isolated env-var-only context.
  - `test_command_telemetry_init.sh` and `test_command_telemetry_complete.sh` — cover argument precedence, run-id format, fail-open behaviour, and state-file recovery across separate shells.
  - `plugins/code/tools/python/test_run_loop_failure_marker.py` — regression guard that `unset`s `CLOSEDLOOP_COMMAND` before exercising `write_runs_log_entry`.
- **Version bumps**:
  - `bootstrap` 1.2.0 → 1.2.2
  - `code` 1.11.16 → 1.14.5
  - `code-review` 1.5.5 → 1.5.7
  - `self-learning` 1.2.5 → 1.2.7

## Test plan

- [x] `bash plugins/code/scripts/tests/test_telemetry_helpers.sh`
- [x] `bash plugins/code/scripts/tests/test_command_telemetry_init.sh`
- [x] `bash plugins/code/scripts/tests/test_command_telemetry_complete.sh`
- [x] `pytest plugins/code/tools/python/test_run_loop_failure_marker.py`
- [ ] Run a slash command end-to-end and confirm a matched `command_complete` event lands in `perf.jsonl`.

## Risks

None identified. Both telemetry scripts fail open (init wraps everything in a function that always returns 0; complete uses `trap 'exit 0' ERR`), so a broken telemetry path cannot abort the calling command. `run-loop.sh` behaviour is preserved because the extracted helpers keep the `RUN_ID` fallback.

---
Loop ID: 019e18b5-49c4-75bd-88fe-47daf14fd36c
Artifact: https://app.closedloop.ai/implementation-plans/PLN-539
