### PR TITLE
chore: bump code plugin version to 1.11.17

### DIFF
--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.11.16",
+  "version": "1.11.17",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"


### PR DESCRIPTION
## Summary
- Version bump for auto-sync markdown answers feature (PR #62)

## Test plan
- [ ] Verify plugin version shows 1.11.17 after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)