### PR TITLE
FEA-859 Add plugin remediation support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ This repository is a plugin monorepo under `plugins/`.
 - Recommended branches: `feat/*`, `fix/*`, `docs/*`, `refactor/*`.
 - PR workflow: fork, create topic branch from `main`, rebase onto upstream, then open PR from your fork.
 - PR description should include purpose, affected plugins/files, and exact commands run.
-- Update relevant changelog entries before pushing plugin edits (`.githooks/pre-push` enforces this expectation).
+- Do not manually edit `CHANGELOG.md` or `README.md` for plugin changes; after code changes are final, run the repo's `/update-documentation` workflow so generated documentation satisfies the changelog requirement enforced by `.githooks/pre-push`.
 
 ## Security & Configuration Tips
 - Keep secrets and keys out of version control (`.env`, tokens, credentials).

--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,16 @@ warn()  { echo -e "${YELLOW}[!]${NC} $1"; }
 err()   { echo -e "${RED}[✗]${NC} $1"; }
 step()  { echo -e "${BLUE}[→]${NC} ${BOLD}$1${NC}"; }
 snapshot_version() { grep -m1 "^$2 " "$1" 2>/dev/null | awk '{print $2}' || true; }
+snapshot_enabled() { grep -m1 "^$2 " "$1" 2>/dev/null | awk '{print $3}' || true; }
+snapshot_plugins() {
+    local destination="$1"
+    if ! claude plugin list --json 2>/dev/null \
+      | jq -r '.[] | .id + " " + (.version // "unknown") + " " + (if .enabled == true then "enabled" elif .enabled == false then "disabled" else "unknown" end)' \
+      > "$destination" 2>/dev/null; then
+        return 1
+    fi
+    [[ -s "$destination" ]]
+}
 sanitize_stderr()  {
     # Strip ANSI color escapes, then drop non-printable control chars.
     # Uses bash ANSI-C quoting for a literal ESC so this works under BSD sed (macOS)
@@ -126,10 +136,11 @@ FAILED=0
 
 SNAPSHOT_PRE="$WORK_DIR/snapshot_pre"
 SNAPSHOT_POST="$WORK_DIR/snapshot_post"
+SNAPSHOT_READY="$WORK_DIR/snapshot_ready"
 STDERR_FILE="$WORK_DIR/install_err"
+ENABLE_ERR_FILE="$WORK_DIR/enable_err"
 
-claude plugin list --json 2>/dev/null \
-  | jq -r '.[] | .id + " " + .version' > "$SNAPSHOT_PRE" 2>/dev/null || true
+snapshot_plugins "$SNAPSHOT_PRE" || true
 [[ -s "$SNAPSHOT_PRE" ]] || warn "Could not snapshot installed plugins — state detection will be approximate"
 
 SUCCESSFUL_PLUGINS=()
@@ -148,8 +159,9 @@ for plugin in "${PLUGINS[@]}"; do
     fi
 done
 
-claude plugin list --json 2>/dev/null \
-  | jq -r '.[] | .id + " " + .version' > "$SNAPSHOT_POST" 2>/dev/null || true
+snapshot_plugins "$SNAPSHOT_POST" || true
+
+ENABLED=0
 
 for plugin_ref in "${SUCCESSFUL_PLUGINS[@]+"${SUCCESSFUL_PLUGINS[@]}"}"; do
     plugin="${plugin_ref%@*}"
@@ -165,6 +177,28 @@ for plugin_ref in "${SUCCESSFUL_PLUGINS[@]+"${SUCCESSFUL_PLUGINS[@]}"}"; do
         UPDATED=$((UPDATED + 1))
         info "Updated: $plugin ($pre_ver -> $post_ver)"
     fi
+
+    post_enabled=$(snapshot_enabled "$SNAPSHOT_POST" "$plugin_ref")
+    if [[ "$post_enabled" != "enabled" ]]; then
+        if claude plugin enable "$plugin_ref" --scope user 2>"$ENABLE_ERR_FILE"; then
+            ENABLED=$((ENABLED + 1))
+            info "Enabled: $plugin"
+        else
+            [[ -s "$ENABLE_ERR_FILE" ]] && sanitize_stderr "$ENABLE_ERR_FILE"
+            warn "Could not enable: $plugin"
+        fi
+    fi
+done
+
+snapshot_plugins "$SNAPSHOT_READY" || true
+READINESS_FAILED=0
+for plugin in "${PLUGINS[@]}"; do
+    plugin_ref="${plugin}@${MARKETPLACE_NAME}"
+    ready_state=$(snapshot_enabled "$SNAPSHOT_READY" "$plugin_ref")
+    if [[ "$ready_state" != "enabled" ]]; then
+        err "Required plugin is not enabled: $plugin_ref"
+        READINESS_FAILED=$((READINESS_FAILED + 1))
+    fi
 done
 
 echo
@@ -172,10 +206,11 @@ echo
 # ── Summary ──────────────────────────────────────────────────────────────────
 TOTAL=$((INSTALLED + UPDATED + UP_TO_DATE + FAILED))
 echo "────────────────────────────────────"
-if [[ $FAILED -eq 0 ]]; then
-    echo -e "${GREEN}${BOLD}All $TOTAL plugins ready ($INSTALLED installed, $UPDATED updated, $UP_TO_DATE already up to date).${NC}"
+if [[ $FAILED -eq 0 && $READINESS_FAILED -eq 0 ]]; then
+    echo -e "${GREEN}${BOLD}All $TOTAL plugins ready ($INSTALLED installed, $UPDATED updated, $UP_TO_DATE already up to date, $ENABLED enabled).${NC}"
 else
-    echo -e "${YELLOW}${BOLD}$TOTAL plugins processed: $INSTALLED installed, $UPDATED updated, $UP_TO_DATE already up to date, $FAILED failed.${NC}"
+    echo -e "${YELLOW}${BOLD}$TOTAL plugins processed: $INSTALLED installed, $UPDATED updated, $UP_TO_DATE already up to date, $FAILED install/update failed, $READINESS_FAILED readiness failed.${NC}"
+    exit 1
 fi
 
 echo

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,20 @@ sanitize_stderr()  {
 MARKETPLACE_SOURCE="closedloop-ai/claude-plugins"
 MARKETPLACE_NAME="closedloop-ai"
 PLUGINS=(bootstrap code code-review judges platform self-learning)
+# Bootstrap is installed for manual repo bootstrapping, but Symphony runtime
+# readiness only requires the plugins used by loop execution and review.
+REQUIRED_PLUGINS=(code code-review judges platform self-learning)
+
+is_required_plugin_ref() {
+    local candidate="$1"
+    local plugin
+    for plugin in "${REQUIRED_PLUGINS[@]}"; do
+        if [[ "$candidate" == "${plugin}@${MARKETPLACE_NAME}" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
 
 # ── Per-run working directory ────────────────────────────────────────────────
 WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/closedloop-install.XXXXXX")
@@ -133,6 +147,7 @@ INSTALLED=0
 UPDATED=0
 UP_TO_DATE=0
 FAILED=0
+REQUIRED_FAILED=0
 
 SNAPSHOT_PRE="$WORK_DIR/snapshot_pre"
 SNAPSHOT_POST="$WORK_DIR/snapshot_post"
@@ -156,6 +171,9 @@ for plugin in "${PLUGINS[@]}"; do
         [[ -s "$STDERR_FILE" ]] && sanitize_stderr "$STDERR_FILE"
         warn "Could not install/update: $plugin"
         FAILED=$((FAILED + 1))
+        if is_required_plugin_ref "$plugin_ref"; then
+            REQUIRED_FAILED=$((REQUIRED_FAILED + 1))
+        fi
     fi
 done
 
@@ -192,7 +210,7 @@ done
 
 snapshot_plugins "$SNAPSHOT_READY" || true
 READINESS_FAILED=0
-for plugin in "${PLUGINS[@]}"; do
+for plugin in "${REQUIRED_PLUGINS[@]}"; do
     plugin_ref="${plugin}@${MARKETPLACE_NAME}"
     ready_state=$(snapshot_enabled "$SNAPSHOT_READY" "$plugin_ref")
     if [[ "$ready_state" != "enabled" ]]; then
@@ -206,8 +224,8 @@ echo
 # ── Summary ──────────────────────────────────────────────────────────────────
 TOTAL=$((INSTALLED + UPDATED + UP_TO_DATE + FAILED))
 echo "────────────────────────────────────"
-if [[ $FAILED -eq 0 && $READINESS_FAILED -eq 0 ]]; then
-    echo -e "${GREEN}${BOLD}All $TOTAL plugins ready ($INSTALLED installed, $UPDATED updated, $UP_TO_DATE already up to date, $ENABLED enabled).${NC}"
+if [[ $REQUIRED_FAILED -eq 0 && $READINESS_FAILED -eq 0 ]]; then
+    echo -e "${GREEN}${BOLD}Required plugins ready ($TOTAL plugins processed: $INSTALLED installed, $UPDATED updated, $UP_TO_DATE already up to date, $FAILED install/update failed, $ENABLED enabled).${NC}"
 else
     echo -e "${YELLOW}${BOLD}$TOTAL plugins processed: $INSTALLED installed, $UPDATED updated, $UP_TO_DATE already up to date, $FAILED install/update failed, $READINESS_FAILED readiness failed.${NC}"
     exit 1

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -276,9 +276,28 @@ detect_claude_terminal_failure() {
       def entry_message:
         ((.result? | strings) // (.error? | strings) // "");
 
+      def unknown_skill_signal:
+        ((.result? | strings | test("Unknown skill:")) // false)
+        or ((.error? | strings | test("Unknown skill:")) // false);
+
       entries as $entries
       | rate_event_message($entries) as $rateMessage
-      | if any($entries[]; rate_limit_signal) then
+      | if any($entries[]; unknown_skill_signal) then
+          ([$entries[] | select(unknown_skill_signal)] | .[0]) as $trigger
+          | ($trigger | entry_message) as $triggerMsg
+          | {
+            status: "unknown_skill",
+            subcode: "CLAUDE_UNKNOWN_SKILL",
+            message: (
+              if ($triggerMsg | length) > 0 then
+                "Claude plugin command unavailable: " + $triggerMsg
+              else
+                "Claude plugin command unavailable: Unknown skill"
+              end
+              | clamp_message
+            )
+          }
+        elif any($entries[]; rate_limit_signal) then
           ([$entries[] | select(rate_limit_signal)] | .[0]) as $trigger
           | ($trigger | entry_message) as $triggerMsg
           | {

--- a/plugins/code/tools/python/test_install_script.py
+++ b/plugins/code/tools/python/test_install_script.py
@@ -1,0 +1,195 @@
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+INSTALL_SH = REPO_ROOT / "install.sh"
+REQUIRED_PLUGIN_REFS = [
+    "bootstrap@closedloop-ai",
+    "code@closedloop-ai",
+    "code-review@closedloop-ai",
+    "judges@closedloop-ai",
+    "platform@closedloop-ai",
+    "self-learning@closedloop-ai",
+]
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def install_stub_tools(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    state_file = tmp_path / "plugins.json"
+    state_file.write_text("{}")
+
+    write_executable(
+        bin_dir / "python3",
+        "#!/usr/bin/env bash\nprintf '3.13\\n'\n",
+    )
+    write_executable(
+        bin_dir / "jq",
+        textwrap.dedent(
+            f"""\
+            #!{sys.executable}
+            import json
+            import sys
+
+            args = sys.argv[1:]
+            raw = sys.stdin.read()
+            try:
+                data = json.loads(raw) if raw.strip() else []
+            except json.JSONDecodeError:
+                data = []
+
+            if "-e" in args:
+                name = None
+                if "--arg" in args:
+                    index = args.index("--arg")
+                    if len(args) > index + 2 and args[index + 1] == "name":
+                        name = args[index + 2]
+                sys.exit(0 if any(item.get("name") == name for item in data) else 1)
+
+            for item in data:
+                enabled = item.get("enabled")
+                state = "enabled" if enabled is True else "disabled" if enabled is False else "unknown"
+                print(f"{{item['id']}} {{item.get('version', 'unknown')}} {{state}}")
+            """
+        ),
+    )
+    write_executable(
+        bin_dir / "claude",
+        textwrap.dedent(
+            f"""\
+            #!{sys.executable}
+            import json
+            import os
+            import sys
+
+            state_file = {str(state_file)!r}
+            required = {REQUIRED_PLUGIN_REFS!r}
+
+            def load():
+                with open(state_file, "r", encoding="utf-8") as handle:
+                    return json.load(handle)
+
+            def save(state):
+                with open(state_file, "w", encoding="utf-8") as handle:
+                    json.dump(state, handle)
+
+            args = sys.argv[1:]
+            if args == ["--version"]:
+                print("1.5.0")
+                raise SystemExit(0)
+            if args == ["plugin", "marketplace", "list", "--json"]:
+                print("[]")
+                raise SystemExit(0)
+            if args[:3] == ["plugin", "marketplace", "add"]:
+                raise SystemExit(0)
+            if len(args) >= 3 and args[:2] == ["plugin", "install"]:
+                ref = args[2]
+                if ref == os.environ.get("TEST_FAIL_INSTALL"):
+                    raise SystemExit(1)
+                state = load()
+                state[ref] = {{
+                    "id": ref,
+                    "version": "1.0.0",
+                    "enabled": ref != os.environ.get("TEST_DISABLED_ON_INSTALL"),
+                }}
+                save(state)
+                raise SystemExit(0)
+            if len(args) >= 3 and args[:2] == ["plugin", "update"]:
+                ref = args[2]
+                if ref == os.environ.get("TEST_FAIL_INSTALL"):
+                    raise SystemExit(1)
+                state = load()
+                state.setdefault(ref, {{"id": ref, "version": "1.0.0", "enabled": True}})
+                save(state)
+                raise SystemExit(0)
+            if len(args) >= 3 and args[:2] == ["plugin", "enable"]:
+                ref = args[2]
+                if ref == os.environ.get("TEST_ENABLE_FAIL"):
+                    raise SystemExit(1)
+                state = load()
+                if ref in state:
+                    state[ref]["enabled"] = True
+                save(state)
+                raise SystemExit(0)
+            if args == ["plugin", "list", "--json"]:
+                state = load()
+                print(json.dumps([state[ref] for ref in required if ref in state]))
+                raise SystemExit(0)
+
+            print(f"unexpected claude args: {{args}}", file=sys.stderr)
+            raise SystemExit(2)
+            """
+        ),
+    )
+    return bin_dir
+
+
+def run_install(
+    tmp_path: Path, extra_env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    bin_dir = install_stub_tools(tmp_path)
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path / "home"),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        "TMPDIR": str(tmp_path),
+        **(extra_env or {}),
+    }
+    return subprocess.run(
+        ["bash", str(INSTALL_SH)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_install_script_succeeds_when_all_required_plugins_are_enabled(
+    tmp_path: Path,
+) -> None:
+    result = run_install(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "All 6 plugins ready" in result.stdout
+
+
+def test_install_script_enables_disabled_required_plugin(tmp_path: Path) -> None:
+    result = run_install(
+        tmp_path,
+        {"TEST_DISABLED_ON_INSTALL": "bootstrap@closedloop-ai"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Enabled: bootstrap" in result.stdout
+
+
+def test_install_script_exits_nonzero_when_enable_fails(tmp_path: Path) -> None:
+    result = run_install(
+        tmp_path,
+        {
+            "TEST_DISABLED_ON_INSTALL": "bootstrap@closedloop-ai",
+            "TEST_ENABLE_FAIL": "bootstrap@closedloop-ai",
+        },
+    )
+
+    assert result.returncode != 0
+    assert "Required plugin is not enabled: bootstrap@closedloop-ai" in result.stdout
+
+
+def test_install_script_exits_nonzero_when_bootstrap_is_missing(tmp_path: Path) -> None:
+    result = run_install(
+        tmp_path,
+        {"TEST_FAIL_INSTALL": "bootstrap@closedloop-ai"},
+    )
+
+    assert result.returncode != 0
+    assert "Required plugin is not enabled: bootstrap@closedloop-ai" in result.stdout

--- a/plugins/code/tools/python/test_install_script.py
+++ b/plugins/code/tools/python/test_install_script.py
@@ -6,8 +6,15 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 INSTALL_SH = REPO_ROOT / "install.sh"
-REQUIRED_PLUGIN_REFS = [
+ALL_PLUGIN_REFS = [
     "bootstrap@closedloop-ai",
+    "code@closedloop-ai",
+    "code-review@closedloop-ai",
+    "judges@closedloop-ai",
+    "platform@closedloop-ai",
+    "self-learning@closedloop-ai",
+]
+REQUIRED_PLUGIN_REFS = [
     "code@closedloop-ai",
     "code-review@closedloop-ai",
     "judges@closedloop-ai",
@@ -71,7 +78,7 @@ def install_stub_tools(tmp_path: Path) -> Path:
             import sys
 
             state_file = {str(state_file)!r}
-            required = {REQUIRED_PLUGIN_REFS!r}
+            all_plugins = {ALL_PLUGIN_REFS!r}
 
             def load():
                 with open(state_file, "r", encoding="utf-8") as handle:
@@ -121,7 +128,7 @@ def install_stub_tools(tmp_path: Path) -> Path:
                 raise SystemExit(0)
             if args == ["plugin", "list", "--json"]:
                 state = load()
-                print(json.dumps([state[ref] for ref in required if ref in state]))
+                print(json.dumps([state[ref] for ref in all_plugins if ref in state]))
                 raise SystemExit(0)
 
             print(f"unexpected claude args: {{args}}", file=sys.stderr)
@@ -159,20 +166,59 @@ def test_install_script_succeeds_when_all_required_plugins_are_enabled(
     result = run_install(tmp_path)
 
     assert result.returncode == 0, result.stderr
-    assert "All 6 plugins ready" in result.stdout
+    assert "Required plugins ready" in result.stdout
 
 
 def test_install_script_enables_disabled_required_plugin(tmp_path: Path) -> None:
     result = run_install(
         tmp_path,
-        {"TEST_DISABLED_ON_INSTALL": "bootstrap@closedloop-ai"},
+        {"TEST_DISABLED_ON_INSTALL": "code@closedloop-ai"},
     )
 
     assert result.returncode == 0, result.stderr
-    assert "Enabled: bootstrap" in result.stdout
+    assert "Enabled: code" in result.stdout
 
 
 def test_install_script_exits_nonzero_when_enable_fails(tmp_path: Path) -> None:
+    result = run_install(
+        tmp_path,
+        {
+            "TEST_DISABLED_ON_INSTALL": "code@closedloop-ai",
+            "TEST_ENABLE_FAIL": "code@closedloop-ai",
+        },
+    )
+
+    assert result.returncode != 0
+    assert "Required plugin is not enabled: code@closedloop-ai" in result.stdout
+
+
+def test_install_script_exits_nonzero_when_required_plugin_is_missing(
+    tmp_path: Path,
+) -> None:
+    result = run_install(
+        tmp_path,
+        {"TEST_FAIL_INSTALL": "code@closedloop-ai"},
+    )
+
+    assert result.returncode != 0
+    assert "Required plugin is not enabled: code@closedloop-ai" in result.stdout
+
+
+def test_install_script_does_not_require_bootstrap_when_missing(tmp_path: Path) -> None:
+    result = run_install(
+        tmp_path,
+        {"TEST_FAIL_INSTALL": "bootstrap@closedloop-ai"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Required plugin is not enabled: bootstrap@closedloop-ai" not in result.stdout
+    )
+
+
+def test_install_script_does_not_require_bootstrap_when_enable_fails(
+    tmp_path: Path,
+) -> None:
     result = run_install(
         tmp_path,
         {
@@ -181,15 +227,7 @@ def test_install_script_exits_nonzero_when_enable_fails(tmp_path: Path) -> None:
         },
     )
 
-    assert result.returncode != 0
-    assert "Required plugin is not enabled: bootstrap@closedloop-ai" in result.stdout
-
-
-def test_install_script_exits_nonzero_when_bootstrap_is_missing(tmp_path: Path) -> None:
-    result = run_install(
-        tmp_path,
-        {"TEST_FAIL_INSTALL": "bootstrap@closedloop-ai"},
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Required plugin is not enabled: bootstrap@closedloop-ai" not in result.stdout
     )
-
-    assert result.returncode != 0
-    assert "Required plugin is not enabled: bootstrap@closedloop-ai" in result.stdout

--- a/plugins/code/tools/python/test_run_loop_failure_marker.py
+++ b/plugins/code/tools/python/test_run_loop_failure_marker.py
@@ -52,11 +52,13 @@ def test_write_loop_user_visible_failure_writes_marker(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     marker = tmp_path / "loop-error.json"
     assert marker.exists()
-    assert json.loads(marker.read_text()) == signed_marker({
-        "code": "RUNNER_ERROR",
-        "message": "Loop execution failed because XYZ.",
-        "result": {"subcode": "XYZ_FAILURE"},
-    })
+    assert json.loads(marker.read_text()) == signed_marker(
+        {
+            "code": "RUNNER_ERROR",
+            "message": "Loop execution failed because XYZ.",
+            "result": {"subcode": "XYZ_FAILURE"},
+        }
+    )
 
 
 def test_write_loop_user_visible_failure_unsets_exported_secret(tmp_path: Path) -> None:
@@ -132,10 +134,12 @@ def test_detect_spurious_complete_no_pending_tasks_returns_empty(
 
 def test_detect_spurious_complete_pending_with_questions_flags(tmp_path: Path) -> None:
     (tmp_path / "plan.json").write_text(
-        json.dumps({
-            "pendingTasks": [{"id": "T-1.0"}, {"id": "T-2.0"}],
-            "openQuestions": [{"id": "Q1", "text": "?"}],
-        })
+        json.dumps(
+            {
+                "pendingTasks": [{"id": "T-1.0"}, {"id": "T-2.0"}],
+                "openQuestions": [{"id": "Q1", "text": "?"}],
+            }
+        )
     )
 
     result = run_bash(
@@ -157,10 +161,12 @@ def test_detect_spurious_complete_pending_without_questions_flags(
     tmp_path: Path,
 ) -> None:
     (tmp_path / "plan.json").write_text(
-        json.dumps({
-            "pendingTasks": [{"id": "T-1.0"}],
-            "openQuestions": [],
-        })
+        json.dumps(
+            {
+                "pendingTasks": [{"id": "T-1.0"}],
+                "openQuestions": [],
+            }
+        )
     )
 
     result = run_bash(
@@ -181,16 +187,20 @@ def test_detect_spurious_complete_skips_when_awaiting_user(tmp_path: Path) -> No
     # tasks and open questions by definition, but state.json signals an
     # AWAITING_USER hard stop, not final completion. Must not be flagged.
     (tmp_path / "plan.json").write_text(
-        json.dumps({
-            "pendingTasks": [{"id": "T-1.0"}],
-            "openQuestions": [{"id": "Q1", "text": "?"}],
-        })
+        json.dumps(
+            {
+                "pendingTasks": [{"id": "T-1.0"}],
+                "openQuestions": [{"id": "Q1", "text": "?"}],
+            }
+        )
     )
     (tmp_path / "state.json").write_text(
-        json.dumps({
-            "phase": "Phase 1.1: Plan review checkpoint",
-            "status": "AWAITING_USER",
-        })
+        json.dumps(
+            {
+                "phase": "Phase 1.1: Plan review checkpoint",
+                "status": "AWAITING_USER",
+            }
+        )
     )
 
     result = run_bash(
@@ -211,16 +221,20 @@ def test_detect_spurious_complete_flags_when_completed_status_with_pending(
     # Final-completion claim with leftover pendingTasks remains a contract
     # violation and must still be flagged.
     (tmp_path / "plan.json").write_text(
-        json.dumps({
-            "pendingTasks": [{"id": "T-1.0"}],
-            "openQuestions": [],
-        })
+        json.dumps(
+            {
+                "pendingTasks": [{"id": "T-1.0"}],
+                "openQuestions": [],
+            }
+        )
     )
     (tmp_path / "state.json").write_text(
-        json.dumps({
-            "phase": "Phase 7: Logging and completion",
-            "status": "COMPLETED",
-        })
+        json.dumps(
+            {
+                "phase": "Phase 7: Logging and completion",
+                "status": "COMPLETED",
+            }
+        )
     )
 
     result = run_bash(
@@ -249,11 +263,13 @@ def test_fail_loop_user_visible_prints_reason_and_exits(tmp_path: Path) -> None:
     assert (
         "CLOSEDLOOP_FATAL[BAD_PLAN_STATE]: Plan state is not loadable." in result.stderr
     )
-    assert json.loads((tmp_path / "loop-error.json").read_text()) == signed_marker({
-        "code": "PRE_RUN_VALIDATION_FAILED",
-        "message": "Plan state is not loadable.",
-        "result": {"subcode": "BAD_PLAN_STATE"},
-    })
+    assert json.loads((tmp_path / "loop-error.json").read_text()) == signed_marker(
+        {
+            "code": "PRE_RUN_VALIDATION_FAILED",
+            "message": "Plan state is not loadable.",
+            "result": {"subcode": "BAD_PLAN_STATE"},
+        }
+    )
 
 
 def write_jsonl(path: Path, entries: list[dict[str, object] | str]) -> None:
@@ -542,6 +558,47 @@ def test_detect_claude_terminal_failure_ignores_successful_rate_limit_prose(
     assert json.loads(result.stdout) == {}
 
 
+def test_detect_claude_terminal_failure_flags_success_shaped_unknown_skill(
+    tmp_path: Path,
+) -> None:
+    payload = run_detect(
+        tmp_path,
+        jsonl=[
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "Unknown skill: code:code",
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            },
+        ],
+    )
+
+    assert payload["status"] == "unknown_skill"
+    assert payload["subcode"] == "CLAUDE_UNKNOWN_SKILL"
+    assert payload["message"] == (
+        "Claude plugin command unavailable: Unknown skill: code:code"
+    )
+
+
+def test_detect_claude_terminal_failure_ignores_normal_success_prose(
+    tmp_path: Path,
+) -> None:
+    payload = run_detect(
+        tmp_path,
+        jsonl=[
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "Completed the plugin readiness implementation.",
+            },
+        ],
+    )
+
+    assert payload == {}
+
+
 def test_handle_claude_terminal_failure_writes_marker_and_stops_retry(
     tmp_path: Path,
 ) -> None:
@@ -573,11 +630,13 @@ def test_handle_claude_terminal_failure_writes_marker_and_stops_retry(
     assert (
         tmp_path / "claude-output.name.txt"
     ).read_text() == "claude-output-rate-run.jsonl\n"
-    assert json.loads((tmp_path / "loop-error.json").read_text()) == signed_marker({
-        "code": "RUNNER_ERROR",
-        "message": message,
-        "result": {"subcode": "CLAUDE_RATE_LIMIT"},
-    })
+    assert json.loads((tmp_path / "loop-error.json").read_text()) == signed_marker(
+        {
+            "code": "RUNNER_ERROR",
+            "message": message,
+            "result": {"subcode": "CLAUDE_RATE_LIMIT"},
+        }
+    )
 
     fields = (tmp_path / "runs.log").read_text().strip().split("|")
     assert fields[0] == "rate-run"
@@ -613,16 +672,51 @@ def test_handle_claude_terminal_failure_writes_context_marker(
     assert (
         tmp_path / "claude-output.name.txt"
     ).read_text() == "claude-output-context-run.jsonl\n"
-    assert json.loads((tmp_path / "loop-error.json").read_text()) == signed_marker({
-        "code": "RUNNER_ERROR",
-        "message": message,
-        "result": {"subcode": "CLAUDE_CONTEXT_LIMIT"},
-    })
+    assert json.loads((tmp_path / "loop-error.json").read_text()) == signed_marker(
+        {
+            "code": "RUNNER_ERROR",
+            "message": message,
+            "result": {"subcode": "CLAUDE_CONTEXT_LIMIT"},
+        }
+    )
 
     fields = (tmp_path / "runs.log").read_text().strip().split("|")
     assert fields[3] == "2"
     assert fields[4] == "context_limit"
     assert fields[5] == "plan_execute"
+
+
+def test_handle_claude_terminal_failure_writes_unknown_skill_marker(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".learnings").mkdir()
+    (tmp_path / ".learnings" / ".lock").write_text("locked")
+    (tmp_path / "state.local").write_text("state")
+    (tmp_path / "claude-output.jsonl").write_text(
+        '{"type":"result","subtype":"success","is_error":false,"result":"Unknown skill: code:code"}\n'
+    )
+
+    message = "Claude plugin command unavailable: Unknown skill: code:code"
+    result = run_bash(
+        f"""
+        source {RUN_LOOP}
+        RUN_ID='unknown-skill-run'
+        STATE_FILE="$CLOSEDLOOP_WORKDIR/state.local"
+        PROGRESS_LOG="$CLOSEDLOOP_WORKDIR/progress.log"
+        handle_claude_terminal_failure "$CLOSEDLOOP_WORKDIR" 4 unknown_skill CLAUDE_UNKNOWN_SKILL "{message}"
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 1
+    assert "CLOSEDLOOP_FATAL[CLAUDE_UNKNOWN_SKILL]" in result.stderr
+    assert json.loads((tmp_path / "loop-error.json").read_text()) == signed_marker(
+        {
+            "code": "RUNNER_ERROR",
+            "message": message,
+            "result": {"subcode": "CLAUDE_UNKNOWN_SKILL"},
+        }
+    )
 
 
 def test_rename_output_on_exit_moves_jsonl_and_writes_sidecar(tmp_path: Path) -> None:
@@ -876,14 +970,28 @@ def test_code_review_log_with_no_session_does_not_backfill_plan_session(
         ("RL-20-rejected-no-overage", "rejected", None, False, {}, "CLAUDE_RATE_LIMIT"),
         (
             "RL-21-allowed-warning-overage-on",
-            "allowed_warning", "allowed_warning", True, {}, None,
+            "allowed_warning",
+            "allowed_warning",
+            True,
+            {},
+            None,
         ),
         (
             "RL-22-allowed-warning-overage-on-with-pct",
-            "allowed_warning", "allowed_warning", True,
-            {"warning_pct_int": 80}, None,
+            "allowed_warning",
+            "allowed_warning",
+            True,
+            {"warning_pct_int": 80},
+            None,
         ),
-        ("RL-23-rejected-overage-on", "rejected", "rejected", True, {}, "CLAUDE_RATE_LIMIT"),
+        (
+            "RL-23-rejected-overage-on",
+            "rejected",
+            "rejected",
+            True,
+            {},
+            "CLAUDE_RATE_LIMIT",
+        ),
         # Group C: overage path regression guards (PLN-530)
         ("RL-25-overage-allowed-on", "allowed", "allowed", True, {}, None),
         ("RL-26-overage-exceeded-on", "allowed", "exceeded", True, {}, None),
@@ -891,16 +999,28 @@ def test_code_review_log_with_no_session_does_not_backfill_plan_session(
         # Group D: cross-branch interaction tests (PLN-530)
         (
             "RL-28-rejected-status-allowed-overage",
-            "rejected", "allowed", True, {}, "CLAUDE_RATE_LIMIT",
+            "rejected",
+            "allowed",
+            True,
+            {},
+            "CLAUDE_RATE_LIMIT",
         ),
         (
             "RL-29-allowed-status-rejected-overage",
-            "allowed", "rejected", True, {}, "CLAUDE_RATE_LIMIT",
+            "allowed",
+            "rejected",
+            True,
+            {},
+            "CLAUDE_RATE_LIMIT",
         ),
         ("RL-30-both-rejected", "rejected", "rejected", True, {}, "CLAUDE_RATE_LIMIT"),
         (
             "RL-31-both-allowed-warning",
-            "allowed_warning", "allowed_warning", True, {}, None,
+            "allowed_warning",
+            "allowed_warning",
+            True,
+            {},
+            None,
         ),
     ],
     ids=lambda v: v if isinstance(v, str) else None,
@@ -1388,11 +1508,13 @@ def test_max_iterations_zero_success_writes_marker_and_exits_4(tmp_path: Path) -
     marker = tmp_path / "loop-error.json"
     assert marker.exists()
     payload = json.loads(marker.read_text())
-    assert payload == signed_marker({
-        "code": "RUNNER_ERROR",
-        "message": "Iteration budget exhausted without forward progress (0/5 iterations succeeded)",
-        "result": {"subcode": "MAX_ITERATIONS_NO_PROGRESS"},
-    })
+    assert payload == signed_marker(
+        {
+            "code": "RUNNER_ERROR",
+            "message": "Iteration budget exhausted without forward progress (0/5 iterations succeeded)",
+            "result": {"subcode": "MAX_ITERATIONS_NO_PROGRESS"},
+        }
+    )
 
 
 def test_max_iterations_with_success_exits_0_no_marker(tmp_path: Path) -> None:
@@ -1498,9 +1620,15 @@ def test_completion_promise_exits_0_regardless_of_counter(tmp_path: Path) -> Non
         # RL-32: empty object passes type check but has no status/overage fields
         ("RL-32-empty-object", {}),
         # RL-33: integer status — jq string equality returns false
-        ("RL-33-status-integer", {"status": 429, "rateLimitType": "five_hour", "resetsAt": 1778266200}),
+        (
+            "RL-33-status-integer",
+            {"status": 429, "rateLimitType": "five_hour", "resetsAt": 1778266200},
+        ),
         # RL-34: boolean status — jq string equality returns false
-        ("RL-34-status-boolean", {"status": True, "rateLimitType": "five_hour", "resetsAt": 1778266200}),
+        (
+            "RL-34-status-boolean",
+            {"status": True, "rateLimitType": "five_hour", "resetsAt": 1778266200},
+        ),
         # RL-35: string instead of object — "object" type guard rejects it
         ("RL-35-info-is-string", "rejected"),
     ],

--- a/plugins/code/tools/python/test_run_loop_failure_marker.py
+++ b/plugins/code/tools/python/test_run_loop_failure_marker.py
@@ -710,6 +710,15 @@ def test_handle_claude_terminal_failure_writes_unknown_skill_marker(
 
     assert result.returncode == 1
     assert "CLOSEDLOOP_FATAL[CLAUDE_UNKNOWN_SKILL]" in result.stderr
+    assert not (tmp_path / ".learnings" / ".lock").exists()
+    assert not (tmp_path / "state.local").exists()
+    assert not (tmp_path / "claude-output.jsonl").exists()
+    assert (tmp_path / "claude-output-unknown-skill-run.jsonl").read_text() == (
+        '{"type":"result","subtype":"success","is_error":false,"result":"Unknown skill: code:code"}\n'
+    )
+    assert (
+        tmp_path / "claude-output.name.txt"
+    ).read_text() == "claude-output-unknown-skill-run.jsonl\n"
     assert json.loads((tmp_path / "loop-error.json").read_text()) == signed_marker(
         {
             "code": "RUNNER_ERROR",


### PR DESCRIPTION
## Work item

- Work item: https://app.closedloop.ai/features/FEA-859
- Plan: https://app.closedloop.ai/implementation-plans/PLN-554

## Summary

- Adds plugin installer/update/enable remediation support for ClosedLoop plugin setup.
- Updates run-loop failure marker handling and tests around plugin-related failure behavior.
- Adds installer script test coverage for plugin setup behavior.

## Validation

- Implementation quality gate: passed after targeted re-check, including manual plugin remediation coverage.
- `git diff --check` passed before commit.
- `git diff --check HEAD~1 HEAD` passed after commit.

Functional validation evidence was not stale for this repo after the final Symphony-only UI fix pass; no additional plugin repo code changes were made after the quality gate.

## Known blockers

None.
