### PR TITLE
feat(code): add per-user security override mechanism

### DIFF
--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.11.17",
+  "version": "1.11.18",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/hooks/pretooluse-hook.sh
+++ b/plugins/code/hooks/pretooluse-hook.sh
@@ -30,6 +30,35 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 # rather than auto-allowed by the workspace rule below.
 _SEC_DENY='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked: credential access denied by security policy"}}'
 
+# ── Security overrides ─────────────────────────────────────────────────────
+# Per-user overrides loaded from ~/.claude/security-overrides.json.
+# Only categories explicitly set to true are allowed through.
+# Categories: process-kill, keychain, browser-profiles, ssh-keys,
+#             cloud-credentials-cmd, cloud-credentials-files
+_OVERRIDES_FILE="${CLAUDE_SECURITY_OVERRIDES:-$HOME/.claude/security-overrides.json}"
+
+_override_enabled() {
+    local category="$1"
+    if [[ -f "$_OVERRIDES_FILE" ]]; then
+        local val
+        val=$(jq -r --arg cat "$category" '.overrides[$cat] // false' "$_OVERRIDES_FILE" 2>/dev/null)
+        if [[ "$val" == "true" ]]; then
+            echo "$(date): SECURITY OVERRIDE: allowed category=$category" >> "${DEBUG_LOG:-/dev/null}"
+            return 0
+        fi
+    fi
+    return 1
+}
+
+_sec_deny_unless_override() {
+    local category="$1"
+    if _override_enabled "$category"; then
+        return 1  # don't deny — override active
+    fi
+    echo "$_SEC_DENY"
+    exit 0
+}
+
 case "$TOOL_NAME" in
     Bash)
         _sec_cmd=$(echo "$TOOL_INPUT" | jq -r '.command // empty' 2>/dev/null || echo "")
@@ -39,39 +68,37 @@ case "$TOOL_NAME" in
             # (e.g. a running desktop-dev in the main tree killed by a worktree agent).
             # Claude should never need these; use process.kill(pid) for specific PIDs instead.
             *pkill*|*killall*)
-                echo "$_SEC_DENY"
-                exit 0
+                _sec_deny_unless_override "process-kill"
                 ;;
             # macOS Keychain
             *security\ find-generic-password*|*security\ find-internet-password*|*security\ dump-keychain*|\
             *security\ delete-generic-password*|*security\ delete-internet-password*|\
             *find-generic-password*|*find-internet-password*)
-                echo "$_SEC_DENY"
-                exit 0
+                _sec_deny_unless_override "keychain"
                 ;;
             # Browser profile directories
             *"Library/Application Support/Google/Chrome"*|*"Library/Application Support/Chromium"*|\
             *"Library/Application Support/BraveSoftware"*|*"Library/Application Support/Microsoft Edge"*|\
             *"Library/Application Support/Firefox"*|*.mozilla/firefox*|*"Library/Safari/Cookies"*)
-                echo "$_SEC_DENY"
-                exit 0
+                _sec_deny_unless_override "browser-profiles"
                 ;;
             # Browser DBs via sqlite3
             *sqlite3*Cookies*|*sqlite3*"Login Data"*|*sqlite3*"Web Data"*)
-                echo "$_SEC_DENY"
-                exit 0
+                _sec_deny_unless_override "browser-profiles"
                 ;;
             # SSH private keys
             */.ssh/id_*)
-                echo "$_SEC_DENY"
-                exit 0
+                _sec_deny_unless_override "ssh-keys"
                 ;;
-            # Cloud credentials (commands and file paths)
-            */.aws/credentials*|*"gcloud auth print-access-token"*|*"gcloud auth application-default"*|\
+            # Cloud credential commands
+            *"gcloud auth print-access-token"*|*"gcloud auth application-default"*)
+                _sec_deny_unless_override "cloud-credentials-cmd"
+                ;;
+            # Cloud credential files
+            */.aws/credentials*|\
             */.config/gcloud/credentials.db*|*/.config/gcloud/application_default_credentials.json*|\
             */.config/gcloud/legacy_credentials/*)
-                echo "$_SEC_DENY"
-                exit 0
+                _sec_deny_unless_override "cloud-credentials-files"
                 ;;
         esac
         ;;
@@ -82,19 +109,16 @@ case "$TOOL_NAME" in
             */Google/Chrome/*/Cookies|*/Google/Chrome/*/Login\ Data|\
             */Chromium/*/Cookies|*/Firefox/Profiles/*/cookies.sqlite|\
             */Safari/Cookies/Cookies.binarycookies)
-                echo "$_SEC_DENY"
-                exit 0
+                _sec_deny_unless_override "browser-profiles"
                 ;;
             # SSH private keys
             */.ssh/id_*)
-                echo "$_SEC_DENY"
-                exit 0
+                _sec_deny_unless_override "ssh-keys"
                 ;;
             # Cloud credentials
             */.aws/credentials|*/.config/gcloud/credentials.db|\
             */.config/gcloud/legacy_credentials/*|*/.config/gcloud/application_default_credentials.json)
-                echo "$_SEC_DENY"
-                exit 0
+                _sec_deny_unless_override "cloud-credentials-files"
                 ;;
         esac
         ;;

--- a/plugins/code/hooks/pretooluse-hook.sh
+++ b/plugins/code/hooks/pretooluse-hook.sh
@@ -36,6 +36,31 @@ _SEC_DENY='{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecisi
 # Categories: process-kill, keychain, browser-profiles, ssh-keys,
 #             cloud-credentials-cmd, cloud-credentials-files
 _OVERRIDES_FILE="${CLAUDE_SECURITY_OVERRIDES:-$HOME/.claude/security-overrides.json}"
+_PENDING_DEBUG_LOGS=()
+
+_debug_log() {
+    local message="$1"
+    if [[ "${DEBUG_LOG:-/dev/null}" != "/dev/null" ]]; then
+        echo "$message" >> "$DEBUG_LOG"
+        return 0
+    fi
+    _PENDING_DEBUG_LOGS+=("$message")
+}
+
+_flush_debug_logs() {
+    if [[ "${DEBUG_LOG:-/dev/null}" == "/dev/null" ]]; then
+        return 0
+    fi
+    if [[ ${#_PENDING_DEBUG_LOGS[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    local message
+    for message in "${_PENDING_DEBUG_LOGS[@]}"; do
+        echo "$message" >> "$DEBUG_LOG"
+    done
+    _PENDING_DEBUG_LOGS=()
+}
 
 _override_enabled() {
     local category="$1"
@@ -43,7 +68,7 @@ _override_enabled() {
         local val
         val=$(jq -r --arg cat "$category" '.overrides[$cat] // false' "$_OVERRIDES_FILE" 2>/dev/null)
         if [[ "$val" == "true" ]]; then
-            echo "$(date): SECURITY OVERRIDE: allowed category=$category" >> "${DEBUG_LOG:-/dev/null}"
+            _debug_log "$(date): SECURITY OVERRIDE: allowed category=$category"
             return 0
         fi
     fi
@@ -62,6 +87,8 @@ _sec_deny_unless_override() {
 case "$TOOL_NAME" in
     Bash)
         _sec_cmd=$(echo "$TOOL_INPUT" | jq -r '.command // empty' 2>/dev/null || echo "")
+        # Check each sensitive category independently so an allowed earlier
+        # match cannot mask a later disallowed category in the same command.
         case "$_sec_cmd" in
             # Broad process killing — globally denied.
             # pkill/killall match by name and kill processes outside the current context
@@ -70,30 +97,42 @@ case "$TOOL_NAME" in
             *pkill*|*killall*)
                 _sec_deny_unless_override "process-kill"
                 ;;
+        esac
+        case "$_sec_cmd" in
             # macOS Keychain
             *security\ find-generic-password*|*security\ find-internet-password*|*security\ dump-keychain*|\
             *security\ delete-generic-password*|*security\ delete-internet-password*|\
             *find-generic-password*|*find-internet-password*)
                 _sec_deny_unless_override "keychain"
                 ;;
+        esac
+        case "$_sec_cmd" in
             # Browser profile directories
             *"Library/Application Support/Google/Chrome"*|*"Library/Application Support/Chromium"*|\
             *"Library/Application Support/BraveSoftware"*|*"Library/Application Support/Microsoft Edge"*|\
             *"Library/Application Support/Firefox"*|*.mozilla/firefox*|*"Library/Safari/Cookies"*)
                 _sec_deny_unless_override "browser-profiles"
                 ;;
+        esac
+        case "$_sec_cmd" in
             # Browser DBs via sqlite3
             *sqlite3*Cookies*|*sqlite3*"Login Data"*|*sqlite3*"Web Data"*)
                 _sec_deny_unless_override "browser-profiles"
                 ;;
+        esac
+        case "$_sec_cmd" in
             # SSH private keys
             */.ssh/id_*)
                 _sec_deny_unless_override "ssh-keys"
                 ;;
+        esac
+        case "$_sec_cmd" in
             # Cloud credential commands
             *"gcloud auth print-access-token"*|*"gcloud auth application-default"*)
                 _sec_deny_unless_override "cloud-credentials-cmd"
                 ;;
+        esac
+        case "$_sec_cmd" in
             # Cloud credential files
             */.aws/credentials*|\
             */.config/gcloud/credentials.db*|*/.config/gcloud/application_default_credentials.json*|\
@@ -163,7 +202,8 @@ fi
 # Redirect debug logs into workdir (per-run, not shared /tmp)
 mkdir -p "$CLOSEDLOOP_WORKDIR/.learnings"
 DEBUG_LOG="$CLOSEDLOOP_WORKDIR/.learnings/pretooluse-hook-debug.log"
-echo "$(date): PreToolUse hook started, tool=$TOOL_NAME" >> "$DEBUG_LOG"
+_flush_debug_logs
+_debug_log "$(date): PreToolUse hook started, tool=$TOOL_NAME"
 
 # Source closedloop config and skip learning injection if disabled
 CLOSEDLOOP_CONFIG="$CLOSEDLOOP_WORKDIR/$CLOSEDLOOP_STATE_DIR/config.env"

--- a/plugins/code/hooks/pretooluse-hook.sh
+++ b/plugins/code/hooks/pretooluse-hook.sh
@@ -53,7 +53,7 @@ _override_enabled() {
 _sec_deny_unless_override() {
     local category="$1"
     if _override_enabled "$category"; then
-        return 1  # don't deny — override active
+        return 0  # don't deny — override active, continue normally
     fi
     echo "$_SEC_DENY"
     exit 0

--- a/plugins/code/hooks/tests/test_security_overrides.sh
+++ b/plugins/code/hooks/tests/test_security_overrides.sh
@@ -8,6 +8,8 @@
 #   4. Malformed override files are treated as no-override (deny)
 #   5. Override works for Read/Write/Edit tool file-path rules
 #   6. Cloud credentials are split into cmd vs files categories
+#   7. Mixed-category Bash commands still deny later disallowed matches
+#   8. Override audit logs are preserved once WORKDIR logging is available
 #
 # Usage:
 #   bash plugins/code/hooks/tests/test_security_overrides.sh
@@ -88,6 +90,17 @@ assert_not_denied() {
         fail "$test_name" "hook exited with code $hook_exit (expected 0)"
     else
         pass "$test_name"
+    fi
+}
+
+assert_file_contains() {
+    local test_name="$1"
+    local file_path="$2"
+    local expected="$3"
+    if [[ -f "$file_path" ]] && grep -Fq "$expected" "$file_path"; then
+        pass "$test_name"
+    else
+        fail "$test_name" "expected '$expected' in $file_path"
     fi
 }
 
@@ -335,10 +348,57 @@ EOF
 }
 
 # ------------------------------------------------------------------
-# Test 9: Non-blocked commands pass through regardless
+# Test 9: Mixed-category commands still deny disallowed categories
 # ------------------------------------------------------------------
 echo ""
-echo "Test 9: Non-blocked commands pass through regardless"
+echo "Test 9: Mixed-category commands still deny disallowed categories"
+{
+    tmpdir=$(mktemp -d)
+    overrides="$tmpdir/overrides.json"
+
+    cat > "$overrides" <<'EOF'
+{"overrides":{"process-kill":true}}
+EOF
+
+    run_hook "$(build_bash_input "pkill node && cat ~/.aws/credentials")" "$overrides"
+    assert_denied "mixed command denied when later cloud credential access is still blocked" "$hook_output"
+
+    cat > "$overrides" <<'EOF'
+{"overrides":{"cloud-credentials-cmd":true}}
+EOF
+
+    run_hook "$(build_bash_input "gcloud auth print-access-token && cat ~/.ssh/id_rsa")" "$overrides"
+    assert_denied "mixed command denied when later ssh key access is still blocked" "$hook_output"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 10: Override audit logs survive once WORKDIR logging is available
+# ------------------------------------------------------------------
+echo ""
+echo "Test 10: Override audit logs are written after workdir discovery"
+{
+    read -r tmpdir cwd workdir session_id <<< "$(setup_temp_env "override")"
+    overrides="$tmpdir/overrides.json"
+    log_file="$workdir/.learnings/pretooluse-hook-debug.log"
+
+    cat > "$overrides" <<'EOF'
+{"overrides":{"process-kill":true}}
+EOF
+
+    run_hook "$(build_bash_input "pkill node" "$session_id" "$cwd")" "$overrides"
+    assert_not_denied "process-kill allowed in mapped session" "$hook_output"
+    assert_file_contains "override audit message written to debug log" "$log_file" "SECURITY OVERRIDE: allowed category=process-kill"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 11: Non-blocked commands pass through regardless
+# ------------------------------------------------------------------
+echo ""
+echo "Test 11: Non-blocked commands pass through regardless"
 {
     tmpdir=$(mktemp -d)
     no_file="$tmpdir/nonexistent.json"

--- a/plugins/code/hooks/tests/test_security_overrides.sh
+++ b/plugins/code/hooks/tests/test_security_overrides.sh
@@ -49,13 +49,20 @@ build_read_input() {
         '{tool_name:"Read",tool_input:{file_path:$fp},session_id:$sid,cwd:$cwd}'
 }
 
+hook_output=""
+hook_exit=0
 run_hook() {
     # Runs the pretooluse hook with the given input and override file.
-    # Returns the hook's stdout; exit code is captured in $hook_exit.
+    # Sets hook_output (stdout) and hook_exit (exit code) as globals.
+    # Must NOT be called via $() — that creates a subshell and loses globals.
     local input="$1"
     local overrides_file="$2"
+    local _tmpout
+    _tmpout=$(mktemp)
     hook_exit=0
-    echo "$input" | env CLAUDE_SECURITY_OVERRIDES="$overrides_file" bash "$PRE_HOOK" 2>/dev/null || hook_exit=$?
+    echo "$input" | env CLAUDE_SECURITY_OVERRIDES="$overrides_file" bash "$PRE_HOOK" > "$_tmpout" 2>/dev/null || hook_exit=$?
+    hook_output=$(<"$_tmpout")
+    rm -f "$_tmpout"
 }
 
 assert_denied() {
@@ -66,7 +73,7 @@ assert_denied() {
     if [[ "$decision" == "deny" ]]; then
         pass "$test_name"
     else
-        fail "$test_name" "expected deny but got: $output"
+        fail "$test_name" "expected deny but got: $output (exit=$hook_exit)"
     fi
 }
 
@@ -77,6 +84,8 @@ assert_not_denied() {
     decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
     if [[ "$decision" == "deny" ]]; then
         fail "$test_name" "expected pass-through but got deny"
+    elif [[ "$hook_exit" -ne 0 ]]; then
+        fail "$test_name" "hook exited with code $hook_exit (expected 0)"
     else
         pass "$test_name"
     fi
@@ -96,24 +105,24 @@ echo "Test 1: All categories denied when no override file exists"
     no_file="$tmpdir/nonexistent.json"
 
     # pkill
-    output=$(run_hook "$(build_bash_input "pkill node")" "$no_file")
-    assert_denied "process-kill denied (no override file)" "$output"
+    run_hook "$(build_bash_input "pkill node")" "$no_file"
+    assert_denied "process-kill denied (no override file)" "$hook_output"
 
     # gcloud auth
-    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$no_file")
-    assert_denied "cloud-credentials-cmd denied (no override file)" "$output"
+    run_hook "$(build_bash_input "gcloud auth print-access-token")" "$no_file"
+    assert_denied "cloud-credentials-cmd denied (no override file)" "$hook_output"
 
     # aws credentials file
-    output=$(run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$no_file")
-    assert_denied "cloud-credentials-files denied (no override file)" "$output"
+    run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$no_file"
+    assert_denied "cloud-credentials-files denied (no override file)" "$hook_output"
 
     # ssh key
-    output=$(run_hook "$(build_bash_input "cat ~/.ssh/id_rsa")" "$no_file")
-    assert_denied "ssh-keys denied (no override file)" "$output"
+    run_hook "$(build_bash_input "cat ~/.ssh/id_rsa")" "$no_file"
+    assert_denied "ssh-keys denied (no override file)" "$hook_output"
 
     # keychain
-    output=$(run_hook "$(build_bash_input "security find-generic-password -s foo")" "$no_file")
-    assert_denied "keychain denied (no override file)" "$output"
+    run_hook "$(build_bash_input "security find-generic-password -s foo")" "$no_file"
+    assert_denied "keychain denied (no override file)" "$hook_output"
 
     rm -rf "$tmpdir"
 }
@@ -132,12 +141,12 @@ echo "Test 2: Per-category override allows specific blocked commands"
 {"overrides":{"process-kill":true}}
 EOF
 
-    output=$(run_hook "$(build_bash_input "pkill node")" "$overrides")
-    assert_not_denied "process-kill allowed with override" "$output"
+    run_hook "$(build_bash_input "pkill node")" "$overrides"
+    assert_not_denied "process-kill allowed with override" "$hook_output"
 
     # killall variant
-    output=$(run_hook "$(build_bash_input "killall node")" "$overrides")
-    assert_not_denied "killall allowed with override" "$output"
+    run_hook "$(build_bash_input "killall node")" "$overrides"
+    assert_not_denied "killall allowed with override" "$hook_output"
 
     rm -rf "$tmpdir"
 }
@@ -157,23 +166,23 @@ echo "Test 3: Partial override only unblocks the specified category"
 EOF
 
     # gcloud auth command should pass
-    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
-    assert_not_denied "cloud-credentials-cmd allowed" "$output"
+    run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides"
+    assert_not_denied "cloud-credentials-cmd allowed" "$hook_output"
 
-    output=$(run_hook "$(build_bash_input "gcloud auth application-default print-access-token")" "$overrides")
-    assert_not_denied "gcloud auth application-default allowed" "$output"
+    run_hook "$(build_bash_input "gcloud auth application-default print-access-token")" "$overrides"
+    assert_not_denied "gcloud auth application-default allowed" "$hook_output"
 
     # cloud credential files should still be denied
-    output=$(run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides")
-    assert_denied "cloud-credentials-files still denied" "$output"
+    run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides"
+    assert_denied "cloud-credentials-files still denied" "$hook_output"
 
     # pkill should still be denied
-    output=$(run_hook "$(build_bash_input "pkill node")" "$overrides")
-    assert_denied "process-kill still denied" "$output"
+    run_hook "$(build_bash_input "pkill node")" "$overrides"
+    assert_denied "process-kill still denied" "$hook_output"
 
     # ssh keys should still be denied
-    output=$(run_hook "$(build_bash_input "cat ~/.ssh/id_rsa")" "$overrides")
-    assert_denied "ssh-keys still denied" "$output"
+    run_hook "$(build_bash_input "cat ~/.ssh/id_rsa")" "$overrides"
+    assert_denied "ssh-keys still denied" "$hook_output"
 
     rm -rf "$tmpdir"
 }
@@ -190,11 +199,11 @@ echo "Test 4: Malformed override file treated as no override (deny)"
     # Write invalid JSON
     echo "this is not json" > "$overrides"
 
-    output=$(run_hook "$(build_bash_input "pkill node")" "$overrides")
-    assert_denied "process-kill denied (malformed override file)" "$output"
+    run_hook "$(build_bash_input "pkill node")" "$overrides"
+    assert_denied "process-kill denied (malformed override file)" "$hook_output"
 
-    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
-    assert_denied "cloud-credentials-cmd denied (malformed override file)" "$output"
+    run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides"
+    assert_denied "cloud-credentials-cmd denied (malformed override file)" "$hook_output"
 
     rm -rf "$tmpdir"
 }
@@ -214,20 +223,20 @@ echo "Test 5: Override works for Read tool file-path rules"
 EOF
 
     # Read ~/.aws/credentials should pass
-    output=$(run_hook "$(build_read_input "$HOME/.aws/credentials")" "$overrides")
-    assert_not_denied "Read cloud credential file allowed" "$output"
+    run_hook "$(build_read_input "$HOME/.aws/credentials")" "$overrides"
+    assert_not_denied "Read cloud credential file allowed" "$hook_output"
 
     # Read gcloud credentials.db should pass
-    output=$(run_hook "$(build_read_input "$HOME/.config/gcloud/credentials.db")" "$overrides")
-    assert_not_denied "Read gcloud credentials.db allowed" "$output"
+    run_hook "$(build_read_input "$HOME/.config/gcloud/credentials.db")" "$overrides"
+    assert_not_denied "Read gcloud credentials.db allowed" "$hook_output"
 
     # Read SSH key should still be denied
-    output=$(run_hook "$(build_read_input "$HOME/.ssh/id_rsa")" "$overrides")
-    assert_denied "Read ssh key still denied" "$output"
+    run_hook "$(build_read_input "$HOME/.ssh/id_rsa")" "$overrides"
+    assert_denied "Read ssh key still denied" "$hook_output"
 
     # Read browser cookies should still be denied
-    output=$(run_hook "$(build_read_input "$HOME/Library/Application Support/Google/Chrome/Default/Cookies")" "$overrides")
-    assert_denied "Read browser cookies still denied" "$output"
+    run_hook "$(build_read_input "$HOME/Library/Application Support/Google/Chrome/Default/Cookies")" "$overrides"
+    assert_denied "Read browser cookies still denied" "$hook_output"
 
     rm -rf "$tmpdir"
 }
@@ -247,26 +256,26 @@ echo "Test 6: Cloud credentials cmd vs files are independent categories"
 EOF
 
     # File access allowed
-    output=$(run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides")
-    assert_not_denied "cloud-credentials-files Bash allowed" "$output"
+    run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides"
+    assert_not_denied "cloud-credentials-files Bash allowed" "$hook_output"
 
-    output=$(run_hook "$(build_bash_input "cat ~/.config/gcloud/application_default_credentials.json")" "$overrides")
-    assert_not_denied "cloud-credentials-files gcloud ADC allowed" "$output"
+    run_hook "$(build_bash_input "cat ~/.config/gcloud/application_default_credentials.json")" "$overrides"
+    assert_not_denied "cloud-credentials-files gcloud ADC allowed" "$hook_output"
 
     # Command still denied
-    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
-    assert_denied "cloud-credentials-cmd still denied" "$output"
+    run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides"
+    assert_denied "cloud-credentials-cmd still denied" "$hook_output"
 
     # Now flip: enable only cmd
     cat > "$overrides" <<'EOF'
 {"overrides":{"cloud-credentials-cmd":true}}
 EOF
 
-    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
-    assert_not_denied "cloud-credentials-cmd allowed" "$output"
+    run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides"
+    assert_not_denied "cloud-credentials-cmd allowed" "$hook_output"
 
-    output=$(run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides")
-    assert_denied "cloud-credentials-files denied when only cmd enabled" "$output"
+    run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides"
+    assert_denied "cloud-credentials-files denied when only cmd enabled" "$hook_output"
 
     rm -rf "$tmpdir"
 }
@@ -284,11 +293,11 @@ echo "Test 7: Override set to false is same as not set"
 {"overrides":{"process-kill":false,"cloud-credentials-cmd":false}}
 EOF
 
-    output=$(run_hook "$(build_bash_input "pkill node")" "$overrides")
-    assert_denied "process-kill denied when explicitly false" "$output"
+    run_hook "$(build_bash_input "pkill node")" "$overrides"
+    assert_denied "process-kill denied when explicitly false" "$hook_output"
 
-    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
-    assert_denied "cloud-credentials-cmd denied when explicitly false" "$output"
+    run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides"
+    assert_denied "cloud-credentials-cmd denied when explicitly false" "$hook_output"
 
     rm -rf "$tmpdir"
 }
@@ -306,21 +315,21 @@ echo "Test 8: Multiple overrides enabled simultaneously"
 {"overrides":{"process-kill":true,"cloud-credentials-cmd":true,"cloud-credentials-files":true}}
 EOF
 
-    output=$(run_hook "$(build_bash_input "pkill node")" "$overrides")
-    assert_not_denied "process-kill allowed" "$output"
+    run_hook "$(build_bash_input "pkill node")" "$overrides"
+    assert_not_denied "process-kill allowed" "$hook_output"
 
-    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
-    assert_not_denied "cloud-credentials-cmd allowed" "$output"
+    run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides"
+    assert_not_denied "cloud-credentials-cmd allowed" "$hook_output"
 
-    output=$(run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides")
-    assert_not_denied "cloud-credentials-files allowed" "$output"
+    run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides"
+    assert_not_denied "cloud-credentials-files allowed" "$hook_output"
 
     # Non-overridden categories still denied
-    output=$(run_hook "$(build_bash_input "cat ~/.ssh/id_rsa")" "$overrides")
-    assert_denied "ssh-keys still denied" "$output"
+    run_hook "$(build_bash_input "cat ~/.ssh/id_rsa")" "$overrides"
+    assert_denied "ssh-keys still denied" "$hook_output"
 
-    output=$(run_hook "$(build_bash_input "security find-generic-password -s foo")" "$overrides")
-    assert_denied "keychain still denied" "$output"
+    run_hook "$(build_bash_input "security find-generic-password -s foo")" "$overrides"
+    assert_denied "keychain still denied" "$hook_output"
 
     rm -rf "$tmpdir"
 }
@@ -334,14 +343,14 @@ echo "Test 9: Non-blocked commands pass through regardless"
     tmpdir=$(mktemp -d)
     no_file="$tmpdir/nonexistent.json"
 
-    output=$(run_hook "$(build_bash_input "ls -la")" "$no_file")
-    assert_not_denied "ls -la passes through" "$output"
+    run_hook "$(build_bash_input "ls -la")" "$no_file"
+    assert_not_denied "ls -la passes through" "$hook_output"
 
-    output=$(run_hook "$(build_bash_input "git status")" "$no_file")
-    assert_not_denied "git status passes through" "$output"
+    run_hook "$(build_bash_input "git status")" "$no_file"
+    assert_not_denied "git status passes through" "$hook_output"
 
-    output=$(run_hook "$(build_read_input "/tmp/somefile.txt")" "$no_file")
-    assert_not_denied "Read /tmp/somefile.txt passes through" "$output"
+    run_hook "$(build_read_input "/tmp/somefile.txt")" "$no_file"
+    assert_not_denied "Read /tmp/somefile.txt passes through" "$hook_output"
 
     rm -rf "$tmpdir"
 }

--- a/plugins/code/hooks/tests/test_security_overrides.sh
+++ b/plugins/code/hooks/tests/test_security_overrides.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# Tests for the security override mechanism in pretooluse-hook.sh.
+#
+# Validates that:
+#   1. Default deny still blocks all categories when no override file exists
+#   2. Per-category overrides selectively allow specific blocked commands
+#   3. Partial overrides only unblock the specified category
+#   4. Malformed override files are treated as no-override (deny)
+#   5. Override works for Read/Write/Edit tool file-path rules
+#   6. Cloud credentials are split into cmd vs files categories
+#
+# Usage:
+#   bash plugins/code/hooks/tests/test_security_overrides.sh
+#
+# Exit code: 0 if all tests pass, 1 if any test fails.
+
+set -uo pipefail
+
+# ---- Paths ---------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOKS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PRE_HOOK="$HOOKS_DIR/pretooluse-hook.sh"
+
+# ---- Shared helpers ------------------------------------------------------
+source "$SCRIPT_DIR/test_helpers.sh"
+
+# ---- Test-specific helpers -----------------------------------------------
+build_bash_input() {
+    # Emits a minimal JSON PreToolUse hook payload for a Bash command.
+    local command="$1"
+    local session_id="${2:-nosession}"
+    local cwd="${3:-/tmp}"
+    jq -n -c \
+        --arg cmd "$command" \
+        --arg sid "$session_id" \
+        --arg cwd "$cwd" \
+        '{tool_name:"Bash",tool_input:{command:$cmd},session_id:$sid,cwd:$cwd}'
+}
+
+build_read_input() {
+    # Emits a minimal JSON PreToolUse hook payload for a Read tool.
+    local file_path="$1"
+    local session_id="${2:-nosession}"
+    local cwd="${3:-/tmp}"
+    jq -n -c \
+        --arg fp "$file_path" \
+        --arg sid "$session_id" \
+        --arg cwd "$cwd" \
+        '{tool_name:"Read",tool_input:{file_path:$fp},session_id:$sid,cwd:$cwd}'
+}
+
+run_hook() {
+    # Runs the pretooluse hook with the given input and override file.
+    # Returns the hook's stdout; exit code is captured in $hook_exit.
+    local input="$1"
+    local overrides_file="$2"
+    hook_exit=0
+    echo "$input" | env CLAUDE_SECURITY_OVERRIDES="$overrides_file" bash "$PRE_HOOK" 2>/dev/null || hook_exit=$?
+}
+
+assert_denied() {
+    local test_name="$1"
+    local output="$2"
+    local decision
+    decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+    if [[ "$decision" == "deny" ]]; then
+        pass "$test_name"
+    else
+        fail "$test_name" "expected deny but got: $output"
+    fi
+}
+
+assert_not_denied() {
+    local test_name="$1"
+    local output="$2"
+    local decision
+    decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+    if [[ "$decision" == "deny" ]]; then
+        fail "$test_name" "expected pass-through but got deny"
+    else
+        pass "$test_name"
+    fi
+}
+
+# ---- Tests ---------------------------------------------------------------
+
+echo "Running security override tests for pretooluse-hook.sh"
+echo ""
+
+# ------------------------------------------------------------------
+# Test 1: Default deny — no override file
+# ------------------------------------------------------------------
+echo "Test 1: All categories denied when no override file exists"
+{
+    tmpdir=$(mktemp -d)
+    no_file="$tmpdir/nonexistent.json"
+
+    # pkill
+    output=$(run_hook "$(build_bash_input "pkill node")" "$no_file")
+    assert_denied "process-kill denied (no override file)" "$output"
+
+    # gcloud auth
+    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$no_file")
+    assert_denied "cloud-credentials-cmd denied (no override file)" "$output"
+
+    # aws credentials file
+    output=$(run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$no_file")
+    assert_denied "cloud-credentials-files denied (no override file)" "$output"
+
+    # ssh key
+    output=$(run_hook "$(build_bash_input "cat ~/.ssh/id_rsa")" "$no_file")
+    assert_denied "ssh-keys denied (no override file)" "$output"
+
+    # keychain
+    output=$(run_hook "$(build_bash_input "security find-generic-password -s foo")" "$no_file")
+    assert_denied "keychain denied (no override file)" "$output"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 2: Per-category override allows specific command
+# ------------------------------------------------------------------
+echo ""
+echo "Test 2: Per-category override allows specific blocked commands"
+{
+    tmpdir=$(mktemp -d)
+    overrides="$tmpdir/overrides.json"
+
+    # Enable only process-kill
+    cat > "$overrides" <<'EOF'
+{"overrides":{"process-kill":true}}
+EOF
+
+    output=$(run_hook "$(build_bash_input "pkill node")" "$overrides")
+    assert_not_denied "process-kill allowed with override" "$output"
+
+    # killall variant
+    output=$(run_hook "$(build_bash_input "killall node")" "$overrides")
+    assert_not_denied "killall allowed with override" "$output"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 3: Partial override — only the enabled category is allowed
+# ------------------------------------------------------------------
+echo ""
+echo "Test 3: Partial override only unblocks the specified category"
+{
+    tmpdir=$(mktemp -d)
+    overrides="$tmpdir/overrides.json"
+
+    # Enable only cloud-credentials-cmd
+    cat > "$overrides" <<'EOF'
+{"overrides":{"cloud-credentials-cmd":true}}
+EOF
+
+    # gcloud auth command should pass
+    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
+    assert_not_denied "cloud-credentials-cmd allowed" "$output"
+
+    output=$(run_hook "$(build_bash_input "gcloud auth application-default print-access-token")" "$overrides")
+    assert_not_denied "gcloud auth application-default allowed" "$output"
+
+    # cloud credential files should still be denied
+    output=$(run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides")
+    assert_denied "cloud-credentials-files still denied" "$output"
+
+    # pkill should still be denied
+    output=$(run_hook "$(build_bash_input "pkill node")" "$overrides")
+    assert_denied "process-kill still denied" "$output"
+
+    # ssh keys should still be denied
+    output=$(run_hook "$(build_bash_input "cat ~/.ssh/id_rsa")" "$overrides")
+    assert_denied "ssh-keys still denied" "$output"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 4: Malformed override file treated as no override
+# ------------------------------------------------------------------
+echo ""
+echo "Test 4: Malformed override file treated as no override (deny)"
+{
+    tmpdir=$(mktemp -d)
+    overrides="$tmpdir/overrides.json"
+
+    # Write invalid JSON
+    echo "this is not json" > "$overrides"
+
+    output=$(run_hook "$(build_bash_input "pkill node")" "$overrides")
+    assert_denied "process-kill denied (malformed override file)" "$output"
+
+    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
+    assert_denied "cloud-credentials-cmd denied (malformed override file)" "$output"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 5: Override works for Read/Write/Edit file-path rules
+# ------------------------------------------------------------------
+echo ""
+echo "Test 5: Override works for Read tool file-path rules"
+{
+    tmpdir=$(mktemp -d)
+    overrides="$tmpdir/overrides.json"
+
+    # Enable cloud-credentials-files
+    cat > "$overrides" <<'EOF'
+{"overrides":{"cloud-credentials-files":true}}
+EOF
+
+    # Read ~/.aws/credentials should pass
+    output=$(run_hook "$(build_read_input "$HOME/.aws/credentials")" "$overrides")
+    assert_not_denied "Read cloud credential file allowed" "$output"
+
+    # Read gcloud credentials.db should pass
+    output=$(run_hook "$(build_read_input "$HOME/.config/gcloud/credentials.db")" "$overrides")
+    assert_not_denied "Read gcloud credentials.db allowed" "$output"
+
+    # Read SSH key should still be denied
+    output=$(run_hook "$(build_read_input "$HOME/.ssh/id_rsa")" "$overrides")
+    assert_denied "Read ssh key still denied" "$output"
+
+    # Read browser cookies should still be denied
+    output=$(run_hook "$(build_read_input "$HOME/Library/Application Support/Google/Chrome/Default/Cookies")" "$overrides")
+    assert_denied "Read browser cookies still denied" "$output"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 6: Cloud credentials split — cmd vs files are independent
+# ------------------------------------------------------------------
+echo ""
+echo "Test 6: Cloud credentials cmd vs files are independent categories"
+{
+    tmpdir=$(mktemp -d)
+    overrides="$tmpdir/overrides.json"
+
+    # Enable only cloud-credentials-files (not cmd)
+    cat > "$overrides" <<'EOF'
+{"overrides":{"cloud-credentials-files":true}}
+EOF
+
+    # File access allowed
+    output=$(run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides")
+    assert_not_denied "cloud-credentials-files Bash allowed" "$output"
+
+    output=$(run_hook "$(build_bash_input "cat ~/.config/gcloud/application_default_credentials.json")" "$overrides")
+    assert_not_denied "cloud-credentials-files gcloud ADC allowed" "$output"
+
+    # Command still denied
+    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
+    assert_denied "cloud-credentials-cmd still denied" "$output"
+
+    # Now flip: enable only cmd
+    cat > "$overrides" <<'EOF'
+{"overrides":{"cloud-credentials-cmd":true}}
+EOF
+
+    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
+    assert_not_denied "cloud-credentials-cmd allowed" "$output"
+
+    output=$(run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides")
+    assert_denied "cloud-credentials-files denied when only cmd enabled" "$output"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 7: Override set to false is same as not set
+# ------------------------------------------------------------------
+echo ""
+echo "Test 7: Override set to false is same as not set"
+{
+    tmpdir=$(mktemp -d)
+    overrides="$tmpdir/overrides.json"
+
+    cat > "$overrides" <<'EOF'
+{"overrides":{"process-kill":false,"cloud-credentials-cmd":false}}
+EOF
+
+    output=$(run_hook "$(build_bash_input "pkill node")" "$overrides")
+    assert_denied "process-kill denied when explicitly false" "$output"
+
+    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
+    assert_denied "cloud-credentials-cmd denied when explicitly false" "$output"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 8: Multiple overrides enabled simultaneously
+# ------------------------------------------------------------------
+echo ""
+echo "Test 8: Multiple overrides enabled simultaneously"
+{
+    tmpdir=$(mktemp -d)
+    overrides="$tmpdir/overrides.json"
+
+    cat > "$overrides" <<'EOF'
+{"overrides":{"process-kill":true,"cloud-credentials-cmd":true,"cloud-credentials-files":true}}
+EOF
+
+    output=$(run_hook "$(build_bash_input "pkill node")" "$overrides")
+    assert_not_denied "process-kill allowed" "$output"
+
+    output=$(run_hook "$(build_bash_input "gcloud auth print-access-token")" "$overrides")
+    assert_not_denied "cloud-credentials-cmd allowed" "$output"
+
+    output=$(run_hook "$(build_bash_input "cat ~/.aws/credentials")" "$overrides")
+    assert_not_denied "cloud-credentials-files allowed" "$output"
+
+    # Non-overridden categories still denied
+    output=$(run_hook "$(build_bash_input "cat ~/.ssh/id_rsa")" "$overrides")
+    assert_denied "ssh-keys still denied" "$output"
+
+    output=$(run_hook "$(build_bash_input "security find-generic-password -s foo")" "$overrides")
+    assert_denied "keychain still denied" "$output"
+
+    rm -rf "$tmpdir"
+}
+
+# ------------------------------------------------------------------
+# Test 9: Non-blocked commands pass through regardless
+# ------------------------------------------------------------------
+echo ""
+echo "Test 9: Non-blocked commands pass through regardless"
+{
+    tmpdir=$(mktemp -d)
+    no_file="$tmpdir/nonexistent.json"
+
+    output=$(run_hook "$(build_bash_input "ls -la")" "$no_file")
+    assert_not_denied "ls -la passes through" "$output"
+
+    output=$(run_hook "$(build_bash_input "git status")" "$no_file")
+    assert_not_denied "git status passes through" "$output"
+
+    output=$(run_hook "$(build_read_input "/tmp/somefile.txt")" "$no_file")
+    assert_not_denied "Read /tmp/somefile.txt passes through" "$output"
+
+    rm -rf "$tmpdir"
+}
+
+# ---- Summary -------------------------------------------------------------
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Adds a granular override system to `pretooluse-hook.sh` so users can selectively unblock security-restricted categories via `~/.claude/security-overrides.json`
- Splits the monolithic cloud credentials category into independent `cloud-credentials-cmd` (gcloud auth commands) and `cloud-credentials-files` (~/.aws/credentials, ~/.config/gcloud/*) categories
- Supports override via `CLAUDE_SECURITY_OVERRIDES` env var for testing

### Override categories
| Category | What it unblocks |
|---|---|
| `process-kill` | `pkill`, `killall` |
| `keychain` | macOS `security find-*-password`, `dump-keychain` |
| `browser-profiles` | Chrome/Firefox/Safari profile dirs and sqlite DBs |
| `ssh-keys` | `~/.ssh/id_*` |
| `cloud-credentials-cmd` | `gcloud auth print-access-token`, `gcloud auth application-default` |
| `cloud-credentials-files` | `~/.aws/credentials`, `~/.config/gcloud/*` |

### Example `~/.claude/security-overrides.json`
```json
{
  "overrides": {
    "cloud-credentials-cmd": true,
    "cloud-credentials-files": true,
    "process-kill": true
  }
}
```

## Test plan
- [x] 33 new tests in `test_security_overrides.sh` — all passing
- [ ] Verify default deny still works with no override file present
- [ ] Verify partial overrides only unblock the specified category
- [ ] Verify malformed JSON override file degrades safely to deny-all
- [ ] Verify cloud-credentials-cmd and cloud-credentials-files are independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)