### PR TITLE
FEA-585: build judge input from runtime context

### DIFF
--- a/plugins/judges/.claude-plugin/plugin.json
+++ b/plugins/judges/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "judges",
   "description": "LLM Judges plugin",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/judges/README.md
+++ b/plugins/judges/README.md
@@ -27,8 +27,8 @@ graph TD
     PlanInput --> CommonPlan["common_input_preamble.md (shared contract preamble)"]
     CommonPlan --> PlanPreamble["plan_preamble.md (artifact-specific preamble)"]
     PlanPreamble --> PlanBatches[Plan judge batches]
-    CtxMgr -->|code mode| CodeJSON["code-context.json"]
-    CodeJSON --> CodeInput["judge-input.json (primary = code-context.json)"]
+    CtxMgr -->|code mode| CodeJSON[".closedloop-ai/context/code-context.json"]
+    CodeJSON --> CodeInput["judge-input.json (primary = .closedloop-ai/context/code-context.json)"]
     CodeInput --> CommonCode["common_input_preamble.md (shared contract preamble)"]
     CommonCode --> CodePreamble["code_preamble.md (artifact-specific preamble)"]
     CodePreamble --> CodeBatches[Code judge batches]
@@ -66,7 +66,7 @@ The `artifact-type-tailored-context` skill compresses individual artifact files 
 - Collect plan/code evaluation artifacts from `$CLOSEDLOOP_WORKDIR`
 - Allocate and enforce a 30,000-token budget across artifacts
 - Invoke `judges:artifact-type-tailored-context` per artifact
-- Write `plan-context.json` or `code-context.json` with compaction metadata
+- Write `plan-context.json` or `.closedloop-ai/context/code-context.json` with compaction metadata
 
 ### brownfield-accuracy-judge
 
@@ -259,7 +259,7 @@ Orchestrates parallel judge agent execution, aggregates `CaseScore` results, and
 - Writes `$CLOSEDLOOP_WORKDIR/plan-judges.json`
 
 **Code mode** (`--artifact-type code`):
-- Launches `context-manager-for-judges` agent to produce `code-context.json`
+- Launches `context-manager-for-judges` agent to produce canonical `.closedloop-ai/context/code-context.json`
 - Builds `judge-input.json` with code evaluation task and artifact mapping
 - Reuses `$CLOSEDLOOP_WORKDIR/investigation-log.md` as secondary context when available (best-effort generation if missing)
 - Prepends `common_input_preamble.md` + `code_preamble.md` to each judge prompt
@@ -341,7 +341,7 @@ Checks for a cached plan evaluation result before launching the plan-evaluator a
 ```
 
 3. The skill resolves `investigation-log.md` as best-effort supporting context (reuse if present; attempt generation when missing; continue if unavailable).
-4. The skill runs `context-manager-for-judges` first to produce `code-context.json`, then builds `judge-input.json` and launches 11 judges.
+4. The skill runs `context-manager-for-judges` first to produce canonical `.closedloop-ai/context/code-context.json`, then builds `judge-input.json` and launches 11 judges. Root `code-context.json` is a legacy fallback only when the canonical file is absent.
 5. Results are written to `$CLOSEDLOOP_WORKDIR/code-judges.json`.
 
 ### Evaluating a Feature Artifact

--- a/plugins/judges/agents/feature-completeness-judge.md
+++ b/plugins/judges/agents/feature-completeness-judge.md
@@ -24,9 +24,11 @@ Wrap all analytical thinking in `<thinking>` tags before producing your final JS
 
 ## Step 1: Locate and Read the Feature Document
 
-Read the Feature from `$CLOSEDLOOP_WORKDIR/prd.md`. If the file is absent or unreadable, output a CaseScore JSON with `final_status: 3` (error) and a note in the justification.
+Read `$CLOSEDLOOP_WORKDIR/judge-input.json` first. Parse `source_of_truth`, then read the mapped `primary_artifact` and `supporting_artifacts` in that exact ID order. Treat the primary artifact as the Feature document and supporting descriptors as source-of-truth evidence for completeness. Use legacy `$CLOSEDLOOP_WORKDIR/prd.md` only when `judge-input.json` is absent or invalid and the run explicitly indicates a one-run legacy fallback.
 
-Note: Features are stored at the standard PRD artifact path (`prd.md`) regardless of their maturity level. The document may range from a single sentence to a multi-section document.
+If neither the mapped Feature artifact nor an explicit legacy fallback is readable, output a CaseScore JSON with `final_status: 3` (error) and a note in the justification.
+
+Note: Feature documents may range from a single sentence to a multi-section document. Their runtime filename is not authoritative; the envelope mapping is.
 
 ## Step 2: Apply the Five Analysis Checks
 
@@ -292,7 +294,7 @@ Your justification string MUST include:
 </example>
 
 <example name="error_missing_file">
-**Scenario:** The prd.md file does not exist at $CLOSEDLOOP_WORKDIR.
+**Scenario:** `judge-input.json` is absent or invalid and no explicit legacy Feature fallback file exists at $CLOSEDLOOP_WORKDIR.
 
 **Analysis:** Cannot proceed with evaluation due to missing required input.
 
@@ -306,7 +308,7 @@ Your justification string MUST include:
       "metric_name": "feature_completeness",
       "threshold": 0.8,
       "score": 0.0,
-      "justification": "Error: Unable to read prd.md from $CLOSEDLOOP_WORKDIR. File not found. Cannot evaluate Feature completeness without the Feature document."
+      "justification": "Error: Unable to read judge-input.json or an explicit legacy Feature fallback from $CLOSEDLOOP_WORKDIR. Cannot evaluate Feature completeness without the Feature document."
     }
   ]
 }
@@ -320,7 +322,8 @@ When performing your analysis, structure your thinking as follows:
 ```
 <thinking>
 ## 1. File Reading
-- Read prd.md: [success/failure]
+- Read judge-input.json: [success/failure and source_of_truth order]
+- Read mapped Feature/supporting artifacts: [success/failure]
 - Error check: [any issues that would trigger final_status: 3]
 - Document length: [approximate word count or line count]
 - Document structure: [list of sections/headings found, if any]

--- a/plugins/judges/agents/prd-auditor.md
+++ b/plugins/judges/agents/prd-auditor.md
@@ -23,7 +23,7 @@ Your task is to audit a draft PRD for structural completeness and produce a Case
 <analysis_instructions>
 You MUST perform your analysis in a structured, step-by-step manner. Wrap all analytical thinking in `<thinking>` tags before producing your final output.
 
-The PRD to audit is located at `$CLOSEDLOOP_WORKDIR/prd.md`. Read it first.
+Read `$CLOSEDLOOP_WORKDIR/judge-input.json` first. Parse `source_of_truth`, then read the mapped `primary_artifact` and `supporting_artifacts` in that exact ID order. Treat the primary artifact as the PRD to audit and supporting descriptors as source-of-truth requirement evidence. Use legacy `$CLOSEDLOOP_WORKDIR/prd.md` only when `judge-input.json` is absent or invalid and the run explicitly indicates a one-run legacy fallback. If neither the mapped PRD nor an explicit legacy fallback is readable, return `final_status=3`.
 
 ## Check 1: User Story AC Coverage
 
@@ -247,7 +247,7 @@ Your justification string MUST include:
 </example>
 
 <example name="error_prd_missing">
-**Scenario:** The prd.md file is missing from $CLOSEDLOOP_WORKDIR.
+**Scenario:** `judge-input.json` is absent or invalid and no explicit legacy PRD fallback file exists at $CLOSEDLOOP_WORKDIR.
 
 **Analysis:** Cannot proceed with evaluation due to missing required input.
 
@@ -261,7 +261,7 @@ Your justification string MUST include:
       "metric_name": "structural_completeness",
       "threshold": 0.8,
       "score": 0.0,
-      "justification": "Error: Unable to read prd.md from $CLOSEDLOOP_WORKDIR. File not found. Cannot evaluate structural completeness without the PRD document."
+      "justification": "Error: Unable to read judge-input.json or an explicit legacy PRD fallback from $CLOSEDLOOP_WORKDIR. Cannot evaluate structural completeness without the PRD document."
     }
   ]
 }
@@ -275,7 +275,8 @@ When performing your analysis, structure your thinking as follows:
 ```
 <thinking>
 ## 1. File Reading
-- Read prd.md: [success/failure]
+- Read judge-input.json: [success/failure and source_of_truth order]
+- Read mapped PRD/supporting artifacts: [success/failure]
 - Error check: [any issues that would trigger final_status: 3]
 
 ## 2. Check 1: User Story AC Coverage

--- a/plugins/judges/agents/prd-dependency-judge.md
+++ b/plugins/judges/agents/prd-dependency-judge.md
@@ -24,11 +24,9 @@ Wrap all analytical reasoning in `<thinking>` tags before producing your final J
 
 ## Step 1: Read Input Artifacts
 
-Read the PRD from `$CLOSEDLOOP_WORKDIR`. Look for:
-- A file named `prd.md` or similar (check `$CLOSEDLOOP_WORKDIR` for the PRD)
-- A `judge-input.json` that maps to source-of-truth artifacts
+Read `$CLOSEDLOOP_WORKDIR/judge-input.json` first. Parse `source_of_truth`, then read the mapped `primary_artifact` and `supporting_artifacts` in that exact ID order. Treat the primary artifact as the PRD or Feature document under evaluation and supporting descriptors as source-of-truth dependency evidence.
 
-If no PRD is found, output a CaseScore JSON with `final_status: 3` (error) and a note in the justification.
+Use legacy `$CLOSEDLOOP_WORKDIR/prd.md` only when `judge-input.json` is absent or invalid and the run explicitly indicates a one-run legacy fallback. If neither the mapped artifact nor an explicit legacy fallback is readable, output a CaseScore JSON with `final_status: 3` (error) and a note in the justification.
 
 ## Step 2: Parse User Stories
 

--- a/plugins/judges/agents/prd-scope-judge.md
+++ b/plugins/judges/agents/prd-scope-judge.md
@@ -16,6 +16,10 @@ You evaluate requirements artifacts — not code. Your findings are emitted as a
 <analysis_instructions>
 Wrap all reasoning in `<thinking>` tags before emitting JSON output.
 
+## Step 1: Load PRD Evidence
+
+Read `$CLOSEDLOOP_WORKDIR/judge-input.json` first. Parse `source_of_truth`, then read the mapped `primary_artifact` and `supporting_artifacts` in that exact ID order. Treat the primary artifact as the PRD and supporting descriptors as source-of-truth requirement evidence. Use legacy `$CLOSEDLOOP_WORKDIR/prd.md` only when `judge-input.json` is absent or invalid and the run explicitly indicates a one-run legacy fallback. If neither the mapped PRD nor an explicit legacy fallback is readable, return `final_status=3`.
+
 ## Rule 1: Traceability Check
 
 For each user story identifier matching the pattern `US-###` found in the PRD:

--- a/plugins/judges/agents/prd-testability-judge.md
+++ b/plugins/judges/agents/prd-testability-judge.md
@@ -23,7 +23,9 @@ Wrap all analytical thinking in `<thinking>` tags before producing your final JS
 
 ## Step 1: Locate and Read the PRD
 
-Read the PRD from `$CLOSEDLOOP_WORKDIR/prd.md`. If the file is absent or unreadable, output a CaseScore JSON with `final_status: 3` (error) and a note in the justification.
+Read `$CLOSEDLOOP_WORKDIR/judge-input.json` first. Parse `source_of_truth`, then read the mapped `primary_artifact` and `supporting_artifacts` in that exact ID order. Treat the primary artifact as the PRD or Feature document under evaluation and supporting descriptors as source-of-truth requirement evidence. Use legacy `$CLOSEDLOOP_WORKDIR/prd.md` only when `judge-input.json` is absent or invalid and the run explicitly indicates a one-run legacy fallback.
+
+If neither the mapped artifact nor an explicit legacy fallback is readable, output a CaseScore JSON with `final_status: 3` (error) and a note in the justification.
 
 ## Step 2: Extract Acceptance Criteria and User Stories
 

--- a/plugins/judges/skills/artifact-type-tailored-context/preambles/common_input_preamble.md
+++ b/plugins/judges/skills/artifact-type-tailored-context/preambles/common_input_preamble.md
@@ -10,7 +10,8 @@ You MUST follow this sequence before analysis:
 2. Parse envelope fields: `evaluation_type`, `task`, `primary_artifact`, `supporting_artifacts`, `source_of_truth`, `fallback_mode`, `metadata`.
 3. Read mapped artifacts from envelope paths:
    - `primary_artifact` is authoritative evidence.
-   - `supporting_artifacts` are secondary evidence in listed order.
+   - `supporting_artifacts` are source-of-truth evidence in listed order.
+   - When `source_of_truth` is present, load artifacts in exactly that ID order.
 
 Do not assume fixed artifact filenames unless they are explicitly mapped in the envelope.
 
@@ -26,6 +27,11 @@ If any of the following occur, return a CaseScore error result:
 
 - `judge-input.json` missing, unreadable, or malformed JSON
 - A required mapped artifact is missing or unreadable
+
+For PRD and Feature runs only, a missing or malformed `judge-input.json` may fall
+back to legacy `prd.md` / `plan.md` paths when the run prompt explicitly says
+the mapper failed and a one-run legacy fallback is active. Otherwise, treat the
+missing or malformed envelope as an error.
 
 Error response requirements:
 

--- a/plugins/judges/skills/artifact-type-tailored-context/preambles/common_input_preamble.md
+++ b/plugins/judges/skills/artifact-type-tailored-context/preambles/common_input_preamble.md
@@ -29,9 +29,9 @@ If any of the following occur, return a CaseScore error result:
 - A required mapped artifact is missing or unreadable
 
 For PRD and Feature runs only, a missing or malformed `judge-input.json` may fall
-back to legacy `prd.md` / `plan.md` paths when the run prompt explicitly says
-the mapper failed and a one-run legacy fallback is active. Otherwise, treat the
-missing or malformed envelope as an error.
+back to legacy `prd.md` paths when the run prompt explicitly says the mapper
+failed and a one-run legacy fallback is active. Otherwise, treat the missing or
+malformed envelope as an error.
 
 Error response requirements:
 

--- a/plugins/judges/skills/artifact-type-tailored-context/preambles/feature_preamble.md
+++ b/plugins/judges/skills/artifact-type-tailored-context/preambles/feature_preamble.md
@@ -10,7 +10,7 @@ Think of it as PRD-grade rigor applied to a deliberately narrower surface.
 
 ## Feature Document Shape
 
-Features are stored at `$CLOSEDLOOP_WORKDIR/prd.md` regardless of artifact type (the file path is shared with PRDs). Do not let the filename mislead you — the artifact you are evaluating is a Feature, not a PRD.
+Features are mapped through `$CLOSEDLOOP_WORKDIR/judge-input.json`. New runtime materialization uses `feature.md`; legacy runs may map `prd.md`. Do not let the filename mislead you — the artifact you are evaluating is a Feature, not a PRD.
 
 A well-formed Feature includes, at the depth appropriate for one narrow feature:
 
@@ -47,7 +47,7 @@ For Feature evaluation, always read the orchestrator-provided `judge-input.json`
 - Confirm `evaluation_type` is `feature` (not `prd` — the envelope is feature-specific even though the file path is `prd.md`).
 - Use `task` as the explicit evaluation objective.
 - Use `source_of_truth` ordering to prioritize evidence across artifacts.
-- Treat `primary_artifact` (`$CLOSEDLOOP_WORKDIR/prd.md`) as the authoritative Feature artifact unless `fallback_mode.active=true` declares an alternative path.
+- Treat `primary_artifact` as the authoritative Feature artifact and load supporting descriptors in `source_of_truth` order.
 - Do not assume fixed file names beyond what the envelope maps.
 
 ## Scoring Principles
@@ -61,4 +61,4 @@ For Feature evaluation, always read the orchestrator-provided `judge-input.json`
 
 ---
 
-**Reminder:** You are evaluating a Feature artifact (`evaluation_type=feature`) — a requirements document scoped to one narrow, independently deliverable feature. The document lives at `$CLOSEDLOOP_WORKDIR/prd.md` by convention.
+**Reminder:** You are evaluating a Feature artifact (`evaluation_type=feature`) — a requirements document scoped to one narrow, independently deliverable feature. Use the document mapped by `primary_artifact`, not a hardcoded filename.

--- a/plugins/judges/skills/run-judges/SKILL.md
+++ b/plugins/judges/skills/run-judges/SKILL.md
@@ -33,6 +33,17 @@ The judge input contract is maintained in:
 
 This keeps orchestration flow readable while preserving a single source of truth for contract fields and semantics.
 
+`run-judges` is the producer chokepoint for `judge-input.json`. After mode-specific context preparation and before launching any judge agent, invoke the deterministic mapper:
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/skills/run-judges/scripts/judge_input_mapping.py" \
+  --workdir "$CLOSEDLOOP_WORKDIR" \
+  --artifact-type "$ARTIFACT_TYPE" \
+  --schema "${CLAUDE_PLUGIN_ROOT}/schemas/judge-input.schema.json"
+```
+
+The mapper builds from the runtime workdir contract: primary artifacts under `<runDir>`, supporting context under `<runDir>/.closedloop-ai/context`, and attachments under `<runDir>/.closedloop-ai/work/attachments`. It validates the generated envelope against `schemas/judge-input.schema.json` before judge launch. If mapping fails, emit a clear warning and use the documented one-run legacy fallback paths (`prd.md`, `plan.md`, or existing compatibility artifacts) only for that run.
+
 ## Task Context
 
 You are orchestrating quality evaluation for a ClosedLoop artifact (implementation plan, code, or PRD). Your responsibilities:
@@ -55,15 +66,15 @@ You are orchestrating quality evaluation for a ClosedLoop artifact (implementati
 
 **For PRD artifacts (--artifact-type prd):**
 1. Check `$CLOSEDLOOP_WORKDIR/prd.md` exists (graceful exit if missing)
-2. Build `judge-input.json` with evaluation_type: "prd" and primary_artifact pointing to prd.md
+2. Build and schema-validate `judge-input.json` by invoking `scripts/judge_input_mapping.py`
 3. Launch the 5 PRD judges in 2 sequential batches (3 + 2, max 4 concurrent per batch)
 4. Aggregate all 5 CaseScores into a valid EvaluationReport
 5. Write the report to `$CLOSEDLOOP_WORKDIR/prd-judges.json`
 6. Validate output structure and completeness
 
 **For Feature artifacts (--artifact-type feature):**
-1. Check `$CLOSEDLOOP_WORKDIR/prd.md` exists (graceful exit code 0 if missing)
-2. Build `judge-input.json` with `evaluation_type="feature"` and `primary_artifact` pointing to `$CLOSEDLOOP_WORKDIR/prd.md`
+1. Check `$CLOSEDLOOP_WORKDIR/feature.md` exists, or `$CLOSEDLOOP_WORKDIR/prd.md` exists for legacy Feature inputs (graceful exit code 0 if both are missing)
+2. Build and schema-validate `judge-input.json` by invoking `scripts/judge_input_mapping.py`
 3. Launch 3 judges in 1 batch (feature-completeness-judge + prd-testability-judge + prd-dependency-judge)
 4. Aggregate 3 CaseScores into a valid EvaluationReport
 5. Write the report to `$CLOSEDLOOP_WORKDIR/feature-judges.json`
@@ -389,12 +400,10 @@ After validating `prd.md` and `plan.json`, resolve supporting context for plan j
    - Compatibility mode: `plan.json` + `prd.md` may be used for this run only.
 
 8. **Build plan-mode `judge-input.json`**
-   - Set `evaluation_type` = `plan`.
-   - Set `task` to plan quality evaluation objective (16-plan-judge workflow).
-   - Set `primary_artifact` to `plan-context.json` in normal mode.
-   - In compatibility mode, set primary to `plan.json` and include `prd.md` as supporting.
-   - Include `investigation-log.md` as supporting artifact when available.
-   - Set `source_of_truth` ordering from primary to secondary artifacts.
+   - Invoke `scripts/judge_input_mapping.py` with `--artifact-type plan`.
+   - The mapper sets `evaluation_type`, `task`, `primary_artifact`, `supporting_artifacts`, `source_of_truth`, `fallback_mode`, and metadata from the runtime workdir contract.
+   - In compatibility mode, allow the mapper to produce a schema-valid fallback envelope for existing plan compatibility artifacts and include `prd.md` as supporting evidence when available.
+   - If the mapper exits non-zero, log the error and use the one-run legacy fallback only if `prd.md` plus `plan.md` or the existing compatibility artifact is readable.
 
 **For code artifacts (--artifact-type code):**
 ```bash
@@ -407,27 +416,25 @@ fi
 
 # Launch context-manager-for-judges agent to prepare compressed context
 # This agent reads code artifacts (git diff, changed-files.json, etc.)
-# and produces code-context.json with token-budgeted compression
+# and produces .closedloop-ai/context/code-context.json with token-budgeted compression
 
 # investigation-log.md is optional secondary context for code judging
 if [ ! -f "$CLOSEDLOOP_WORKDIR/investigation-log.md" ]; then
-  echo "WARNING: investigation-log.md unavailable. Continuing code judges with code-context.json only."
+  echo "WARNING: investigation-log.md unavailable. Continuing code judges with canonical code context only."
 fi
 
-# Verify code-context.json exists after context manager completes
-if [ ! -f "$CLOSEDLOOP_WORKDIR/code-context.json" ]; then
-  echo "ERROR: Context preparation failed - code-context.json not found"
+# Verify canonical code context exists after context manager completes. The root
+# code-context.json path is fallback-only for old runs.
+if [ ! -f "$CLOSEDLOOP_WORKDIR/.closedloop-ai/context/code-context.json" ] && [ ! -f "$CLOSEDLOOP_WORKDIR/code-context.json" ]; then
+  echo "ERROR: Context preparation failed - .closedloop-ai/context/code-context.json not found"
   # Abort with error CaseScore for all judges
   # Generate error report with final_status=3, justification="Context preparation failed"
   exit 1
 fi
 
-# Build code-mode judge-input.json
-# - evaluation_type: "code"
-# - task: code quality evaluation objective (11-code-judge workflow)
-# - primary_artifact: code-context.json
-# - supporting_artifacts: investigation-log.md (optional), plus any other run artifacts
-# - source_of_truth: ["code_context", ...]
+# Build and validate code-mode judge-input.json with scripts/judge_input_mapping.py.
+# The mapper prefers .closedloop-ai/context/code-context.json as primary and
+# preserves root code-context.json as a one-run legacy fallback when needed.
 ```
 
 **For PRD artifacts (--artifact-type prd):**
@@ -441,41 +448,35 @@ if [ ! -f "$CLOSEDLOOP_WORKDIR/prd.md" ]; then
   exit 0  # Graceful exit — do not fail parent workflow
 fi
 
-# Build prd-mode judge-input.json
-# - evaluation_type: "prd"
-# - task: PRD quality evaluation objective (prd-auditor + 4 critics)
-# - primary_artifact: $CLOSEDLOOP_WORKDIR/prd.md
-# - supporting_artifacts: [] (none required)
-# - source_of_truth: ["prd"]
+# Build and validate prd-mode judge-input.json with scripts/judge_input_mapping.py.
+# The mapper sets primary_artifact to primary_prd and includes mapped context,
+# prompt, repo metadata, prior summaries, and attachments in source_of_truth order.
 ```
 
 **PRD context prep notes:**
 - Missing `prd.md` results in a WARNING and graceful exit (code 0), not an error
-- No context manager is launched; `judge-input.json` is built directly with `primary_artifact` pointing to `$CLOSEDLOOP_WORKDIR/prd.md`
+- No context manager is launched; `judge-input.json` is built by `scripts/judge_input_mapping.py` and validated against `schemas/judge-input.schema.json`
 - Performance: emit sub_step=0 (context_prep, skipped=true) perf event immediately, then proceed to sub_step=1 (batch_1) and sub_step=2 (batch_2)
 
 **For Feature artifacts (--artifact-type feature):**
 
-Feature mode does NOT use context-manager-for-judges. Context preparation is lightweight: verify `prd.md` exists, then build judge-input.json directly from it.
+Feature mode does NOT use context-manager-for-judges. Context preparation is lightweight: verify `feature.md` exists, or `prd.md` exists for legacy Feature inputs, then build judge-input.json from the mapper.
 
 ```bash
-# Feature mode context prep: check prd.md exists
-if [ ! -f "$CLOSEDLOOP_WORKDIR/prd.md" ]; then
-  echo "WARNING: $CLOSEDLOOP_WORKDIR/prd.md not found. Skipping Feature judges."
+# Feature mode context prep: check feature.md or legacy prd.md exists
+if [ ! -f "$CLOSEDLOOP_WORKDIR/feature.md" ] && [ ! -f "$CLOSEDLOOP_WORKDIR/prd.md" ]; then
+  echo "WARNING: neither $CLOSEDLOOP_WORKDIR/feature.md nor legacy $CLOSEDLOOP_WORKDIR/prd.md found. Skipping Feature judges."
   exit 0  # Graceful exit — do not fail parent workflow
 fi
 
-# Build feature-mode judge-input.json
-# - evaluation_type: "feature"
-# - task: Feature quality evaluation objective (3-feature-judge workflow)
-# - primary_artifact: $CLOSEDLOOP_WORKDIR/prd.md
-# - supporting_artifacts: [] (none required)
-# - source_of_truth: ["prd"]
+# Build and validate feature-mode judge-input.json with scripts/judge_input_mapping.py.
+# The mapper prefers feature.md and marks fallback_mode.active=true when it must
+# use the legacy prd.md Feature path.
 ```
 
 **Feature context prep notes:**
-- Missing `prd.md` results in a WARNING and graceful exit (code 0), not an error
-- No context manager is launched; `judge-input.json` is built directly with `evaluation_type="feature"` and `primary_artifact` pointing to `$CLOSEDLOOP_WORKDIR/prd.md`
+- Missing both `feature.md` and legacy `prd.md` results in a WARNING and graceful exit (code 0), not an error
+- No context manager is launched; `judge-input.json` is built by `scripts/judge_input_mapping.py` with `evaluation_type="feature"`
 - Performance: emit sub_step=0 (context_prep, skipped=true) perf event immediately, then proceed to sub_step=1 (batch_1), sub_step=2 (aggregate), sub_step=3 (validate)
 - Preamble: use `feature_preamble.md` for all 3 feature judges
 
@@ -528,7 +529,7 @@ The run-judges skill supports three artifact types with different judge configur
 - **Output**: `prd-judges.json`
 - **Report ID**: `{RUN_ID}-prd-judges`
 - **Validation**: `--category prd` (5 judges expected)
-- **Canonical input**: `$CLOSEDLOOP_WORKDIR/prd.md`
+- **Canonical input**: `$CLOSEDLOOP_WORKDIR/judge-input.json` produced by `scripts/judge_input_mapping.py`, with `primary_prd` normally pointing to `$CLOSEDLOOP_WORKDIR/prd.md`
 
 ### Feature Artifacts (--artifact-type feature)
 - **Judges**: 3 total (feature-completeness-judge, prd-testability-judge, prd-dependency-judge)
@@ -536,7 +537,7 @@ The run-judges skill supports three artifact types with different judge configur
 - **Output**: `feature-judges.json`
 - **Report ID**: `{RUN_ID}-feature-judges`
 - **Validation**: `--category feature` (3 judges expected)
-- **Canonical input**: `$CLOSEDLOOP_WORKDIR/prd.md`
+- **Canonical input**: `$CLOSEDLOOP_WORKDIR/judge-input.json` produced by `scripts/judge_input_mapping.py`, with `primary_feature` normally pointing to `feature.md` and legacy fallback to `prd.md`
 - **Preamble**: use `feature_preamble.md` (Feature-shaped contract; do NOT substitute `prd_preamble.md`)
 
 **Feature Mode Execution:**
@@ -693,7 +694,7 @@ Apply your {judge_name} criteria to assess code quality.
 ```
 WORKDIR=$CLOSEDLOOP_WORKDIR. Read $CLOSEDLOOP_WORKDIR/judge-input.json first.
 Evaluate according to `task` and `source_of_truth` ordering.
-Treat the envelope's `primary_artifact` ($CLOSEDLOOP_WORKDIR/prd.md) as the authoritative PRD document.
+Treat the envelope's `primary_artifact` as the authoritative PRD document and load supporting descriptors as source-of-truth evidence.
 Apply your {judge_name} criteria to assess PRD quality.
 ```
 
@@ -701,7 +702,7 @@ Apply your {judge_name} criteria to assess PRD quality.
 ```
 WORKDIR=$CLOSEDLOOP_WORKDIR. Read $CLOSEDLOOP_WORKDIR/judge-input.json first.
 Evaluate according to `task` and `source_of_truth` ordering.
-Treat the envelope's `primary_artifact` ($CLOSEDLOOP_WORKDIR/prd.md) as the authoritative Feature document.
+Treat the envelope's `primary_artifact` as the authoritative Feature document and load supporting descriptors as source-of-truth evidence.
 Apply your {judge_name} criteria to assess Feature quality.
 ```
 
@@ -1158,7 +1159,7 @@ Before marking this task complete, verify:
 
 **For code artifacts (--artifact-type code):**
 - [ ] **Context preparation** - context-manager-for-judges agent launched successfully
-- [ ] **Context validation** - code-context.json exists at `$CLOSEDLOOP_WORKDIR`
+- [ ] **Context validation** - canonical `.closedloop-ai/context/code-context.json` exists at `$CLOSEDLOOP_WORKDIR`, or root `code-context.json` fallback is explicitly used for an old run
 - [ ] **Judge input contract** - `judge-input.json` exists with required fields
 - [ ] **Investigation context resolution** - `investigation-log.md` reused or generated best-effort; missing file does not block code judging
 - [ ] **Preamble injection** - common_input_preamble.md + code_preamble.md prepended to all judge prompts
@@ -1171,7 +1172,7 @@ Before marking this task complete, verify:
 **For PRD artifacts (--artifact-type prd):**
 - [ ] **prd.md existence check** - `$CLOSEDLOOP_WORKDIR/prd.md` found, or graceful exit with WARNING (code 0)
 - [ ] **No context manager** - context-manager-for-judges is NOT launched for prd mode
-- [ ] **Judge input contract** - `judge-input.json` written with `evaluation_type="prd"` and `primary_artifact=$CLOSEDLOOP_WORKDIR/prd.md`
+- [ ] **Judge input contract** - `scripts/judge_input_mapping.py` wrote schema-valid `judge-input.json` with `evaluation_type="prd"` and `primary_artifact.id="primary_prd"`
 - [ ] **Parallel execution** - 5 PRD judges launched in 2 sequential batches: batch_1 (sub_step=1, 3 judges) and batch_2 (sub_step=2, 2 judges), max 4 concurrent per batch
 - [ ] **Result aggregation** - Valid EvaluationReport with 5 CaseScore entries (sub_step=3)
 - [ ] **File output** - `prd-judges.json` written to `$CLOSEDLOOP_WORKDIR`
@@ -1179,9 +1180,9 @@ Before marking this task complete, verify:
 - [ ] **Validation passed** - Script exits with code 0 using `--category prd` (sub_step=4)
 
 **For Feature artifacts (--artifact-type feature):**
-- [ ] **prd.md existence check** - `$CLOSEDLOOP_WORKDIR/prd.md` found, or emit sub_step=0 (skipped=true) perf event, emit WARNING, and graceful exit with WARNING (code 0)
+- [ ] **Feature input existence check** - `$CLOSEDLOOP_WORKDIR/feature.md` or legacy `$CLOSEDLOOP_WORKDIR/prd.md` found, or emit sub_step=0 (skipped=true) perf event, emit WARNING, and graceful exit with WARNING (code 0)
 - [ ] **No context manager** - context-manager-for-judges is NOT launched for feature mode
-- [ ] **Judge input contract** - `judge-input.json` written with `evaluation_type="feature"` and `primary_artifact=$CLOSEDLOOP_WORKDIR/prd.md`
+- [ ] **Judge input contract** - `scripts/judge_input_mapping.py` wrote schema-valid `judge-input.json` with `evaluation_type="feature"` and `primary_artifact.id="primary_feature"`
 - [ ] **Preamble** - feature_preamble.md used for all 3 feature judges (Feature-shaped contract; do NOT substitute prd_preamble.md)
 - [ ] **Parallel execution** - 3 feature judges launched in 1 batch (sub_step=1): feature-completeness-judge + prd-testability-judge + prd-dependency-judge
 - [ ] **Result aggregation** - Valid EvaluationReport with 3 CaseScore entries (sub_step=2)
@@ -1207,13 +1208,13 @@ Before marking this task complete, verify:
 | "report_id should end with '-code-judges'" | Incorrect ID format for code | Use pattern: `{RUN_ID}-code-judges` for code artifacts |
 | "Judge {name} has no metrics" | Empty metrics array | Each CaseScore must have ≥1 MetricStatistics entry |
 | "Context preparation failed" | context-manager-for-judges failed | Check context-manager agent output; verify artifact files exist |
-| "judge-input.json missing" | Orchestrator did not generate envelope | Build `$CLOSEDLOOP_WORKDIR/judge-input.json` before launching judges |
-| "judge-input schema invalid" | Missing required envelope fields | Ensure required fields: `evaluation_type`, `task`, `primary_artifact`, `supporting_artifacts`, `source_of_truth`, `fallback_mode`, `metadata` |
+| "judge-input.json missing" | Orchestrator did not generate envelope | Run `scripts/judge_input_mapping.py` before launching judges |
+| "judge-input schema invalid" | Missing required envelope fields | Re-run `scripts/judge_input_mapping.py`; it validates required fields: `evaluation_type`, `task`, `primary_artifact`, `supporting_artifacts`, `source_of_truth`, `fallback_mode`, `metadata` |
 | "plan-context.json not found" | plan context manager did not produce output | Run `@judges:context-manager-for-judges` with `artifact_type=plan`; if still missing, activate one-run compatibility fallback to `plan.json` + `prd.md` |
 | "Preamble file not found" | Missing common or artifact preamble .md file | Verify both `skills/artifact-type-tailored-context/preambles/common_input_preamble.md` and `skills/artifact-type-tailored-context/preambles/{artifact_type}_preamble.md` exist |
 | "pre-explorer unavailable" | `@code:pre-explorer` not installed/resolvable | Log warning and use internal fallback investigation to create `investigation-log.md` |
 | "investigation-log.md missing after fallback" | Both pre-explorer and internal fallback failed | Log warning and continue; do not block context preparation |
-| "investigation-log.md missing in code mode" | pre-explorer unavailable or generation failed during code preflight | Log warning and continue with `code-context.json` only (non-blocking) |
+| "investigation-log.md missing in code mode" | pre-explorer unavailable or generation failed during code preflight | Log warning and continue with `.closedloop-ai/context/code-context.json` only (non-blocking), using root `code-context.json` only as legacy fallback |
 | "Invalid --artifact-type value" | Unsupported artifact type | Use only 'plan', 'code', 'prd', or 'feature' |
 | "prd.md not found" | PRD document missing from workdir | Emit WARNING and exit gracefully (code 0); do not fail the parent workflow |
 | "report_id should end with '-prd-judges'" | Incorrect ID format for prd | Use pattern: `{RUN_ID}-prd-judges` for PRD artifacts |
@@ -1275,7 +1276,7 @@ This is the standard plan mode flow; orchestrators must support context-manager 
 When `--artifact-type prd` is specified:
 - Check `$CLOSEDLOOP_WORKDIR/prd.md` exists; emit WARNING and exit gracefully (code 0) if missing
 - Do NOT launch context-manager-for-judges
-- Build `judge-input.json` with `evaluation_type="prd"` and `primary_artifact=$CLOSEDLOOP_WORKDIR/prd.md`
+- Build and schema-validate `judge-input.json` with `scripts/judge_input_mapping.py --artifact-type prd`
 - Launch the 5 PRD judges in 2 sequential batches (sub_step=1: feature-completeness-judge + prd-auditor + prd-scope-judge; sub_step=2: prd-dependency-judge + prd-testability-judge) to respect the 4-concurrent-agent Task limit
 - Aggregate all 5 CaseScores (sub_step=3) and write to `prd-judges.json`
 - Validate with `--category prd` (sub_step=4)
@@ -1283,9 +1284,9 @@ When `--artifact-type prd` is specified:
 ### Feature Mode Execution Flow
 
 When `--artifact-type feature` is specified:
-- Check `$CLOSEDLOOP_WORKDIR/prd.md` exists; emit sub_step=0 (context_prep, skipped=true) perf event, emit WARNING, and exit gracefully (code 0) if missing
+- Check `$CLOSEDLOOP_WORKDIR/feature.md` exists, or legacy `$CLOSEDLOOP_WORKDIR/prd.md` exists; emit sub_step=0 (context_prep, skipped=true) perf event, emit WARNING, and exit gracefully (code 0) if both are missing
 - Do NOT launch context-manager-for-judges
-- Build `judge-input.json` with `evaluation_type="feature"` and `primary_artifact=$CLOSEDLOOP_WORKDIR/prd.md`
+- Build and schema-validate `judge-input.json` with `scripts/judge_input_mapping.py --artifact-type feature`
 - Use `feature_preamble.md` for all 3 feature judges (Feature-shaped contract; do NOT substitute `prd_preamble.md`)
 - Launch the 3 feature judges in 1 batch (sub_step=1: feature-completeness-judge + prd-testability-judge + prd-dependency-judge) to respect the 4-concurrent-agent Task limit
 - Aggregate all 3 CaseScores (sub_step=2) and write to `feature-judges.json`

--- a/plugins/judges/skills/run-judges/references/judge-input-contract.md
+++ b/plugins/judges/skills/run-judges/references/judge-input-contract.md
@@ -2,13 +2,20 @@
 
 This document defines the canonical contract for `$CLOSEDLOOP_WORKDIR/judge-input.json`.
 
-All judge runs (plan/code) must construct this envelope before launching judge agents.
+All judge runs (plan/code/prd/feature) must construct this envelope before launching judge agents.
 
 ## Required Path
 
 - Output file: `$CLOSEDLOOP_WORKDIR/judge-input.json`
-- Producer: orchestrator (for example, `run-judges`)
+- Producer: `run-judges`, via `skills/run-judges/scripts/judge_input_mapping.py`
 - Consumer: all judge agents
+
+## Runtime Path Contract
+
+- Primary artifacts live under `$CLOSEDLOOP_WORKDIR`; Code uses `$CLOSEDLOOP_WORKDIR/.closedloop-ai/context/code-context.json` as its primary artifact.
+- Supporting artifacts live under `$CLOSEDLOOP_WORKDIR/.closedloop-ai/context`.
+- Attachments live under `$CLOSEDLOOP_WORKDIR/.closedloop-ai/work/attachments`.
+- The producer validates the generated envelope against `schemas/judge-input.schema.json` before any judge agent is launched.
 
 ## Required Fields
 

--- a/plugins/judges/skills/run-judges/scripts/judge_input_mapping.py
+++ b/plugins/judges/skills/run-judges/scripts/judge_input_mapping.py
@@ -1,0 +1,653 @@
+#!/usr/bin/env python3
+"""Build and validate the run-judges judge-input envelope.
+
+The mapper is intentionally filesystem-driven: `run-judges --workdir <runDir>`
+is the only runtime root, primary artifacts live under that directory,
+supporting context lives under `.closedloop-ai/context`, and attachments live
+under `.closedloop-ai/work/attachments`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterable, Literal, Sequence
+
+EvaluationType = Literal["plan", "code", "prd", "feature"]
+
+CONTEXT_DIR = Path(".closedloop-ai/context")
+ATTACHMENTS_DIR = Path(".closedloop-ai/work/attachments")
+SCHEMA_RELATIVE_PATH = Path("plugins/judges/schemas/judge-input.schema.json")
+
+TASKS: dict[EvaluationType, str] = {
+    "plan": "Evaluate implementation plan quality against the configured plan judge criteria.",
+    "code": "Evaluate implementation code quality against the configured code judge criteria.",
+    "prd": "Evaluate PRD quality against the configured PRD judge criteria.",
+    "feature": "Evaluate Feature quality against the configured Feature judge criteria.",
+}
+
+PRIMARY_IDS: dict[EvaluationType, str] = {
+    "plan": "primary_plan",
+    "code": "primary_code_context",
+    "prd": "primary_prd",
+    "feature": "primary_feature",
+}
+
+PRIMARY_CANDIDATES: dict[EvaluationType, list[tuple[Path, bool]]] = {
+    "prd": [(Path("prd.md"), False)],
+    "feature": [(Path("feature.md"), False), (Path("prd.md"), True)],
+    "plan": [
+        (Path("plan.md"), False),
+        (Path("plan-context.json"), True),
+        (Path("plan.json"), True),
+    ],
+    "code": [
+        (CONTEXT_DIR / "code-context.json", False),
+        (Path("code-context.json"), True),
+    ],
+}
+
+CONTEXT_MANIFEST_NAMES = {
+    "artifacts.json",
+    "context-index.json",
+    "context-pack.json",
+    "supporting-artifacts.json",
+}
+
+SPECIAL_CONTEXT_FILES: dict[str, tuple[str, str]] = {
+    "prompt.md": ("prompt", "Prompt context"),
+    "prompt.txt": ("prompt", "Prompt context"),
+    "evaluation-prompt.md": ("prompt", "Prompt context"),
+    "user-prompt.md": ("prompt", "Prompt context"),
+    "repo-info.json": ("repo_metadata", "Repository metadata"),
+    "repo-metadata.json": ("repo_metadata", "Repository metadata"),
+    "repository.json": ("repo_metadata", "Repository metadata"),
+    "code-evaluation-context.json": (
+        "code_evaluation_context",
+        "Code evaluation metadata",
+    ),
+    "code-evaluation-context.md": (
+        "code_evaluation_context",
+        "Code evaluation metadata",
+    ),
+    "prior-loop-summaries.json": (
+        "prior_loop_summaries",
+        "Prior loop summaries",
+    ),
+    "prior-loop-summaries.md": (
+        "prior_loop_summaries",
+        "Prior loop summaries",
+    ),
+    "prior-summaries.json": ("prior_loop_summaries", "Prior loop summaries"),
+}
+
+
+@dataclass(frozen=True)
+class MappingResult:
+    """Result of selecting the primary artifact for an evaluation mode."""
+
+    path: Path
+    fallback_reason: str
+
+    @property
+    def uses_legacy_fallback(self) -> bool:
+        return bool(self.fallback_reason)
+
+
+class JudgeInputMappingError(ValueError):
+    """Raised when a schema-valid judge-input envelope cannot be produced."""
+
+
+def sanitize_descriptor_stem(raw: str) -> str:
+    """Convert arbitrary text to lowercase ASCII snake-case descriptor text."""
+
+    ascii_text = raw.encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^0-9A-Za-z]+", "_", ascii_text).strip("_").lower()
+    return slug or "item"
+
+
+def detect_artifact_type(path: Path) -> str:
+    """Infer the descriptor content type from a materialized filename."""
+
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return "json"
+    if suffix in {".md", ".markdown"}:
+        return "markdown"
+    if suffix in {".diff", ".patch"}:
+        return "diff"
+    if suffix in {".yaml", ".yml"}:
+        return "yaml"
+    return "text"
+
+
+def build_judge_input(
+    workdir: Path,
+    artifact_type: EvaluationType,
+    *,
+    run_id: str | None = None,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Build the judge-input envelope from the runtime workdir contract.
+
+    Args:
+        workdir: Runtime directory passed to `run-judges --workdir`.
+        artifact_type: Evaluation mode being judged.
+        run_id: Optional run identifier override. Defaults to the
+            `CLOSEDLOOP_RUN_ID` environment variable or the workdir name.
+        generated_at: Optional ISO-8601 timestamp override for deterministic
+            tests. Defaults to the current UTC timestamp.
+
+    Returns:
+        A schema-shaped judge-input dictionary with relative artifact paths.
+
+    Raises:
+        JudgeInputMappingError: If no primary artifact can be selected.
+    """
+
+    workdir = workdir.resolve()
+    primary = _select_primary_artifact(workdir, artifact_type)
+    primary_descriptor = _descriptor(
+        PRIMARY_IDS[artifact_type],
+        primary.path,
+        required=True,
+        description=_primary_description(artifact_type, primary.path),
+    )
+
+    used_ids = {primary_descriptor["id"]}
+    supporting_artifacts = _discover_supporting_artifacts(
+        workdir,
+        primary.path,
+        used_ids,
+    )
+
+    if primary.uses_legacy_fallback:
+        supporting_artifacts.extend(
+            _legacy_supporting_artifacts(workdir, artifact_type, primary.path, used_ids)
+        )
+
+    source_of_truth = [
+        primary_descriptor["id"],
+        *[artifact["id"] for artifact in supporting_artifacts],
+    ]
+    fallback_artifacts: list[str] = []
+    if primary.uses_legacy_fallback:
+        fallback_artifacts = [
+            primary_descriptor["id"],
+            *[artifact["id"] for artifact in supporting_artifacts],
+        ]
+
+    return {
+        "evaluation_type": artifact_type,
+        "task": TASKS[artifact_type],
+        "primary_artifact": primary_descriptor,
+        "supporting_artifacts": supporting_artifacts,
+        "source_of_truth": source_of_truth,
+        "fallback_mode": {
+            "active": primary.uses_legacy_fallback,
+            "reason": primary.fallback_reason,
+            "fallback_artifacts": fallback_artifacts,
+        },
+        "metadata": {
+            "run_id": run_id or os.environ.get("CLOSEDLOOP_RUN_ID") or workdir.name,
+            "generated_at": generated_at
+            or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        },
+    }
+
+
+def validate_judge_input(envelope: dict[str, Any], schema_path: Path) -> None:
+    """Validate an envelope against `judge-input.schema.json`.
+
+    The preferred path uses `jsonschema` when available from the active uv
+    environment. A small built-in validator covers this repository's schema so
+    the producer still enforces the checked-in contract if that optional package
+    is unavailable in a runtime shell.
+    """
+
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    try:
+        from jsonschema import Draft7Validator
+    except ImportError:
+        _validate_against_local_schema(envelope, schema)
+        return
+
+    errors = sorted(
+        Draft7Validator(schema).iter_errors(envelope),
+        key=lambda error: list(error.path),
+    )
+    if errors:
+        first = errors[0]
+        path = ".".join(str(part) for part in first.path) or "<root>"
+        raise JudgeInputMappingError(f"judge-input schema invalid at {path}: {first.message}")
+
+
+def write_judge_input(
+    workdir: Path,
+    artifact_type: EvaluationType,
+    schema_path: Path,
+    output_path: Path | None = None,
+) -> dict[str, Any]:
+    """Build, validate, and write `judge-input.json` for a run directory."""
+
+    envelope = build_judge_input(workdir, artifact_type)
+    validate_judge_input(envelope, schema_path)
+    output = output_path or workdir / "judge-input.json"
+    output.write_text(json.dumps(envelope, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return envelope
+
+
+def _select_primary_artifact(workdir: Path, artifact_type: EvaluationType) -> MappingResult:
+    for relative_path, is_legacy in PRIMARY_CANDIDATES[artifact_type]:
+        if (workdir / relative_path).is_file():
+            reason = (
+                f"Using legacy {relative_path.as_posix()} fallback because the "
+                "runtime contract primary artifact was not available."
+                if is_legacy
+                else ""
+            )
+            return MappingResult(relative_path, reason)
+
+    candidates = ", ".join(path.as_posix() for path, _ in PRIMARY_CANDIDATES[artifact_type])
+    raise JudgeInputMappingError(
+        f"No primary artifact found for {artifact_type}; expected one of: {candidates}"
+    )
+
+
+def _descriptor(
+    descriptor_id: str,
+    relative_path: Path,
+    *,
+    required: bool,
+    description: str,
+) -> dict[str, Any]:
+    return {
+        "id": descriptor_id,
+        "path": relative_path.as_posix(),
+        "type": detect_artifact_type(relative_path),
+        "required": required,
+        "description": description,
+    }
+
+
+def _primary_description(artifact_type: EvaluationType, path: Path) -> str:
+    descriptions = {
+        "prd": "Primary PRD artifact",
+        "feature": "Primary Feature artifact",
+        "plan": "Primary implementation plan artifact",
+        "code": "Primary code evaluation context",
+    }
+    return f"{descriptions[artifact_type]} ({path.as_posix()})"
+
+
+def _discover_supporting_artifacts(
+    workdir: Path,
+    primary_path: Path,
+    used_ids: set[str],
+) -> list[dict[str, Any]]:
+    context_dir = workdir / CONTEXT_DIR
+    attachments_dir = workdir / ATTACHMENTS_DIR
+    artifacts: list[dict[str, Any]] = []
+
+    context_files = _all_context_files(context_dir, workdir, primary_path)
+    manifest_order = _manifest_ordered_context_paths(context_dir, workdir)
+    direct_refs = _ordered_direct_refs(context_files, manifest_order)
+    special_files = _ordered_special_context_files(context_files)
+
+    family_slugs: dict[str, int] = {}
+    for index, relative_path in enumerate(direct_refs):
+        slug = _family_slug(relative_path, family_slugs)
+        descriptor_id = _ensure_unique_id(f"ref_{index:03d}_{slug}", used_ids)
+        artifacts.append(
+            _descriptor(
+                descriptor_id,
+                relative_path,
+                required=True,
+                description="Direct referenced context artifact",
+            )
+        )
+
+    for relative_path, descriptor_id, description in special_files:
+        artifacts.append(
+            _descriptor(
+                _ensure_unique_id(descriptor_id, used_ids),
+                relative_path,
+                required=True,
+                description=description,
+            )
+        )
+
+    attachment_slugs: dict[str, int] = {}
+    for index, relative_path in enumerate(_attachment_files(attachments_dir, workdir)):
+        slug = _family_slug(relative_path, attachment_slugs)
+        descriptor_id = _ensure_unique_id(f"attachment_{index:03d}_{slug}", used_ids)
+        artifacts.append(
+            _descriptor(
+                descriptor_id,
+                relative_path,
+                required=True,
+                description="Materialized attachment",
+            )
+        )
+
+    return artifacts
+
+
+def _legacy_supporting_artifacts(
+    workdir: Path,
+    artifact_type: EvaluationType,
+    primary_path: Path,
+    used_ids: set[str],
+) -> list[dict[str, Any]]:
+    artifacts: list[dict[str, Any]] = []
+    if artifact_type == "plan":
+        for candidate in (Path("prd.md"), Path("plan.md")):
+            if candidate == primary_path:
+                continue
+            if (workdir / candidate).is_file():
+                artifacts.append(
+                    _descriptor(
+                        _ensure_unique_id(
+                            f"ref_{len(artifacts):03d}_{sanitize_descriptor_stem(candidate.stem)}",
+                            used_ids,
+                        ),
+                        candidate,
+                        required=True,
+                        description="Legacy fallback artifact",
+                    )
+                )
+    return artifacts
+
+
+def _all_context_files(
+    context_dir: Path,
+    workdir: Path,
+    primary_path: Path,
+) -> list[Path]:
+    if not context_dir.is_dir():
+        return []
+
+    primary_abs = (workdir / primary_path).resolve()
+    skip_legacy_artifacts = _has_explicit_context_files(context_dir)
+    files: list[Path] = []
+    for path in context_dir.rglob("*"):
+        if not path.is_file() or path.name in CONTEXT_MANIFEST_NAMES:
+            continue
+        context_relative_path = path.relative_to(context_dir)
+        if skip_legacy_artifacts and _is_legacy_context_artifact(context_relative_path):
+            continue
+        if path.resolve() == primary_abs:
+            continue
+        files.append(path.relative_to(workdir))
+    return sorted(files, key=lambda path: path.as_posix())
+
+
+def _has_explicit_context_files(context_dir: Path) -> bool:
+    """Return true when FEA-585 explicit context should shadow legacy artifacts."""
+
+    supporting_artifacts_dir = context_dir / "supporting-artifacts"
+    return supporting_artifacts_dir.is_dir() and any(
+        path.is_file() for path in supporting_artifacts_dir.rglob("*")
+    )
+
+
+def _is_legacy_context_artifact(context_relative_path: Path) -> bool:
+    """Identify legacy pack.artifacts materializations under context/artifacts."""
+
+    return bool(context_relative_path.parts) and context_relative_path.parts[0] == "artifacts"
+
+
+def _manifest_ordered_context_paths(context_dir: Path, workdir: Path) -> list[Path]:
+    ordered: list[Path] = []
+    for manifest_name in sorted(CONTEXT_MANIFEST_NAMES):
+        manifest_path = context_dir / manifest_name
+        if not manifest_path.is_file():
+            continue
+        try:
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        ordered.extend(_extract_manifest_paths(payload, context_dir, workdir))
+    return _dedupe_existing_paths(ordered, workdir)
+
+
+def _extract_manifest_paths(payload: Any, context_dir: Path, workdir: Path) -> list[Path]:
+    if isinstance(payload, list):
+        return [_coerce_manifest_entry(item, context_dir, workdir) for item in payload]
+    if isinstance(payload, dict):
+        for key in (
+            "supportingArtifacts",
+            "referencedArtifacts",
+            "directReferences",
+            "artifacts",
+            "files",
+            "contextFiles",
+        ):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [_coerce_manifest_entry(item, context_dir, workdir) for item in value]
+    return []
+
+
+def _coerce_manifest_entry(item: Any, context_dir: Path, workdir: Path) -> Path:
+    raw = ""
+    if isinstance(item, str):
+        raw = item
+    elif isinstance(item, dict):
+        for key in (
+            "path",
+            "relativePath",
+            "materializedPath",
+            "localPath",
+            "file",
+            "filename",
+            "name",
+        ):
+            value = item.get(key)
+            if isinstance(value, str) and value:
+                raw = value
+                break
+    if not raw:
+        return Path()
+
+    path = Path(raw)
+    if path.is_absolute():
+        try:
+            return path.resolve().relative_to(workdir.resolve())
+        except ValueError:
+            return Path()
+    if path.parts[:2] == (".closedloop-ai", "context"):
+        return path
+    return CONTEXT_DIR / path
+
+
+def _dedupe_existing_paths(paths: Iterable[Path], workdir: Path) -> list[Path]:
+    seen: set[str] = set()
+    ordered: list[Path] = []
+    for path in paths:
+        if not path.parts:
+            continue
+        key = path.as_posix()
+        if key in seen or not (workdir / path).is_file():
+            continue
+        seen.add(key)
+        ordered.append(path)
+    return ordered
+
+
+def _ordered_direct_refs(
+    context_files: Sequence[Path],
+    manifest_order: Sequence[Path],
+) -> list[Path]:
+    context_set = set(context_files)
+    ordered: list[Path] = []
+    for path in manifest_order:
+        if path in context_set and not _special_descriptor_for(path):
+            ordered.append(path)
+    ordered_set = set(ordered)
+    for path in context_files:
+        if path not in ordered_set and not _special_descriptor_for(path):
+            ordered.append(path)
+    return ordered
+
+
+def _ordered_special_context_files(
+    context_files: Sequence[Path],
+) -> list[tuple[Path, str, str]]:
+    by_id: dict[str, list[tuple[Path, str]]] = {
+        "prompt": [],
+        "repo_metadata": [],
+        "code_evaluation_context": [],
+        "prior_loop_summaries": [],
+    }
+    for path in context_files:
+        special = _special_descriptor_for(path)
+        if special:
+            descriptor_id, description = special
+            by_id[descriptor_id].append((path, description))
+
+    ordered: list[tuple[Path, str, str]] = []
+    for descriptor_id in (
+        "prompt",
+        "repo_metadata",
+        "code_evaluation_context",
+        "prior_loop_summaries",
+    ):
+        for path, description in sorted(by_id[descriptor_id], key=lambda item: item[0].as_posix()):
+            ordered.append((path, descriptor_id, description))
+    return ordered
+
+
+def _special_descriptor_for(path: Path) -> tuple[str, str] | None:
+    return SPECIAL_CONTEXT_FILES.get(path.name)
+
+
+def _attachment_files(attachments_dir: Path, workdir: Path) -> list[Path]:
+    if not attachments_dir.is_dir():
+        return []
+    files = [
+        path.relative_to(workdir)
+        for path in attachments_dir.rglob("*")
+        if path.is_file()
+    ]
+    return sorted(files, key=lambda path: path.as_posix())
+
+
+def _family_slug(relative_path: Path, family_slugs: dict[str, int]) -> str:
+    stem = relative_path.stem or relative_path.name
+    slug = sanitize_descriptor_stem(stem)
+    count = family_slugs.get(slug, 0)
+    family_slugs[slug] = count + 1
+    if count == 0:
+        return slug
+    return f"{slug}_dup{count:03d}"
+
+
+def _ensure_unique_id(descriptor_id: str, used_ids: set[str]) -> str:
+    if descriptor_id not in used_ids:
+        used_ids.add(descriptor_id)
+        return descriptor_id
+
+    counter = 1
+    while True:
+        candidate = f"{descriptor_id}_dup{counter:03d}"
+        if candidate not in used_ids:
+            used_ids.add(candidate)
+            return candidate
+        counter += 1
+
+
+def _validate_against_local_schema(envelope: dict[str, Any], schema: dict[str, Any]) -> None:
+    required = schema.get("required", [])
+    missing = [field for field in required if field not in envelope]
+    if missing:
+        raise JudgeInputMappingError(f"judge-input schema invalid: missing {missing}")
+    if envelope.get("evaluation_type") not in {"plan", "code", "prd", "feature"}:
+        raise JudgeInputMappingError("judge-input schema invalid: invalid evaluation_type")
+    if not isinstance(envelope.get("supporting_artifacts"), list):
+        raise JudgeInputMappingError("judge-input schema invalid: supporting_artifacts must be an array")
+    if not isinstance(envelope.get("source_of_truth"), list) or not envelope["source_of_truth"]:
+        raise JudgeInputMappingError("judge-input schema invalid: source_of_truth must be a non-empty array")
+    _validate_descriptor(envelope.get("primary_artifact"), "primary_artifact")
+    for index, descriptor in enumerate(envelope.get("supporting_artifacts", [])):
+        _validate_descriptor(descriptor, f"supporting_artifacts[{index}]")
+    fallback_mode = envelope.get("fallback_mode")
+    if not isinstance(fallback_mode, dict):
+        raise JudgeInputMappingError("judge-input schema invalid: fallback_mode must be an object")
+    for field in ("active", "reason", "fallback_artifacts"):
+        if field not in fallback_mode:
+            raise JudgeInputMappingError(f"judge-input schema invalid: fallback_mode.{field} missing")
+    metadata = envelope.get("metadata")
+    if not isinstance(metadata, dict) or not metadata.get("run_id"):
+        raise JudgeInputMappingError("judge-input schema invalid: metadata.run_id missing")
+
+
+def _validate_descriptor(descriptor: Any, path: str) -> None:
+    if not isinstance(descriptor, dict):
+        raise JudgeInputMappingError(f"judge-input schema invalid: {path} must be an object")
+    for field in ("id", "path", "type", "required"):
+        if field not in descriptor:
+            raise JudgeInputMappingError(f"judge-input schema invalid: {path}.{field} missing")
+    for field in ("id", "path", "type"):
+        if not isinstance(descriptor[field], str) or not descriptor[field]:
+            raise JudgeInputMappingError(
+                f"judge-input schema invalid: {path}.{field} must be a non-empty string"
+            )
+    if not isinstance(descriptor["required"], bool):
+        raise JudgeInputMappingError(f"judge-input schema invalid: {path}.required must be boolean")
+
+
+def _default_schema_path(script_path: Path) -> Path:
+    for parent in script_path.resolve().parents:
+        candidate = parent / SCHEMA_RELATIVE_PATH
+        if candidate.is_file():
+            return candidate
+    return script_path.resolve().parents[3] / "schemas/judge-input.schema.json"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build run-judges judge-input.json")
+    parser.add_argument("--workdir", required=True, help="Runtime workdir passed to run-judges")
+    parser.add_argument(
+        "--artifact-type",
+        choices=("plan", "code", "prd", "feature"),
+        required=True,
+        help="Evaluation artifact type",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=_default_schema_path(Path(__file__)),
+        help="Path to judge-input.schema.json",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output path for judge-input.json (defaults to <workdir>/judge-input.json)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        write_judge_input(
+            Path(args.workdir),
+            args.artifact_type,
+            args.schema,
+            args.output,
+        )
+    except JudgeInputMappingError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+    except OSError as error:
+        print(f"ERROR: failed to write judge-input.json: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/judges/skills/run-judges/scripts/test_judge_agent_input_contract.py
+++ b/plugins/judges/skills/run-judges/scripts/test_judge_agent_input_contract.py
@@ -1,0 +1,96 @@
+"""Contract tests for PRD/Feature judge prompt input loading."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPT_DIR.parents[4]
+AGENTS_DIR = REPO_ROOT / "plugins/judges/agents"
+
+PRD_FEATURE_JUDGES = {
+    "feature-completeness-judge",
+    "prd-auditor",
+    "prd-dependency-judge",
+    "prd-scope-judge",
+    "prd-testability-judge",
+}
+
+LEGACY_EVIDENCE_TOKENS = (
+    "$CLOSEDLOOP_WORKDIR/prd.md",
+    "$CLOSEDLOOP_WORKDIR/plan.md",
+)
+
+LEGACY_FIRST_PATTERNS = (
+    re.compile(r"Read the (?:PRD|Feature) from `?\$CLOSEDLOOP_WORKDIR/prd\.md`?"),
+    re.compile(r"PRD to audit is located at `\$CLOSEDLOOP_WORKDIR/prd\.md`"),
+    re.compile(r"file named `prd\.md` or similar"),
+)
+
+
+def _agent_name(content: str) -> str:
+    match = re.search(r"^name:\s*(?P<name>[A-Za-z0-9_-]+)\s*$", content, re.MULTILINE)
+    return match.group("name") if match else ""
+
+
+def _prd_feature_agent_files() -> dict[str, Path]:
+    discovered: dict[str, Path] = {}
+    for path in AGENTS_DIR.glob("*.md"):
+        content = path.read_text(encoding="utf-8")
+        name = _agent_name(content)
+        if name in PRD_FEATURE_JUDGES:
+            discovered[name] = path
+    return discovered
+
+
+def test_discovers_all_prd_feature_judge_prompts() -> None:
+    discovered = _prd_feature_agent_files()
+    assert set(discovered) == PRD_FEATURE_JUDGES
+
+
+def test_prd_feature_judges_read_judge_input_before_legacy_paths() -> None:
+    for judge_name, path in _prd_feature_agent_files().items():
+        content = path.read_text(encoding="utf-8")
+        judge_input_index = content.find("judge-input.json")
+        assert judge_input_index != -1, f"{judge_name} must mention judge-input.json"
+
+        legacy_indexes = [
+            content.find(token)
+            for token in LEGACY_EVIDENCE_TOKENS
+            if content.find(token) != -1
+        ]
+        if legacy_indexes:
+            assert judge_input_index < min(legacy_indexes), (
+                f"{judge_name} presents a legacy path before judge-input.json"
+            )
+
+
+def test_prd_feature_judges_require_source_of_truth_ordering() -> None:
+    for judge_name, path in _prd_feature_agent_files().items():
+        content = path.read_text(encoding="utf-8")
+        assert "source_of_truth" in content, (
+            f"{judge_name} must instruct agents to load source_of_truth order"
+        )
+        assert "primary_artifact" in content, (
+            f"{judge_name} must use the mapped primary artifact"
+        )
+        assert "supporting_artifacts" in content, (
+            f"{judge_name} must treat supporting descriptors as evidence"
+        )
+
+
+def test_prd_feature_judges_limit_prd_plan_paths_to_absent_or_invalid_fallback() -> None:
+    for judge_name, path in _prd_feature_agent_files().items():
+        content = path.read_text(encoding="utf-8")
+        assert "absent or invalid" in content, (
+            f"{judge_name} must restrict legacy paths to absent-or-invalid fallback"
+        )
+        assert "legacy" in content.lower() and "fallback" in content.lower(), (
+            f"{judge_name} must describe legacy fallback semantics"
+        )
+        for pattern in LEGACY_FIRST_PATTERNS:
+            assert not pattern.search(content), (
+                f"{judge_name} still contains legacy-first evidence wording"
+            )

--- a/plugins/judges/skills/run-judges/scripts/test_judge_input_mapping.py
+++ b/plugins/judges/skills/run-judges/scripts/test_judge_input_mapping.py
@@ -1,0 +1,311 @@
+"""Tests for judge_input_mapping.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from judge_input_mapping import (  # type: ignore[import-not-found]
+    JudgeInputMappingError,
+    build_judge_input,
+    main,
+    sanitize_descriptor_stem,
+    validate_judge_input,
+)
+
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPT_DIR.parents[4]
+SCHEMA_PATH = REPO_ROOT / "plugins/judges/schemas/judge-input.schema.json"
+
+
+def _write(path: Path, content: str = "content") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _assert_schema_valid(envelope: dict) -> None:
+    validate_judge_input(envelope, SCHEMA_PATH)
+
+
+def _ids(envelope: dict) -> list[str]:
+    return [item["id"] for item in envelope["supporting_artifacts"]]
+
+
+def _paths(envelope: dict) -> list[str]:
+    return [item["path"] for item in envelope["supporting_artifacts"]]
+
+
+def _build(workdir: Path, artifact_type: str) -> dict:
+    return build_judge_input(
+        workdir,
+        artifact_type,  # type: ignore[arg-type]
+        run_id="run-test",
+        generated_at="2026-05-13T00:00:00Z",
+    )
+
+
+def test_sanitizes_descriptor_stems_to_lowercase_ascii_snake_case() -> None:
+    assert sanitize_descriptor_stem("Feature Ref.md") == "feature_ref_md"
+    assert sanitize_descriptor_stem("  ###  ") == "item"
+    assert sanitize_descriptor_stem("A+B/C") == "a_b_c"
+
+
+def test_prd_mapping_uses_runtime_contract_order_and_schema(tmp_path: Path) -> None:
+    _write(tmp_path / "prd.md", "# PRD")
+    context_dir = tmp_path / ".closedloop-ai/context"
+    _write(context_dir / "ref B.md", "# ref b")
+    _write(context_dir / "ref A.md", "# ref a")
+    _write(
+        context_dir / "supporting-artifacts.json",
+        json.dumps(
+            [
+                { "path": ".closedloop-ai/context/ref B.md" },
+                { "path": ".closedloop-ai/context/ref A.md" },
+            ]
+        ),
+    )
+    _write(context_dir / "prompt.md", "# prompt")
+    _write(context_dir / "repo-info.json", "{}")
+    _write(context_dir / "code-evaluation-context.json", "{}")
+    _write(context_dir / "prior-loop-summaries.json", "[]")
+    _write(tmp_path / ".closedloop-ai/work/attachments/zeta.txt", "z")
+    _write(tmp_path / ".closedloop-ai/work/attachments/alpha.txt", "a")
+
+    envelope = _build(tmp_path, "prd")
+
+    assert envelope["primary_artifact"]["id"] == "primary_prd"
+    assert envelope["primary_artifact"]["path"] == "prd.md"
+    assert _ids(envelope) == [
+        "ref_000_ref_b",
+        "ref_001_ref_a",
+        "prompt",
+        "repo_metadata",
+        "code_evaluation_context",
+        "prior_loop_summaries",
+        "attachment_000_alpha",
+        "attachment_001_zeta",
+    ]
+    assert _paths(envelope) == [
+        ".closedloop-ai/context/ref B.md",
+        ".closedloop-ai/context/ref A.md",
+        ".closedloop-ai/context/prompt.md",
+        ".closedloop-ai/context/repo-info.json",
+        ".closedloop-ai/context/code-evaluation-context.json",
+        ".closedloop-ai/context/prior-loop-summaries.json",
+        ".closedloop-ai/work/attachments/alpha.txt",
+        ".closedloop-ai/work/attachments/zeta.txt",
+    ]
+    assert envelope["source_of_truth"] == [
+        "primary_prd",
+        *_ids(envelope),
+    ]
+    assert envelope["fallback_mode"] == {
+        "active": False,
+        "reason": "",
+        "fallback_artifacts": [],
+    }
+    _assert_schema_valid(envelope)
+
+
+def test_feature_mapping_prefers_feature_primary_and_supporting_prd(tmp_path: Path) -> None:
+    _write(tmp_path / "feature.md", "# Feature")
+    _write(tmp_path / ".closedloop-ai/context/supporting-prd.md", "# PRD")
+
+    envelope = _build(tmp_path, "feature")
+
+    assert envelope["primary_artifact"]["id"] == "primary_feature"
+    assert envelope["primary_artifact"]["path"] == "feature.md"
+    assert _ids(envelope) == ["ref_000_supporting_prd"]
+    assert envelope["source_of_truth"] == ["primary_feature", "ref_000_supporting_prd"]
+    _assert_schema_valid(envelope)
+
+
+def test_plan_mapping_keeps_prompt_before_prior_summaries(tmp_path: Path) -> None:
+    _write(tmp_path / "plan.md", "# Plan")
+    _write(tmp_path / ".closedloop-ai/context/prompt.md", "# prompt")
+    _write(tmp_path / ".closedloop-ai/context/prior-loop-summaries.json", "[]")
+
+    envelope = _build(tmp_path, "plan")
+
+    assert envelope["primary_artifact"]["id"] == "primary_plan"
+    assert envelope["primary_artifact"]["path"] == "plan.md"
+    assert _ids(envelope) == ["prompt", "prior_loop_summaries"]
+    assert envelope["source_of_truth"] == [
+        "primary_plan",
+        "prompt",
+        "prior_loop_summaries",
+    ]
+    _assert_schema_valid(envelope)
+
+
+def test_code_mapping_uses_context_code_context_as_primary(tmp_path: Path) -> None:
+    _write(tmp_path / ".closedloop-ai/context/code-context.json", "{}")
+    _write(tmp_path / "code-context.json", '{"legacy": true}')
+    _write(tmp_path / ".closedloop-ai/context/direct-ref.md", "# direct")
+    _write(tmp_path / ".closedloop-ai/context/repo-metadata.json", "{}")
+    _write(tmp_path / ".closedloop-ai/context/code-evaluation-context.json", "{}")
+    _write(tmp_path / ".closedloop-ai/work/attachments/changes.patch", "diff")
+
+    envelope = _build(tmp_path, "code")
+
+    assert envelope["primary_artifact"]["id"] == "primary_code_context"
+    assert envelope["primary_artifact"]["path"] == ".closedloop-ai/context/code-context.json"
+    assert _ids(envelope) == [
+        "ref_000_direct_ref",
+        "repo_metadata",
+        "code_evaluation_context",
+        "attachment_000_changes",
+    ]
+    assert ".closedloop-ai/context/code-context.json" not in _paths(envelope)
+    assert envelope["fallback_mode"]["active"] is False
+    _assert_schema_valid(envelope)
+
+
+def test_code_mapping_uses_root_code_context_only_as_legacy_fallback(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "code-context.json", "{}")
+
+    envelope = _build(tmp_path, "code")
+
+    assert envelope["primary_artifact"]["id"] == "primary_code_context"
+    assert envelope["primary_artifact"]["path"] == "code-context.json"
+    assert envelope["supporting_artifacts"] == []
+    assert envelope["source_of_truth"] == ["primary_code_context"]
+    assert envelope["fallback_mode"]["active"] is True
+    assert envelope["fallback_mode"]["fallback_artifacts"] == ["primary_code_context"]
+    _assert_schema_valid(envelope)
+
+
+def test_explicit_supporting_artifacts_shadow_legacy_context_artifacts(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "prd.md", "# PRD")
+    _write(tmp_path / ".closedloop-ai/context/artifacts/prd-primary.md", "# legacy primary")
+    _write(tmp_path / ".closedloop-ai/context/artifacts/prd-ref-a.md", "# legacy ref")
+    _write(
+        tmp_path / ".closedloop-ai/context/supporting-artifacts/prd-ref-a.md",
+        "# explicit ref",
+    )
+    _write(tmp_path / ".closedloop-ai/context/prompt.md", "# prompt")
+
+    envelope = _build(tmp_path, "prd")
+
+    assert envelope["primary_artifact"]["id"] == "primary_prd"
+    assert _ids(envelope) == ["ref_000_prd_ref_a", "prompt"]
+    assert _paths(envelope) == [
+        ".closedloop-ai/context/supporting-artifacts/prd-ref-a.md",
+        ".closedloop-ai/context/prompt.md",
+    ]
+    assert not any("/artifacts/" in path for path in _paths(envelope))
+    assert envelope["source_of_truth"] == [
+        "primary_prd",
+        "ref_000_prd_ref_a",
+        "prompt",
+    ]
+    _assert_schema_valid(envelope)
+
+
+def test_duplicate_descriptor_suffixes_get_deterministic_dup_ordinals(tmp_path: Path) -> None:
+    _write(tmp_path / "prd.md", "# PRD")
+    _write(tmp_path / ".closedloop-ai/context/a b.md", "# one")
+    _write(tmp_path / ".closedloop-ai/context/a-b.md", "# two")
+    _write(tmp_path / ".closedloop-ai/work/attachments/log.txt", "one")
+    _write(tmp_path / ".closedloop-ai/work/attachments/nested/log.txt", "two")
+
+    envelope = _build(tmp_path, "prd")
+
+    assert _ids(envelope) == [
+        "ref_000_a_b",
+        "ref_001_a_b_dup001",
+        "attachment_000_log",
+        "attachment_001_log_dup001",
+    ]
+    assert envelope["source_of_truth"] == [
+        "primary_prd",
+        "ref_000_a_b",
+        "ref_001_a_b_dup001",
+        "attachment_000_log",
+        "attachment_001_log_dup001",
+    ]
+    _assert_schema_valid(envelope)
+
+
+def test_feature_legacy_prd_primary_is_schema_valid_fallback(tmp_path: Path) -> None:
+    _write(tmp_path / "prd.md", "# Legacy feature path")
+
+    envelope = _build(tmp_path, "feature")
+
+    assert envelope["primary_artifact"]["id"] == "primary_feature"
+    assert envelope["primary_artifact"]["path"] == "prd.md"
+    assert envelope["fallback_mode"]["active"] is True
+    assert envelope["fallback_mode"]["fallback_artifacts"] == ["primary_feature"]
+    assert envelope["source_of_truth"] == ["primary_feature"]
+    _assert_schema_valid(envelope)
+
+
+def test_plan_legacy_plan_json_fallback_includes_prd_when_present(tmp_path: Path) -> None:
+    _write(tmp_path / "plan.json", "{}")
+    _write(tmp_path / "prd.md", "# PRD")
+
+    envelope = _build(tmp_path, "plan")
+
+    assert envelope["primary_artifact"]["path"] == "plan.json"
+    assert envelope["fallback_mode"]["active"] is True
+    assert _ids(envelope) == ["ref_000_prd"]
+    assert envelope["source_of_truth"] == ["primary_plan", "ref_000_prd"]
+    assert envelope["fallback_mode"]["fallback_artifacts"] == [
+        "primary_plan",
+        "ref_000_prd",
+    ]
+    _assert_schema_valid(envelope)
+
+
+def test_missing_primary_artifact_fails_without_writing(tmp_path: Path) -> None:
+    with pytest.raises(JudgeInputMappingError, match="No primary artifact found"):
+        _build(tmp_path, "prd")
+
+    assert not (tmp_path / "judge-input.json").exists()
+
+
+def test_cli_writes_schema_valid_judge_input_json(tmp_path: Path) -> None:
+    _write(tmp_path / "prd.md", "# PRD")
+
+    result = main(
+        [
+            "--workdir",
+            str(tmp_path),
+            "--artifact-type",
+            "prd",
+            "--schema",
+            str(SCHEMA_PATH),
+        ]
+    )
+
+    assert result == 0
+    payload = json.loads((tmp_path / "judge-input.json").read_text(encoding="utf-8"))
+    assert payload["primary_artifact"]["id"] == "primary_prd"
+    _assert_schema_valid(payload)
+
+
+def test_descriptor_paths_resolve_inside_runtime_workdir(tmp_path: Path) -> None:
+    _write(tmp_path / "prd.md", "# PRD")
+    _write(tmp_path / ".closedloop-ai/context/ref.md", "# ref")
+    _write(tmp_path / ".closedloop-ai/work/attachments/file.txt", "file")
+
+    envelope = _build(tmp_path, "prd")
+
+    for descriptor in [
+        envelope["primary_artifact"],
+        *envelope["supporting_artifacts"],
+    ]:
+        resolved = (tmp_path / descriptor["path"]).resolve()
+        assert resolved.is_file()
+        assert resolved.is_relative_to(tmp_path.resolve())


### PR DESCRIPTION
## Summary

Implements the `claude-plugins` judge-input side of FEA-585 evaluation context parity.

- Adds deterministic `judge-input.json` mapping from runtime workdir paths.
- Validates generated judge input against the schema before judge launch.
- Treats `.closedloop-ai/context/code-context.json` as the canonical Code primary and root `code-context.json` as fallback-only.
- Ignores legacy `context/artifacts/**` duplicates when explicit FEA-585 supporting artifacts exist.
- Updates PRD/Feature judges and preambles to consume `source_of_truth` order first, with legacy fallback only when mapped input is absent or invalid.

## Companion PRs

- Symphony: https://github.com/closedloop-ai/symphony-alpha/pull/1158
- Desktop: https://github.com/closedloop-ai/closedloop-electron/pull/188

## Validation

- `rtk uv run pytest plugins/judges/skills/run-judges/scripts/test_judge_input_mapping.py plugins/judges/skills/run-judges/scripts/test_judge_agent_input_contract.py plugins/judges/skills/run-judges/scripts/test_validate_judge_report.py plugins/judges/tools/python/test_validate_agent_registry.py`
- `rtk uv run ruff check plugins/judges/skills/run-judges/scripts/judge_input_mapping.py plugins/judges/skills/run-judges/scripts/test_judge_input_mapping.py plugins/judges/skills/run-judges/scripts/test_judge_agent_input_contract.py`
- `rtk git diff --check`
