### PR TITLE
chore: CLAUDE.md learnings from PR review (week of 2026-05-14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,15 @@ All commits MUST follow the conventions in `CONTRIBUTING.md`. Specifically:
 ### Branching
 
 `feat/*`, `fix/*`, `docs/*`, `refactor/*` from `main`.
+
+## Learned Patterns
+
+### Testing
+- **[mistake]**: Extract test helpers (data factories, env setup, assertion helpers) into shared modules (`conftest.py`, `test_helpers.sh`) when used by 2+ test files — never inline logic that a helper already provides. (context: tests|duplication|helpers)
+- **[mistake]**: When adding a test alongside existing sibling tests, match their assertion coverage (cleanup checks, side-effect assertions) and env-var isolation (clear ambient env vars that could leak into assertions). (context: tests|isolation|assertions)
+
+### Code Quality
+- **[mistake]**: When modifying behavior, audit adjacent comments and docstrings for accuracy — remove or update references to non-existent files, incomplete field lists, or scope descriptions narrower than actual behavior. (context: comments|docstrings|accuracy)
+
+### Documentation & Versioning
+- **[mistake]**: Never reference code, APIs, or schema fields that don't exist in the codebase or documented spec. Before writing CHANGELOG "Fixed" or "Replaces" entries, verify the prior implementation exists via grep. Before adding manifest fields, verify they're in the documented schema. (context: changelog|hallucination|verification)


### PR DESCRIPTION
## Summary
Automated analysis of 30 PRs merged 2026-04-30–2026-05-14.
Processed 52 review comments (52 human, 0 bot).
Identified 4 recurring failure modes.

## Feature Flags
None — documentation-only change.

## New Patterns

### CLAUDE.md — ### Testing
- **[mistake]**: Extract test helpers (data factories, env setup, assertion helpers) into shared modules (`conftest.py`, `test_helpers.sh`) when used by 2+ test files — never inline logic that a helper already provides.
  - PR #62 (mikeangstadt): "`_base_data` duplicates `make_minimal_data` from `test_validate_plan_sync.py` (>60% structural overlap)"
  - PR #62 (mikeangstadt): "`_base_data` duplicates `make_minimal_data` from conftest.py"
  - PR #69 (shafty023): "Agent-type file recreation inlined in 3 tests instead of calling `_recreate_agent_type_file`"
  - PR #70 (mikeangstadt): "Test helper duplication (~150 lines) — `setup_temp_env`, `pass`/`fail`, `create_sentinel`, `assert_field_equals` copy-pasted across 4-5 test files"

- **[mistake]**: When adding a test alongside existing sibling tests, match their assertion coverage (cleanup checks, side-effect assertions) and env-var isolation (clear ambient env vars that could leak into assertions).
  - PR #81 (mikeangstadt): "Ambient `CLOSEDLOOP_COMMAND` leaks into this assertion... The companion file explicitly passes `env={\"CLOSEDLOOP_COMMAND\": \"\", ...}` — same fix should be applied here."
  - PR #85 (mikeangstadt): "test_handle_claude_terminal_failure_writes_unknown_skill_marker omits cleanup assertions present in parallel tests"

### CLAUDE.md — ### Code Quality
- **[mistake]**: When modifying behavior, audit adjacent comments and docstrings for accuracy — remove or update references to non-existent files, incomplete field lists, or scope descriptions narrower than actual behavior.
  - PR #58 (aponamarev): "Stale comment references non-existent `workflow.json`"
  - PR #62 (mikeangstadt): "Misleading comment says 'A-### lines' but `needs_check` covers all unchecked migrations"
  - PR #69 (shafty023): "Schema comment says 'Token/model fields' but `command` field is also PERF_V2-only"

### CLAUDE.md — ### Documentation & Versioning
- **[mistake]**: Never reference code, APIs, or schema fields that don't exist in the codebase or documented spec. Before writing CHANGELOG "Fixed" or "Replaces" entries, verify the prior implementation exists via grep. Before adding manifest fields, verify they're in the documented schema.
  - PR #69 (shafty023): "Is this hallucinated? i'm not finding this in any docs nor is this set to a valid version" (re: `claudeCodeMinimumVersion` manifest field)
  - PR #87 (mikeangstadt): "CHANGELOG 'Added' entry fabricates a prior implementation that `compute_average_excluding_errors` replaces"
  - PR #87 (mikeangstadt): "CHANGELOG 'Fixed' entry describes a non-existent bug in `compute_average_excluding_errors`"

## Deduplicated (already covered)
- "CHANGELOG manual edits / convention violations" — already in CLAUDE.md: "Do NOT manually edit CHANGELOG.md or README.md. After all code changes are finalized, run /update-documentation to generate documentation updates."
  - PR #54 (shafty023), PR #85 (mikeangstadt), PR #86 (mikeangstadt)
- "Version bump missing for affected plugin" — already in CLAUDE.md: "Any change to a plugin's files MUST include a version bump in that plugin's plugin.json."
  - PR #69 (shafty023)

## Stats
- PRs analyzed: 30
- Comments processed: 52 (52 human, 0 bot)
- New patterns: 4
- Amended patterns: 0
- Deduplicated: 2