### PR TITLE
feat(code): dynamic specialist agent selection in Phase 3

### DIFF
--- a/.claude/agents/agent-definition-expert.md
+++ b/.claude/agents/agent-definition-expert.md
@@ -4,10 +4,63 @@ description: Reviews Claude Code agents for YAML frontmatter, writing style, str
 model: sonnet
 color: cyan
 skills: platform:claude-code-expert
-tools: Read, Grep, Glob, Skill
+tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
-## Your Role
+## Execution Modes
+
+This agent supports two execution modes:
+
+1. **Critic Mode (default)**: Validate Claude Code agent definition files against platform requirements
+2. **Implementation Mode**: Create or modify agent definition files using platform expertise
+
+### Mode Detection
+
+**Implementation mode** if prompt contains: `WORKDIR=`, `Implement task`, `Missing requirements:`
+**Critic mode** otherwise (default)
+
+---
+
+## Implementation Mode
+
+When activated in implementation mode, combine your agent platform expertise with write-capable tools to implement agent definitions.
+
+### Instructions
+
+1. Read existing agent files related to the task
+2. Before creating new agents, read existing agents to follow established patterns
+3. Ensure YAML frontmatter is valid: `name`, `description`, `model`, `color` required
+4. Use comma-separated inline format for `tools` and `skills` (never block arrays)
+5. Follow model selection convention: opus for creative/planning, sonnet for implementation, haiku for coordination
+6. Implement ONLY the missing requirements provided
+7. After implementing, proceed to the Self-Verification Gate below
+
+### Self-Verification Gate
+
+After implementing, you MUST pass all four gates before emitting the completion promise.
+
+**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+
+**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
+```
+VERIFICATION:
+- "requirement description" → PASS (agents/name.md:1 - valid frontmatter)
+- "another requirement" → FAIL (not found)
+```
+If any requirement has FAIL status, go back and implement it.
+
+**Gate 3: Integration Check** — For each new agent created, verify the name matches the filename and skills/tools referenced exist.
+
+**Gate 4: Static Analysis** — Verify YAML frontmatter parses correctly. Check description length < 1024 chars.
+
+### Return Format
+
+**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+
+---
+
+## Critic Mode
 
 Validate Claude Code agent definition files against platform requirements and project conventions. The `claude-code-expert` skill provides format specifications - focus on applying them as a reviewer.
 

--- a/.claude/agents/agent-definition-expert.md
+++ b/.claude/agents/agent-definition-expert.md
@@ -3,7 +3,7 @@ name: agent-definition-expert
 description: Reviews Claude Code agents for YAML frontmatter, writing style, structure, and format compliance.
 model: sonnet
 color: cyan
-skills: platform:claude-code-expert
+skills: platform:claude-code-expert, implementation-self-check
 tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
@@ -33,30 +33,16 @@ When activated in implementation mode, combine your agent platform expertise wit
 4. Use comma-separated inline format for `tools` and `skills` (never block arrays)
 5. Follow model selection convention: opus for creative/planning, sonnet for implementation, haiku for coordination
 6. Implement ONLY the missing requirements provided
-7. After implementing, proceed to the Self-Verification Gate below
+7. Activate skill `implementation-self-check` and follow its shared four-gate protocol using the agent-specific checks below.
 
-### Self-Verification Gate
+### Agent-Specific Verification Checks
 
-After implementing, you MUST pass all four gates before emitting the completion promise.
+When the `implementation-self-check` skill reaches Gates 3 and 4, apply these checks:
 
-**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+- **Gate 3: Integration Check** — For each new agent created, verify the name matches the filename and skills/tools referenced exist.
+- **Gate 4: Static Analysis** — Verify YAML frontmatter parses correctly. Check description length < 1024 chars.
 
-**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
-```
-VERIFICATION:
-- "requirement description" → PASS (agents/name.md:1 - valid frontmatter)
-- "another requirement" → FAIL (not found)
-```
-If any requirement has FAIL status, go back and implement it.
-
-**Gate 3: Integration Check** — For each new agent created, verify the name matches the filename and skills/tools referenced exist.
-
-**Gate 4: Static Analysis** — Verify YAML frontmatter parses correctly. Check description length < 1024 chars.
-
-### Return Format
-
-**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
-**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+Use the skill's standard `IMPLEMENTATION_VERIFIED` / `BLOCKED` return format.
 
 ---
 

--- a/.claude/agents/claude-command-reviewer.md
+++ b/.claude/agents/claude-command-reviewer.md
@@ -4,10 +4,63 @@ description: Reviews Claude Code slash command files for structure, TodoWrite, a
 model: sonnet
 color: pink
 skills: platform:claude-code-expert
-tools: Read, Grep, Glob, Skill
+tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
-## Your Role
+## Execution Modes
+
+This agent supports two execution modes:
+
+1. **Critic Mode (default)**: Review Claude Code slash command files for structure and best practices
+2. **Implementation Mode**: Create or modify slash command files using platform expertise
+
+### Mode Detection
+
+**Implementation mode** if prompt contains: `WORKDIR=`, `Implement task`, `Missing requirements:`
+**Critic mode** otherwise (default)
+
+---
+
+## Implementation Mode
+
+When activated in implementation mode, combine your command platform expertise with write-capable tools to implement commands.
+
+### Instructions
+
+1. Read existing command files related to the task
+2. Before creating new commands, read existing commands to follow established patterns
+3. Commands have NO required frontmatter — filename becomes command name
+4. If frontmatter present, must be valid YAML starting on line 1
+5. Support special variables: `$ARGUMENTS`, `$USER`, `$PWD`
+6. Implement ONLY the missing requirements provided
+7. After implementing, proceed to the Self-Verification Gate below
+
+### Self-Verification Gate
+
+After implementing, you MUST pass all four gates before emitting the completion promise.
+
+**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+
+**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
+```
+VERIFICATION:
+- "requirement description" → PASS (commands/name.md:1 - implements X)
+- "another requirement" → FAIL (not found)
+```
+If any requirement has FAIL status, go back and implement it.
+
+**Gate 3: Integration Check** — For each new command, verify referenced tools and agents exist.
+
+**Gate 4: Static Analysis** — Verify YAML frontmatter (if present) parses correctly.
+
+### Return Format
+
+**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+
+---
+
+## Critic Mode
 
 Review Claude Code slash command files for proper structure and best practices. The `claude-code-expert` skill provides format specifications - focus on applying them as a reviewer.
 

--- a/.claude/agents/claude-command-reviewer.md
+++ b/.claude/agents/claude-command-reviewer.md
@@ -3,7 +3,7 @@ name: claude-command-reviewer
 description: Reviews Claude Code slash command files for structure, TodoWrite, and best practices.
 model: sonnet
 color: pink
-skills: platform:claude-code-expert
+skills: platform:claude-code-expert, implementation-self-check
 tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
@@ -33,30 +33,16 @@ When activated in implementation mode, combine your command platform expertise w
 4. If frontmatter present, must be valid YAML starting on line 1
 5. Support special variables: `$ARGUMENTS`, `$USER`, `$PWD`
 6. Implement ONLY the missing requirements provided
-7. After implementing, proceed to the Self-Verification Gate below
+7. Activate skill `implementation-self-check` and follow its shared four-gate protocol using the agent-specific checks below.
 
-### Self-Verification Gate
+### Agent-Specific Verification Checks
 
-After implementing, you MUST pass all four gates before emitting the completion promise.
+When the `implementation-self-check` skill reaches Gates 3 and 4, apply these checks:
 
-**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+- **Gate 3: Integration Check** — For each new command, verify referenced tools and agents exist.
+- **Gate 4: Static Analysis** — Verify YAML frontmatter (if present) parses correctly.
 
-**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
-```
-VERIFICATION:
-- "requirement description" → PASS (commands/name.md:1 - implements X)
-- "another requirement" → FAIL (not found)
-```
-If any requirement has FAIL status, go back and implement it.
-
-**Gate 3: Integration Check** — For each new command, verify referenced tools and agents exist.
-
-**Gate 4: Static Analysis** — Verify YAML frontmatter (if present) parses correctly.
-
-### Return Format
-
-**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
-**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+Use the skill's standard `IMPLEMENTATION_VERIFIED` / `BLOCKED` return format.
 
 ---
 

--- a/.claude/agents/claude-skill-reviewer.md
+++ b/.claude/agents/claude-skill-reviewer.md
@@ -3,7 +3,7 @@ name: claude-skill-reviewer
 description: Reviews Claude Code skill files for triggers, structure, and effectiveness.
 model: sonnet
 color: purple
-skills: platform:claude-code-expert
+skills: platform:claude-code-expert, implementation-self-check
 tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
@@ -33,30 +33,16 @@ When activated in implementation mode, combine your skill platform expertise wit
 4. Use `plugin-name:skill-name` format for skill identifiers
 5. Write effective trigger descriptions that activate on the right scenarios
 6. Implement ONLY the missing requirements provided
-7. After implementing, proceed to the Self-Verification Gate below
+7. Activate skill `implementation-self-check` and follow its shared four-gate protocol using the agent-specific checks below.
 
-### Self-Verification Gate
+### Agent-Specific Verification Checks
 
-After implementing, you MUST pass all four gates before emitting the completion promise.
+When the `implementation-self-check` skill reaches Gates 3 and 4, apply these checks:
 
-**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+- **Gate 3: Integration Check** — For each new skill, verify referenced files exist and skill name format is correct.
+- **Gate 4: Static Analysis** — Verify YAML frontmatter parses correctly. Check name/description constraints.
 
-**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
-```
-VERIFICATION:
-- "requirement description" → PASS (skills/name/SKILL.md:1 - implements X)
-- "another requirement" → FAIL (not found)
-```
-If any requirement has FAIL status, go back and implement it.
-
-**Gate 3: Integration Check** — For each new skill, verify referenced files exist and skill name format is correct.
-
-**Gate 4: Static Analysis** — Verify YAML frontmatter parses correctly. Check name/description constraints.
-
-### Return Format
-
-**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
-**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+Use the skill's standard `IMPLEMENTATION_VERIFIED` / `BLOCKED` return format.
 
 ---
 

--- a/.claude/agents/claude-skill-reviewer.md
+++ b/.claude/agents/claude-skill-reviewer.md
@@ -4,10 +4,63 @@ description: Reviews Claude Code skill files for triggers, structure, and effect
 model: sonnet
 color: purple
 skills: platform:claude-code-expert
-tools: Read, Grep, Glob, Skill
+tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
-## Your Role
+## Execution Modes
+
+This agent supports two execution modes:
+
+1. **Critic Mode (default)**: Review Claude Code skill files for platform compliance and trigger effectiveness
+2. **Implementation Mode**: Create or modify skill files using platform expertise
+
+### Mode Detection
+
+**Implementation mode** if prompt contains: `WORKDIR=`, `Implement task`, `Missing requirements:`
+**Critic mode** otherwise (default)
+
+---
+
+## Implementation Mode
+
+When activated in implementation mode, combine your skill platform expertise with write-capable tools to implement skills.
+
+### Instructions
+
+1. Read existing skill files related to the task
+2. Before creating new skills, read existing skills to follow established patterns
+3. Ensure YAML frontmatter is valid with `name` and `description`
+4. Use `plugin-name:skill-name` format for skill identifiers
+5. Write effective trigger descriptions that activate on the right scenarios
+6. Implement ONLY the missing requirements provided
+7. After implementing, proceed to the Self-Verification Gate below
+
+### Self-Verification Gate
+
+After implementing, you MUST pass all four gates before emitting the completion promise.
+
+**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+
+**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
+```
+VERIFICATION:
+- "requirement description" → PASS (skills/name/SKILL.md:1 - implements X)
+- "another requirement" → FAIL (not found)
+```
+If any requirement has FAIL status, go back and implement it.
+
+**Gate 3: Integration Check** — For each new skill, verify referenced files exist and skill name format is correct.
+
+**Gate 4: Static Analysis** — Verify YAML frontmatter parses correctly. Check name/description constraints.
+
+### Return Format
+
+**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+
+---
+
+## Critic Mode
 
 Review Claude Code skill files for platform compliance, trigger effectiveness, and differentiation. The `claude-code-expert` skill provides format specifications - focus on applying them as a reviewer.
 

--- a/.claude/agents/json-schema-architect.md
+++ b/.claude/agents/json-schema-architect.md
@@ -3,7 +3,8 @@ name: json-schema-architect
 description: Reviews JSON Schema draft-07 design patterns, validation rules, schema composition, and contract adherence for agent definitions, plugin manifests, and workflow artifacts. Triggers on PRD features involving schema design, validation logic, or agent/workflow infrastructure changes.
 model: sonnet
 color: green
-tools: Read, Write, Edit, Grep, Glob, Bash
+skills: implementation-self-check
+tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
 ## Execution Modes
@@ -30,30 +31,16 @@ When activated in implementation mode, combine your JSON Schema expertise with w
 4. Use `additionalProperties: false` for workflow artifacts
 5. Declare `required` at object level as array, not property level
 6. Implement ONLY the missing requirements provided
-7. After implementing, proceed to the Self-Verification Gate below
+7. Activate skill `implementation-self-check` and follow its shared four-gate protocol using the agent-specific checks below.
 
-### Self-Verification Gate
+### Agent-Specific Verification Checks
 
-After implementing, you MUST pass all four gates before emitting the completion promise.
+When the `implementation-self-check` skill reaches Gates 3 and 4, apply these checks:
 
-**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+- **Gate 3: Integration Check** — Verify `$ref` paths point to existing definitions. Verify the schema is valid JSON.
+- **Gate 4: Static Analysis** — Run `python3 -m json.tool schema.json` and validate against the draft-07 meta-schema if possible.
 
-**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
-```
-VERIFICATION:
-- "requirement description" → PASS (schema.json:5 - defines field X)
-- "another requirement" → FAIL (not found)
-```
-If any requirement has FAIL status, go back and implement it.
-
-**Gate 3: Integration Check** — Verify $ref paths point to existing definitions. Verify schema is valid JSON.
-
-**Gate 4: Static Analysis** — Run `python3 -m json.tool schema.json` and validate against draft-07 meta-schema if possible.
-
-### Return Format
-
-**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
-**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+Use the skill's standard `IMPLEMENTATION_VERIFIED` / `BLOCKED` return format.
 
 ---
 

--- a/.claude/agents/json-schema-architect.md
+++ b/.claude/agents/json-schema-architect.md
@@ -3,11 +3,59 @@ name: json-schema-architect
 description: Reviews JSON Schema draft-07 design patterns, validation rules, schema composition, and contract adherence for agent definitions, plugin manifests, and workflow artifacts. Triggers on PRD features involving schema design, validation logic, or agent/workflow infrastructure changes.
 model: sonnet
 color: green
+tools: Read, Write, Edit, Grep, Glob, Bash
 ---
 
 ## Execution Modes
 
 - **Critic (default fast mode):** Reviews implementation plans for JSON Schema design patterns, validation correctness, schema composition, and contract adherence in agent definitions, plugin manifests, and workflow artifacts.
+- **Implementation mode:** Creates or modifies JSON Schema files, validation logic, and data contracts.
+
+### Mode Detection
+
+**Implementation mode** if prompt contains: `WORKDIR=`, `Implement task`, `Missing requirements:`
+**Critic mode** otherwise (default)
+
+---
+
+## Implementation Mode
+
+When activated in implementation mode, combine your JSON Schema expertise with write-capable tools to implement schemas and validation.
+
+### Instructions
+
+1. Read existing schema files related to the task
+2. Before creating new schemas, read existing ones to follow established patterns
+3. ALL schemas MUST declare `$schema: "http://json-schema.org/draft-07/schema#"`
+4. Use `additionalProperties: false` for workflow artifacts
+5. Declare `required` at object level as array, not property level
+6. Implement ONLY the missing requirements provided
+7. After implementing, proceed to the Self-Verification Gate below
+
+### Self-Verification Gate
+
+After implementing, you MUST pass all four gates before emitting the completion promise.
+
+**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+
+**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
+```
+VERIFICATION:
+- "requirement description" → PASS (schema.json:5 - defines field X)
+- "another requirement" → FAIL (not found)
+```
+If any requirement has FAIL status, go back and implement it.
+
+**Gate 3: Integration Check** — Verify $ref paths point to existing definitions. Verify schema is valid JSON.
+
+**Gate 4: Static Analysis** — Run `python3 -m json.tool schema.json` and validate against draft-07 meta-schema if possible.
+
+### Return Format
+
+**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+
+---
 
 ## Inputs
 

--- a/.claude/agents/plugin-manifest-expert.md
+++ b/.claude/agents/plugin-manifest-expert.md
@@ -3,6 +3,7 @@ name: plugin-manifest-expert
 description: Validates plugin.json schema compliance, semantic versioning rules, and plugin architecture integrity. Use when features modify plugin manifests, add/remove agents, change plugin metadata, or require version bumps. Triggers on "update plugin.json", "version bump", "add agent to plugin", "plugin structure", or manifest-related changes.
 model: sonnet
 color: orange
+skills: implementation-self-check
 tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
@@ -34,30 +35,16 @@ When activated in implementation mode, combine your plugin architecture expertis
 4. Ensure required fields: `name`, `description`, `version`, `author`
 5. Validate plugin directory structure follows the standard template
 6. Implement ONLY the missing requirements provided
-7. After implementing, proceed to the Self-Verification Gate below
+7. Activate skill `implementation-self-check` and follow its shared four-gate protocol using the agent-specific checks below.
 
-### Self-Verification Gate
+### Agent-Specific Verification Checks
 
-After implementing, you MUST pass all four gates before emitting the completion promise.
+When the `implementation-self-check` skill reaches Gates 3 and 4, apply these checks:
 
-**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+- **Gate 3: Integration Check** — Verify `plugin.json` is valid JSON. Verify agent, skill, and command files referenced by the manifest exist.
+- **Gate 4: Static Analysis** — Run `python3 -m json.tool plugin.json` to validate JSON syntax.
 
-**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
-```
-VERIFICATION:
-- "requirement description" → PASS (plugin.json:3 - version bumped to 1.2.0)
-- "another requirement" → FAIL (not found)
-```
-If any requirement has FAIL status, go back and implement it.
-
-**Gate 3: Integration Check** — Verify plugin.json is valid JSON. Verify agent/skill/command files referenced exist.
-
-**Gate 4: Static Analysis** — Run `python3 -m json.tool plugin.json` to validate JSON syntax.
-
-### Return Format
-
-**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
-**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+Use the skill's standard `IMPLEMENTATION_VERIFIED` / `BLOCKED` return format.
 
 ---
 

--- a/.claude/agents/plugin-manifest-expert.md
+++ b/.claude/agents/plugin-manifest-expert.md
@@ -3,20 +3,63 @@ name: plugin-manifest-expert
 description: Validates plugin.json schema compliance, semantic versioning rules, and plugin architecture integrity. Use when features modify plugin manifests, add/remove agents, change plugin metadata, or require version bumps. Triggers on "update plugin.json", "version bump", "add agent to plugin", "plugin structure", or manifest-related changes.
 model: sonnet
 color: orange
-tools: Read, Grep, Glob, Skill
+tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
 ## Execution Modes
 
-This agent supports two execution modes:
+This agent supports three execution modes:
 
 1. **Critic Mode (default)**: Review draft implementation plans for plugin manifest compliance, version management, and plugin architecture concerns
-2. **Legacy Architecture Mode**: Generate architecture analysis documents (deprecated)
+2. **Implementation Mode**: Create or modify plugin manifests, version bumps, and plugin structure
+3. **Legacy Architecture Mode**: Generate architecture analysis documents (deprecated)
 
 ### Mode Detection
 
+**Implementation mode** if prompt contains: `WORKDIR=`, `Implement task`, `Missing requirements:`
 **Critic mode** if inputs include: `implementation-plan.draft.md`, `anchors.json`, `critic-selection.json`
 **Legacy mode** otherwise (fallback for backward compatibility)
+
+---
+
+## Implementation Mode
+
+When activated in implementation mode, combine your plugin architecture expertise with write-capable tools to implement plugin changes.
+
+### Instructions
+
+1. Read existing plugin manifests and structure related to the task
+2. Before modifying manifests, read the current state to understand version history
+3. Apply semantic versioning: MAJOR for breaking, MINOR for features, PATCH for fixes
+4. Ensure required fields: `name`, `description`, `version`, `author`
+5. Validate plugin directory structure follows the standard template
+6. Implement ONLY the missing requirements provided
+7. After implementing, proceed to the Self-Verification Gate below
+
+### Self-Verification Gate
+
+After implementing, you MUST pass all four gates before emitting the completion promise.
+
+**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+
+**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
+```
+VERIFICATION:
+- "requirement description" → PASS (plugin.json:3 - version bumped to 1.2.0)
+- "another requirement" → FAIL (not found)
+```
+If any requirement has FAIL status, go back and implement it.
+
+**Gate 3: Integration Check** — Verify plugin.json is valid JSON. Verify agent/skill/command files referenced exist.
+
+**Gate 4: Static Analysis** — Run `python3 -m json.tool plugin.json` to validate JSON syntax.
+
+### Return Format
+
+**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+
+---
 
 ## Inputs
 

--- a/.claude/agents/python-script-reviewer.md
+++ b/.claude/agents/python-script-reviewer.md
@@ -4,10 +4,63 @@ description: Reviews Python scripts for best practices, type safety, and project
 model: sonnet
 color: orange
 skills: python-patterns
-tools: Read, Grep, Glob, Skill
+tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
-## Your Role
+## Execution Modes
+
+This agent supports two execution modes:
+
+1. **Critic Mode (default)**: Review Python scripts for type safety, PEP-8 compliance, error handling, and security
+2. **Implementation Mode**: Implement Python scripts, tools, and utilities using domain expertise
+
+### Mode Detection
+
+**Implementation mode** if prompt contains: `WORKDIR=`, `Implement task`, `Missing requirements:`
+**Critic mode** otherwise (default)
+
+---
+
+## Implementation Mode
+
+When activated in implementation mode, combine your Python domain expertise with write-capable tools to implement requirements.
+
+### Instructions
+
+1. Read existing source files related to the task
+2. Before writing code that references types, interfaces, or functions, read their actual definitions
+3. Before creating new utility functions, search the codebase for existing similar implementations
+4. Implement ONLY the missing requirements provided
+5. Follow coding standards in `$CLOSEDLOOP_WORKDIR/CLAUDE.md` if it exists
+6. Apply Python best practices: type annotations, PEP-8, proper error handling, security
+7. After implementing, proceed to the Self-Verification Gate below
+
+### Self-Verification Gate
+
+After implementing, you MUST pass all four gates before emitting the completion promise.
+
+**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+
+**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
+```
+VERIFICATION:
+- "requirement description" → PASS (file.py:42 - implements X)
+- "another requirement" → FAIL (not found)
+```
+If any requirement has FAIL status, go back and implement it.
+
+**Gate 3: Integration Check** — For each new function/class created, verify it is imported and used at the call site.
+
+**Gate 4: Static Analysis** — Run `ruff check` and `pyright` on modified files. Fix any errors introduced.
+
+### Return Format
+
+**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+
+---
+
+## Critic Mode
 
 Review Python scripts for type safety, PEP-8 compliance, error handling, and security. The `python-patterns` skill provides detailed examples - focus on applying them as a reviewer.
 

--- a/.claude/agents/python-script-reviewer.md
+++ b/.claude/agents/python-script-reviewer.md
@@ -3,7 +3,7 @@ name: python-script-reviewer
 description: Reviews Python scripts for best practices, type safety, and project conventions.
 model: sonnet
 color: orange
-skills: python-patterns
+skills: python-patterns, implementation-self-check
 tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
@@ -33,30 +33,16 @@ When activated in implementation mode, combine your Python domain expertise with
 4. Implement ONLY the missing requirements provided
 5. Follow coding standards in `$CLOSEDLOOP_WORKDIR/CLAUDE.md` if it exists
 6. Apply Python best practices: type annotations, PEP-8, proper error handling, security
-7. After implementing, proceed to the Self-Verification Gate below
+7. Activate skill `implementation-self-check` and follow its shared four-gate protocol using the agent-specific checks below.
 
-### Self-Verification Gate
+### Agent-Specific Verification Checks
 
-After implementing, you MUST pass all four gates before emitting the completion promise.
+When the `implementation-self-check` skill reaches Gates 3 and 4, apply these checks:
 
-**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+- **Gate 3: Integration Check** — For each new function or class created, verify it is imported and used at the call site.
+- **Gate 4: Static Analysis** — Run `ruff check` and `pyright` on modified files. Fix any errors introduced.
 
-**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
-```
-VERIFICATION:
-- "requirement description" → PASS (file.py:42 - implements X)
-- "another requirement" → FAIL (not found)
-```
-If any requirement has FAIL status, go back and implement it.
-
-**Gate 3: Integration Check** — For each new function/class created, verify it is imported and used at the call site.
-
-**Gate 4: Static Analysis** — Run `ruff check` and `pyright` on modified files. Fix any errors introduced.
-
-### Return Format
-
-**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
-**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+Use the skill's standard `IMPLEMENTATION_VERIFIED` / `BLOCKED` return format.
 
 ---
 

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -1,19 +1,73 @@
 ---
 name: test-engineer
-description: Specialized in Python testing with pytest. Expert in running tests, fixing failures, and ensuring test coverage. Use when running tests, fixing failing tests, or validating test coverage. Does NOT write new tests - focuses on running and fixing.
+description: Specialized in Python testing with pytest. Expert in running tests, fixing failures, and ensuring test coverage. Use when running tests, fixing failing tests, or validating test coverage.
 model: sonnet
 color: yellow
+tools: Read, Write, Edit, Grep, Glob, Bash
 ---
 
-You are a Python testing expert for this Claude Code plugin repository. Your focus is on **running tests and fixing failures**, not writing new tests.
+## Execution Modes
+
+This agent supports two execution modes:
+
+1. **Critic Mode (default)**: Run existing tests, fix failures, validate coverage
+2. **Implementation Mode**: Write new tests and test infrastructure for implemented features
+
+### Mode Detection
+
+**Implementation mode** if prompt contains: `WORKDIR=`, `Implement task`, `Missing requirements:`
+**Critic mode** otherwise (default)
+
+---
+
+## Implementation Mode
+
+When activated in implementation mode, write tests for implemented features using pytest best practices.
+
+### Instructions
+
+1. Read the source files that tests need to cover
+2. Before creating test files, read existing tests to follow established patterns
+3. Use pytest fixtures, `tmp_path` for file operations, `pytest.raises` for exceptions
+4. Use modern Python 3.11+ type syntax: `list[str]`, `str | None`
+5. Co-locate tests with source code (`test_*.py` alongside implementation)
+6. Implement ONLY the missing test requirements provided
+7. After implementing, proceed to the Self-Verification Gate below
+
+### Self-Verification Gate
+
+After implementing, you MUST pass all four gates before emitting the completion promise.
+
+**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+
+**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
+```
+VERIFICATION:
+- "test for X" → PASS (test_module.py:42 - tests X scenario)
+- "test for Y" → FAIL (not found)
+```
+If any requirement has FAIL status, go back and implement it.
+
+**Gate 3: Integration Check** — Run the new tests to verify they pass: `pytest test_file.py -v`
+
+**Gate 4: Static Analysis** — Run `ruff check` and `pyright` on test files. Fix any errors.
+
+### Return Format
+
+**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+
+---
+
+## Critic Mode
+
+You are a Python testing expert for this Claude Code plugin repository. Your focus is on **running tests and fixing failures**.
 
 activate skill python-patterns
 
----
+### Mission
 
-## Mission
-
-Run the existing test suite and fix any failures. You do NOT write new tests - you ensure existing tests pass.
+Run the existing test suite and fix any failures.
 
 **Core responsibilities:**
 

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -3,7 +3,8 @@ name: test-engineer
 description: Specialized in Python testing with pytest. Expert in running tests, fixing failures, and ensuring test coverage. Use when running tests, fixing failing tests, or validating test coverage.
 model: sonnet
 color: yellow
-tools: Read, Write, Edit, Grep, Glob, Bash
+skills: python-patterns, implementation-self-check
+tools: Read, Write, Edit, Grep, Glob, Bash, Skill
 ---
 
 ## Execution Modes
@@ -32,30 +33,16 @@ When activated in implementation mode, write tests for implemented features usin
 4. Use modern Python 3.11+ type syntax: `list[str]`, `str | None`
 5. Co-locate tests with source code (`test_*.py` alongside implementation)
 6. Implement ONLY the missing test requirements provided
-7. After implementing, proceed to the Self-Verification Gate below
+7. Activate skill `implementation-self-check` and follow its shared four-gate protocol using the agent-specific checks below.
 
-### Self-Verification Gate
+### Agent-Specific Verification Checks
 
-After implementing, you MUST pass all four gates before emitting the completion promise.
+When the `implementation-self-check` skill reaches Gates 3 and 4, apply these checks:
 
-**Gate 1: Re-read Modified Files** — For every file you created or modified, use Read to re-read it in full. Verify correctness.
+- **Gate 3: Integration Check** — Run the new tests to verify they pass: `pytest test_file.py -v`.
+- **Gate 4: Static Analysis** — Run `ruff check` and `pyright` on the test files. Fix any errors.
 
-**Gate 2: Requirement Verification** — For each item in the NOT_IMPLEMENTED list, locate specific `file:line` evidence:
-```
-VERIFICATION:
-- "test for X" → PASS (test_module.py:42 - tests X scenario)
-- "test for Y" → FAIL (not found)
-```
-If any requirement has FAIL status, go back and implement it.
-
-**Gate 3: Integration Check** — Run the new tests to verify they pass: `pytest test_file.py -v`
-
-**Gate 4: Static Analysis** — Run `ruff check` and `pyright` on test files. Fix any errors.
-
-### Return Format
-
-**Success:** Output `IMPLEMENTATION_VERIFIED:` with file changes, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
-**Blocked:** Output `BLOCKED:` with details, then `<promise>IMPLEMENTATION_VERIFIED</promise>`
+Use the skill's standard `IMPLEMENTATION_VERIFIED` / `BLOCKED` return format.
 
 ---
 

--- a/.claude/skills/implementation-self-check/SKILL.md
+++ b/.claude/skills/implementation-self-check/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: implementation-self-check
+description: |
+  Shared four-gate verification workflow for write-capable implementation agents.
+  Use after editing files for a NOT_IMPLEMENTED task or when an agent prompt says to proceed to a self-verification gate.
+  Re-reads changed files, produces PASS/FAIL evidence for each missing requirement, runs caller-specific integration and static-analysis checks, and only allows IMPLEMENTATION_VERIFIED output when every gate passes.
+---
+
+# Implementation Self Check
+
+Shared verification protocol for implementation-mode agents. This skill replaces duplicated inline gate text across multiple agent definitions while preserving agent-specific Gate 3 and Gate 4 checks in the caller.
+
+## When to Use
+
+Activate this skill immediately after finishing implementation work, before returning `IMPLEMENTATION_VERIFIED` or `BLOCKED`.
+
+## Standard Four-Gate Protocol
+
+### Gate 1: Re-read Modified Files
+
+Re-read every file created or modified during the session in full. Do not rely on memory of prior edits.
+
+### Gate 2: Requirement Verification
+
+For every item in the orchestrator-provided `NOT_IMPLEMENTED` list, produce explicit `PASS` or `FAIL` evidence with `file:line` references:
+
+```text
+VERIFICATION:
+- "requirement description" → PASS (path/to/file.py:42 - evidence)
+- "another requirement" → FAIL (not found)
+```
+
+If any requirement fails, fix the issue before continuing.
+
+### Gate 3: Integration Check
+
+Run the caller's agent-specific integration checks. These checks stay in the agent definition because they differ by domain.
+
+### Gate 4: Static Analysis
+
+Run the caller's agent-specific static-analysis or syntax checks. Fix any issues introduced by the implementation before returning.
+
+## Completion Rules
+
+- Do not emit `IMPLEMENTATION_VERIFIED` until all four gates pass.
+- If blocked, return the blocker details using the standard blocked format below.
+- If a gate fails, fix the issue and re-run the failed gates before returning.
+
+## Return Format
+
+### Success
+
+```text
+IMPLEMENTATION_VERIFIED:
+- [path/to/file]: [brief description of changes]
+
+VERIFICATION:
+- "requirement 1" → PASS (path/to/file:line - evidence)
+- "requirement 2" → PASS (path/to/file:line - evidence)
+```
+
+Then emit:
+
+```text
+<promise>IMPLEMENTATION_VERIFIED</promise>
+```
+
+### Blocked
+
+```text
+BLOCKED:
+- [describe what is blocked]
+- [what information, dependency, or decision is needed]
+```
+
+Then emit:
+
+```text
+<promise>IMPLEMENTATION_VERIFIED</promise>
+```

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.11.20",
+  "version": "1.12.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/prompts/prompt.md
+++ b/plugins/code/prompts/prompt.md
@@ -211,7 +211,9 @@ Here are the key phases you must complete:
 Discover all available specialist agents that could handle implementation tasks. Run this Bash command and store the output in working memory as `available_agents`:
 
 ```bash
-echo "=== Repo-level agents ===" && for f in .claude/agents/*.md; do name=$(head -10 "$f" 2>/dev/null | grep '^name:' | head -1 | sed 's/^name: *//'); desc=$(head -10 "$f" 2>/dev/null | grep '^description:' | head -1 | sed 's/^description: *//'); tools=$(head -10 "$f" 2>/dev/null | grep '^tools:' | head -1 | sed 's/^tools: *//'); [ -n "$name" ] && echo "  @$name | $desc | tools: $tools"; done 2>/dev/null; echo "=== Plugin agents ===" && echo "  @code:implementation-subagent | Generalist implementation agent (fallback)"
+python3 "${CLAUDE_PLUGIN_ROOT}/tools/python/discover_available_agents.py" \
+  --workspace "$PWD" \
+  --plugin-root "$CLAUDE_PLUGIN_ROOT"
 ```
 
 This produces a list like:
@@ -221,8 +223,12 @@ This produces a list like:
   @python-script-reviewer | Reviews Python scripts... | tools: Read, Write, Edit, Grep, Glob, Bash, Skill
   ...
 === Plugin agents ===
-  @code:implementation-subagent | Generalist implementation agent (fallback)
+  @bootstrap:agent-prompt-generator | Generates bootstrap agent prompts... | tools: inherited
+  @code:implementation-subagent | Implements missing requirements for a task from the implementation plan. | tools: Read, Write, Edit, Glob, Grep, Bash
+  ...
 ```
+
+The discovery script scans repo agents from `.claude/agents/`, local plugin agents from `plugins/*/agents/` when working in this monorepo, and installed plugin agents from `~/.claude/plugins/cache/`.
 
 **Agent selection (per-task, LLM-decided):**
 
@@ -231,7 +237,7 @@ For each task, after verification identifies NOT_IMPLEMENTED requirements, choos
 1. Consider the task description, the `files:` list, and the `missing:` requirements from verification output
 2. Review `available_agents` in working memory — pick the agent whose description is the **best domain match** for this task
 3. An agent is eligible for implementation only if its tools include **Write or Edit** (read-only agents cannot implement)
-4. If no specialist is a clear match, use `@code:implementation-subagent` (the generalist fallback)
+4. If no specialist is a clear match, use the broadest write-capable agent from `available_agents`; if `@code:implementation-subagent` is present, prefer it as the generalist fallback
 5. Prefer specificity: a domain specialist that fits the task well will outperform the generalist
 
 - For each task in `pending_tasks`:

--- a/plugins/code/prompts/prompt.md
+++ b/plugins/code/prompts/prompt.md
@@ -205,16 +205,46 @@ Here are the key phases you must complete:
 
 - Activate `code:plan-validate` skill (runs Python script against $CLOSEDLOOP_WORKDIR) — semantic check is unnecessary here since the plan hasn't changed since Phase 2.7
 - If `pending_tasks` is empty, all tasks are done → proceed to Phase 4
+
+**Dynamic agent discovery (once at phase start):**
+
+Discover all available specialist agents that could handle implementation tasks. Run this Bash command and store the output in working memory as `available_agents`:
+
+```bash
+echo "=== Repo-level agents ===" && for f in .claude/agents/*.md; do name=$(head -10 "$f" 2>/dev/null | grep '^name:' | head -1 | sed 's/^name: *//'); desc=$(head -10 "$f" 2>/dev/null | grep '^description:' | head -1 | sed 's/^description: *//'); tools=$(head -10 "$f" 2>/dev/null | grep '^tools:' | head -1 | sed 's/^tools: *//'); [ -n "$name" ] && echo "  @$name | $desc | tools: $tools"; done 2>/dev/null; echo "=== Plugin agents ===" && echo "  @code:implementation-subagent | Generalist implementation agent (fallback)"
+```
+
+This produces a list like:
+```
+=== Repo-level agents ===
+  @agent-definition-expert | Reviews Claude Code agents... | tools: Read, Write, Edit, Grep, Glob, Bash, Skill
+  @python-script-reviewer | Reviews Python scripts... | tools: Read, Write, Edit, Grep, Glob, Bash, Skill
+  ...
+=== Plugin agents ===
+  @code:implementation-subagent | Generalist implementation agent (fallback)
+```
+
+**Agent selection (per-task, LLM-decided):**
+
+For each task, after verification identifies NOT_IMPLEMENTED requirements, choose the best agent:
+
+1. Consider the task description, the `files:` list, and the `missing:` requirements from verification output
+2. Review `available_agents` in working memory — pick the agent whose description is the **best domain match** for this task
+3. An agent is eligible for implementation only if its tools include **Write or Edit** (read-only agents cannot implement)
+4. If no specialist is a clear match, use `@code:implementation-subagent` (the generalist fallback)
+5. Prefer specificity: a domain specialist that fits the task well will outperform the generalist
+
 - For each task in `pending_tasks`:
   1. **Update state.json** with task-level tracking (see State Tracking section above)
   2. Launch @code:verification-subagent with prompt: "WORKDIR=$CLOSEDLOOP_WORKDIR. Verify task T-X.Y: {task description}"
   3. Process based on result:
      - **VERIFIED**: Proceed to step 4
-     - **NOT_IMPLEMENTED**: Parse the `missing:` and `files:` sections from the verification output. Launch @code:implementation-subagent with prompt: "WORKDIR=$CLOSEDLOOP_WORKDIR. Implement task T-X.Y: {task description}. Missing requirements: {missing list}. Relevant source files already identified: {files list}"
-       - After implementation-subagent returns, check its output:
+     - **NOT_IMPLEMENTED**: Parse the `missing:` and `files:` sections from the verification output. Select the best implementation agent using the **agent selection** logic above. Launch the selected agent with prompt: "WORKDIR=$CLOSEDLOOP_WORKDIR. Implement task T-X.Y: {task description}. Missing requirements: {missing list}. Relevant source files already identified: {files list}"
+       - Log: "Selected agent: {agent name} for task T-X.Y (reason: {brief rationale})"
+       - After implementation agent returns, check its output:
          - If output contains `IMPLEMENTATION_VERIFIED` or `BLOCKED`: proceed to step 4
-         - If output does NOT contain either (max iterations exhausted): log warning "implementation-subagent did not verify T-X.Y", do NOT mark `[x]`, continue to next task
-  4. After task is verified/implemented (and implementation-subagent output passed the check above), launch a **haiku subagent** (description: `"plan-editor"`) to mark `- [x]` in the plan. Prompt: "In $CLOSEDLOOP_WORKDIR/plan.json, update the content field to change task T-X.Y from '- [ ]' to '- [x]', and move the task from pendingTasks to completedTasks array. Then write the updated `content` field value to $CLOSEDLOOP_WORKDIR/plan.md"
+         - If output does NOT contain either (max iterations exhausted): log warning "implementation agent did not verify T-X.Y", do NOT mark `[x]`, continue to next task
+  4. After task is verified/implemented (and implementation agent output passed the check above), launch a **haiku subagent** (description: `"plan-editor"`) to mark `- [x]` in the plan. Prompt: "In $CLOSEDLOOP_WORKDIR/plan.json, update the content field to change task T-X.Y from '- [ ]' to '- [x]', and move the task from pendingTasks to completedTasks array. Then write the updated `content` field value to $CLOSEDLOOP_WORKDIR/plan.md"
 - Do NOT fix errors outside the implementation loop — the subagent self-verifies (up to 4 attempts). Let Phase 5 catch remaining issues.
 - **Optional:** For complex tasks, use `code:iterative-retrieval` skill when launching implementation/verification subagents to refine incomplete responses.
 - After processing all tasks, re-activate `code:plan-validate` skill to confirm no `pending_tasks` remain
@@ -270,8 +300,8 @@ If `decisionTablePath` is `""` (Phase 2.7 generation failed or pointer not writt
    - If `MISALIGNED` (first line of output is `MISALIGNED`):
      - Extract the `<drift_rows>...</drift_rows>` JSON block from the verifier output. Parse the JSON array. **If the block is missing, the JSON is malformed, or any row has an unknown `kind` value not in `{code_drift, test_drift, plan_ambiguity}`, treat as a verifier parse failure**: set `dt_last_failure_reason = "unparseable"`, increment `dt_parse_failures` by 1, log a warning, do NOT route any drift rows, and immediately loop back to step 1. Do NOT increment `dt_attempt` here -- Step 1 owns all increments.
      - If the block is parseable, set `dt_last_failure_reason = "drift"`. For each JSON object in the `drift_rows` array, increment `dt_drift_kind_counts[kind]` by 1 and `dt_fixes_attempted` by 1, then route by the `kind` field:
-       - `code_drift`: launch @code:implementation-subagent with prompt: "WORKDIR=$CLOSEDLOOP_WORKDIR. Implement missing behavioral requirement. Area: {row.area}. Missing: {row.description}. Source file hint: {row.source_file}."
-       - `test_drift`: launch @test-engineer with prompt: "WORKDIR=$CLOSEDLOOP_WORKDIR. Write tests for missing scenario. Area: {row.area}. Missing test scenario: {row.description}. Source file hint: {row.source_file}. Write the test in the appropriate test file for this area." If `row.source_file` points to a non-test file (indicating production code changes are also needed), also launch @code:implementation-subagent with the production-code requirement.
+       - `code_drift`: Using `available_agents` from Phase 3 working memory (re-run discovery if not present), select the best agent for `row.source_file` and `row.area` using the same **agent selection** logic from Phase 3. Launch the selected agent with prompt: "WORKDIR=$CLOSEDLOOP_WORKDIR. Implement missing behavioral requirement. Area: {row.area}. Missing: {row.description}. Source file hint: {row.source_file}."
+       - `test_drift`: launch @test-engineer with prompt: "WORKDIR=$CLOSEDLOOP_WORKDIR. Write tests for missing scenario. Area: {row.area}. Missing test scenario: {row.description}. Source file hint: {row.source_file}. Write the test in the appropriate test file for this area." If `row.source_file` points to a non-test file (indicating production code changes are also needed), select the best agent from `available_agents` for the production-code file and launch it with the production-code requirement.
        - `plan_ambiguity`: set `dt_any_clarifications = true`. Launch a haiku subagent (description: `"plan-editor"`) to append a `Plan Clarifications` note to the decision-table artifact at "$CLOSEDLOOP_WORKDIR/$decisionTablePath" for the following ambiguity: {row.description}. Area: {row.area}. The haiku must NOT modify the `Current Code` or `Intended Change` sections — append only. Quote all paths in shell commands.
      - After all row handlers complete, loop back to step 1.
 

--- a/plugins/code/prompts/prompt.md
+++ b/plugins/code/prompts/prompt.md
@@ -216,29 +216,47 @@ python3 "${CLAUDE_PLUGIN_ROOT}/tools/python/discover_available_agents.py" \
   --plugin-root "$CLAUDE_PLUGIN_ROOT"
 ```
 
-This produces a list like:
-```
-=== Repo-level agents ===
-  @agent-definition-expert | Reviews Claude Code agents... | tools: Read, Write, Edit, Grep, Glob, Bash, Skill
-  @python-script-reviewer | Reviews Python scripts... | tools: Read, Write, Edit, Grep, Glob, Bash, Skill
-  ...
-=== Plugin agents ===
-  @bootstrap:agent-prompt-generator | Generates bootstrap agent prompts... | tools: inherited
-  @code:implementation-subagent | Implements missing requirements for a task from the implementation plan. | tools: Read, Write, Edit, Glob, Grep, Bash
-  ...
+This produces a structured JSON capability record:
+```json
+{
+  "repo_agents": [
+    {
+      "invocation": "python-script-reviewer",
+      "description": "Reviews Python scripts...",
+      "tools": "Read, Write, Edit, Grep, Glob, Bash, Skill",
+      "implementation_capable": true,
+      "file_patterns": "**/*.py, **/test_*.py",
+      "domains": "python, tooling",
+      "trust_source": "repo",
+      "fallback_rank": 0
+    }
+  ],
+  "plugin_agents": [
+    {
+      "invocation": "code:implementation-subagent",
+      "description": "Implements missing requirements for a task...",
+      "tools": "Read, Write, Edit, Glob, Grep, Bash",
+      "implementation_capable": true,
+      "file_patterns": "",
+      "domains": "",
+      "trust_source": "workspace-plugin",
+      "fallback_rank": 1
+    }
+  ]
+}
 ```
 
-The discovery script scans repo agents from `.claude/agents/`, local plugin agents from `plugins/*/agents/` when working in this monorepo, and installed plugin agents from `~/.claude/plugins/cache/`.
+The discovery script scans repo agents from `.claude/agents/`, local plugin agents from `plugins/*/agents/` when working in this monorepo, and installed plugin agents from `~/.claude/plugins/cache/`. The `implementation_capable` flag is `true` only for agents that activate the shared `implementation-self-check` skill — i.e. agents that honor the `IMPLEMENTATION_VERIFIED` contract and the four-gate self-verification. It is derived from the skill marker, **not** the `tools` string, so write-capable plan/build/review agents (which do not implement the contract) are correctly excluded, and contract-honoring agents rendered as `tools: inherited` are correctly included.
 
 **Agent selection (per-task, LLM-decided):**
 
-For each task, after verification identifies NOT_IMPLEMENTED requirements, choose the best agent:
+For each task, after verification identifies NOT_IMPLEMENTED requirements, choose the best agent by consuming the structured record (do NOT pattern-match on the freeform description or tools string):
 
-1. Consider the task description, the `files:` list, and the `missing:` requirements from verification output
-2. Review `available_agents` in working memory — pick the agent whose description is the **best domain match** for this task
-3. An agent is eligible for implementation only if its tools include **Write or Edit** (read-only agents cannot implement)
-4. If no specialist is a clear match, use the broadest write-capable agent from `available_agents`; if `@code:implementation-subagent` is present, prefer it as the generalist fallback
-5. Prefer specificity: a domain specialist that fits the task well will outperform the generalist
+1. **Eligibility:** consider ONLY agents whose `implementation_capable` is `true`. An agent that is write-capable but not implementation-capable (e.g. a code reviewer) must never be selected — it does not emit `IMPLEMENTATION_VERIFIED` or run the gates.
+2. **Domain/file match (PLN-626):** among eligible agents, prefer the one whose `file_patterns` match the task's `files:` list (glob match), then whose `domains`/`description` best fit the task's `missing:` requirements.
+3. **Generalist fallback:** if no specialist matches, pick the eligible agent with the lowest `fallback_rank` (lower `trust_source` rank = more trusted); if `code:implementation-subagent` is eligible, prefer it as the generalist fallback.
+4. **Hard fallback:** if `available_agents` is empty, has no `implementation_capable` agent, or was not produced (discovery failed/unparseable), use `@code:implementation-subagent` directly. See the discovery command note above.
+5. Prefer specificity: a domain specialist that fits the task well will outperform the generalist.
 
 - For each task in `pending_tasks`:
   1. **Update state.json** with task-level tracking (see State Tracking section above)

--- a/plugins/code/tools/python/discover_available_agents.py
+++ b/plugins/code/tools/python/discover_available_agents.py
@@ -15,13 +15,41 @@ from typing import Iterable
 _VERSION_DIR_RE = re.compile(r"^\d+\.")
 
 
+# Agents honour the implementation contract (emit IMPLEMENTATION_VERIFIED, run
+# the four gates) by activating this shared skill. Selection keys on this marker
+# rather than on the freeform tools string, so write-capable critic/plan/review
+# agents and agents rendered as `tools: inherited` are classified correctly.
+_IMPLEMENTATION_SKILL = "implementation-self-check"
+
+# Lower rank = higher precedence when the orchestrator falls back to a generalist.
+_TRUST_RANK = {"repo": 0, "workspace-plugin": 1, "cache": 2}
+
+
 @dataclass(frozen=True)
 class AgentDescriptor:
-    """Minimal metadata needed for agent selection."""
+    """Structured implementation-capability record used for agent selection."""
 
     invocation: str
     description: str
     tools: str
+    implementation_capable: bool
+    file_patterns: str
+    domains: str
+    trust_source: str
+    fallback_rank: int
+
+    def as_record(self) -> dict[str, object]:
+        """Return the JSON record the orchestrator prompt consumes."""
+        return {
+            "invocation": self.invocation,
+            "description": self.description,
+            "tools": self.tools,
+            "implementation_capable": self.implementation_capable,
+            "file_patterns": self.file_patterns,
+            "domains": self.domains,
+            "trust_source": self.trust_source,
+            "fallback_rank": self.fallback_rank,
+        }
 
 
 def _parse_frontmatter(path: Path) -> dict[str, str] | None:
@@ -52,6 +80,23 @@ def _parse_frontmatter(path: Path) -> dict[str, str] | None:
     return metadata
 
 
+def _build_descriptor(
+    invocation: str, metadata: dict[str, str], trust_source: str
+) -> AgentDescriptor:
+    """Construct a structured capability record from parsed frontmatter."""
+    skills = metadata.get("skills", "")
+    return AgentDescriptor(
+        invocation=invocation,
+        description=metadata["description"],
+        tools=metadata.get("tools", "inherited"),
+        implementation_capable=_IMPLEMENTATION_SKILL in skills,
+        file_patterns=metadata.get("file_patterns", ""),
+        domains=metadata.get("domains", ""),
+        trust_source=trust_source,
+        fallback_rank=_TRUST_RANK.get(trust_source, len(_TRUST_RANK)),
+    )
+
+
 def _load_plugin_name(plugin_root: Path) -> str | None:
     manifest_path = plugin_root / ".claude-plugin" / "plugin.json"
     try:
@@ -75,13 +120,7 @@ def _discover_repo_agents(workspace_root: Path) -> list[AgentDescriptor]:
         metadata = _parse_frontmatter(path)
         if metadata is None:
             continue
-        agents.append(
-            AgentDescriptor(
-                invocation=metadata["name"],
-                description=metadata["description"],
-                tools=metadata.get("tools", "inherited"),
-            )
-        )
+        agents.append(_build_descriptor(metadata["name"], metadata, "repo"))
     return agents
 
 
@@ -145,10 +184,12 @@ def _iter_cached_plugin_roots(plugin_cache_root: Path) -> Iterable[Path]:
                 yield latest
 
 
-def _discover_plugin_agents(plugin_roots: Iterable[Path]) -> list[AgentDescriptor]:
+def _discover_plugin_agents(
+    plugin_roots: Iterable[tuple[Path, str]],
+) -> list[AgentDescriptor]:
     discovered: dict[str, AgentDescriptor] = {}
 
-    for plugin_root in plugin_roots:
+    for plugin_root, trust_source in plugin_roots:
         plugin_name = _load_plugin_name(plugin_root)
         agents_dir = plugin_root / "agents"
         if plugin_name is None or not agents_dir.is_dir():
@@ -160,13 +201,13 @@ def _discover_plugin_agents(plugin_roots: Iterable[Path]) -> list[AgentDescripto
                 continue
 
             invocation = f"{plugin_name}:{metadata['name']}"
+            # First match wins: roots are supplied in precedence order
+            # (current plugin, workspace plugins, then cache).
             if invocation in discovered:
                 continue
 
-            discovered[invocation] = AgentDescriptor(
-                invocation=invocation,
-                description=metadata["description"],
-                tools=metadata.get("tools", "inherited"),
+            discovered[invocation] = _build_descriptor(
+                invocation, metadata, trust_source
             )
 
     return sorted(discovered.values(), key=lambda agent: agent.invocation)
@@ -180,11 +221,16 @@ def discover_available_agents(
     """Discover repo-level and plugin agents with stable precedence."""
     repo_agents = _discover_repo_agents(workspace_root)
 
-    plugin_roots: list[Path] = []
+    plugin_roots: list[tuple[Path, str]] = []
     if plugin_root is not None:
-        plugin_roots.append(plugin_root)
-    plugin_roots.extend(_iter_workspace_plugin_roots(workspace_root))
-    plugin_roots.extend(_iter_cached_plugin_roots(plugin_cache_root))
+        plugin_roots.append((plugin_root, "workspace-plugin"))
+    plugin_roots.extend(
+        (root, "workspace-plugin")
+        for root in _iter_workspace_plugin_roots(workspace_root)
+    )
+    plugin_roots.extend(
+        (root, "cache") for root in _iter_cached_plugin_roots(plugin_cache_root)
+    )
 
     plugin_agents = _discover_plugin_agents(plugin_roots)
     return repo_agents, plugin_agents
@@ -193,26 +239,17 @@ def discover_available_agents(
 def render_discovery_output(
     repo_agents: list[AgentDescriptor], plugin_agents: list[AgentDescriptor]
 ) -> str:
-    """Render the text block consumed by the orchestrator prompt."""
-    lines = ["=== Repo-level agents ==="]
-    if repo_agents:
-        for agent in repo_agents:
-            lines.append(
-                f"  @{agent.invocation} | {agent.description} | tools: {agent.tools}"
-            )
-    else:
-        lines.append("  (none found)")
+    """Render the structured capability record consumed by the orchestrator.
 
-    lines.append("=== Plugin agents ===")
-    if plugin_agents:
-        for agent in plugin_agents:
-            lines.append(
-                f"  @{agent.invocation} | {agent.description} | tools: {agent.tools}"
-            )
-    else:
-        lines.append("  (none found)")
-
-    return "\n".join(lines)
+    Emits JSON so the prompt consumes typed fields (``implementation_capable``,
+    ``file_patterns``, ``domains``, ``trust_source``, ``fallback_rank``) instead
+    of parsing a freeform description/tools string.
+    """
+    payload = {
+        "repo_agents": [agent.as_record() for agent in repo_agents],
+        "plugin_agents": [agent.as_record() for agent in plugin_agents],
+    }
+    return json.dumps(payload, indent=2)
 
 
 def _parse_args() -> argparse.Namespace:

--- a/plugins/code/tools/python/discover_available_agents.py
+++ b/plugins/code/tools/python/discover_available_agents.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
+
+# Cache layout is <cache>/<owner>/<plugin>/<version>/.claude-plugin/plugin.json.
+# Only directories whose name starts with a digit are treated as version dirs.
+_VERSION_DIR_RE = re.compile(r"^\d+\.")
 
 
 @dataclass(frozen=True)
@@ -90,19 +95,54 @@ def _iter_workspace_plugin_roots(workspace_root: Path) -> Iterable[Path]:
             yield plugin_root
 
 
+def _parse_version(name: str) -> tuple[int, ...]:
+    """Parse a version directory name into an integer tuple for comparison."""
+    parts = re.findall(r"\d+", name)
+    return tuple(int(p) for p in parts) if parts else (0,)
+
+
+def _latest_version_root(plugin_dir: Path) -> Path | None:
+    """Return the highest-semver version dir under a plugin that holds a manifest."""
+    candidates: list[tuple[tuple[int, ...], Path]] = []
+    try:
+        version_dirs = list(plugin_dir.iterdir())
+    except OSError:
+        return None
+
+    for version_dir in version_dirs:
+        if not version_dir.is_dir() or not _VERSION_DIR_RE.match(version_dir.name):
+            continue
+        if (version_dir / ".claude-plugin" / "plugin.json").is_file():
+            candidates.append((_parse_version(version_dir.name), version_dir))
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0])
+    return candidates[-1][1]
+
+
 def _iter_cached_plugin_roots(plugin_cache_root: Path) -> Iterable[Path]:
+    """Yield the latest cached version root for each ``<owner>/<plugin>``.
+
+    Traverses only the expected cache layout
+    (``<cache>/<owner>/<plugin>/<version>/.claude-plugin/plugin.json``) instead
+    of recursively walking the whole cache tree, and selects the highest
+    semantic version per plugin so stale cached versions are never surfaced.
+    The fixed three-level descent bounds traversal regardless of how deep or
+    oversized the cache tree happens to be.
+    """
     if not plugin_cache_root.is_dir():
         return
 
-    seen: set[Path] = set()
-    for manifest_path in sorted(plugin_cache_root.rglob("plugin.json")):
-        if manifest_path.parent.name != ".claude-plugin":
+    for owner_dir in sorted(plugin_cache_root.iterdir()):
+        if not owner_dir.is_dir():
             continue
-        plugin_root = manifest_path.parent.parent
-        if plugin_root in seen:
-            continue
-        seen.add(plugin_root)
-        yield plugin_root
+        for plugin_dir in sorted(owner_dir.iterdir()):
+            if not plugin_dir.is_dir():
+                continue
+            latest = _latest_version_root(plugin_dir)
+            if latest is not None:
+                yield latest
 
 
 def _discover_plugin_agents(plugin_roots: Iterable[Path]) -> list[AgentDescriptor]:

--- a/plugins/code/tools/python/discover_available_agents.py
+++ b/plugins/code/tools/python/discover_available_agents.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Discover repo-level and plugin-provided agents available to the orchestrator."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class AgentDescriptor:
+    """Minimal metadata needed for agent selection."""
+
+    invocation: str
+    description: str
+    tools: str
+
+
+def _parse_frontmatter(path: Path) -> dict[str, str] | None:
+    """Parse simple flat YAML frontmatter used by agent markdown files."""
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+
+    metadata: dict[str, str] = {}
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == "---":
+            break
+        if not stripped or stripped.startswith("#") or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        value = value.strip()
+        if value:
+            metadata[key.strip()] = value
+
+    if "name" not in metadata or "description" not in metadata:
+        return None
+    return metadata
+
+
+def _load_plugin_name(plugin_root: Path) -> str | None:
+    manifest_path = plugin_root / ".claude-plugin" / "plugin.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    plugin_name = manifest.get("name")
+    if not isinstance(plugin_name, str) or not plugin_name.strip():
+        return None
+    return plugin_name.strip()
+
+
+def _discover_repo_agents(workspace_root: Path) -> list[AgentDescriptor]:
+    agents_dir = workspace_root / ".claude" / "agents"
+    if not agents_dir.is_dir():
+        return []
+
+    agents: list[AgentDescriptor] = []
+    for path in sorted(agents_dir.glob("*.md")):
+        metadata = _parse_frontmatter(path)
+        if metadata is None:
+            continue
+        agents.append(
+            AgentDescriptor(
+                invocation=metadata["name"],
+                description=metadata["description"],
+                tools=metadata.get("tools", "inherited"),
+            )
+        )
+    return agents
+
+
+def _iter_workspace_plugin_roots(workspace_root: Path) -> Iterable[Path]:
+    plugins_dir = workspace_root / "plugins"
+    if not plugins_dir.is_dir():
+        return
+
+    for plugin_root in sorted(path for path in plugins_dir.iterdir() if path.is_dir()):
+        if (plugin_root / ".claude-plugin" / "plugin.json").is_file():
+            yield plugin_root
+
+
+def _iter_cached_plugin_roots(plugin_cache_root: Path) -> Iterable[Path]:
+    if not plugin_cache_root.is_dir():
+        return
+
+    seen: set[Path] = set()
+    for manifest_path in sorted(plugin_cache_root.rglob("plugin.json")):
+        if manifest_path.parent.name != ".claude-plugin":
+            continue
+        plugin_root = manifest_path.parent.parent
+        if plugin_root in seen:
+            continue
+        seen.add(plugin_root)
+        yield plugin_root
+
+
+def _discover_plugin_agents(plugin_roots: Iterable[Path]) -> list[AgentDescriptor]:
+    discovered: dict[str, AgentDescriptor] = {}
+
+    for plugin_root in plugin_roots:
+        plugin_name = _load_plugin_name(plugin_root)
+        agents_dir = plugin_root / "agents"
+        if plugin_name is None or not agents_dir.is_dir():
+            continue
+
+        for path in sorted(agents_dir.glob("*.md")):
+            metadata = _parse_frontmatter(path)
+            if metadata is None:
+                continue
+
+            invocation = f"{plugin_name}:{metadata['name']}"
+            if invocation in discovered:
+                continue
+
+            discovered[invocation] = AgentDescriptor(
+                invocation=invocation,
+                description=metadata["description"],
+                tools=metadata.get("tools", "inherited"),
+            )
+
+    return sorted(discovered.values(), key=lambda agent: agent.invocation)
+
+
+def discover_available_agents(
+    workspace_root: Path,
+    plugin_root: Path | None,
+    plugin_cache_root: Path,
+) -> tuple[list[AgentDescriptor], list[AgentDescriptor]]:
+    """Discover repo-level and plugin agents with stable precedence."""
+    repo_agents = _discover_repo_agents(workspace_root)
+
+    plugin_roots: list[Path] = []
+    if plugin_root is not None:
+        plugin_roots.append(plugin_root)
+    plugin_roots.extend(_iter_workspace_plugin_roots(workspace_root))
+    plugin_roots.extend(_iter_cached_plugin_roots(plugin_cache_root))
+
+    plugin_agents = _discover_plugin_agents(plugin_roots)
+    return repo_agents, plugin_agents
+
+
+def render_discovery_output(
+    repo_agents: list[AgentDescriptor], plugin_agents: list[AgentDescriptor]
+) -> str:
+    """Render the text block consumed by the orchestrator prompt."""
+    lines = ["=== Repo-level agents ==="]
+    if repo_agents:
+        for agent in repo_agents:
+            lines.append(
+                f"  @{agent.invocation} | {agent.description} | tools: {agent.tools}"
+            )
+    else:
+        lines.append("  (none found)")
+
+    lines.append("=== Plugin agents ===")
+    if plugin_agents:
+        for agent in plugin_agents:
+            lines.append(
+                f"  @{agent.invocation} | {agent.description} | tools: {agent.tools}"
+            )
+    else:
+        lines.append("  (none found)")
+
+    return "\n".join(lines)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--workspace",
+        default=".",
+        help="Workspace root whose .claude/agents and plugins/ tree should be scanned.",
+    )
+    parser.add_argument(
+        "--plugin-root",
+        default=None,
+        help="Resolved CLAUDE_PLUGIN_ROOT for the current plugin instance.",
+    )
+    parser.add_argument(
+        "--plugin-cache-root",
+        default=str(Path.home() / ".claude" / "plugins" / "cache"),
+        help="Root of the Claude plugin cache used to discover installed plugin agents.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    plugin_root = Path(args.plugin_root).resolve() if args.plugin_root else None
+    repo_agents, plugin_agents = discover_available_agents(
+        workspace_root=Path(args.workspace).resolve(),
+        plugin_root=plugin_root,
+        plugin_cache_root=Path(args.plugin_cache_root).resolve(),
+    )
+    print(render_discovery_output(repo_agents, plugin_agents))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/code/tools/python/test_discover_available_agents.py
+++ b/plugins/code/tools/python/test_discover_available_agents.py
@@ -14,6 +14,9 @@ def _write_agent(
     name: str,
     description: str,
     tools: str | None = None,
+    skills: str | None = None,
+    file_patterns: str | None = None,
+    domains: str | None = None,
 ) -> None:
     lines = [
         "---",
@@ -24,6 +27,12 @@ def _write_agent(
     ]
     if tools is not None:
         lines.append(f"tools: {tools}")
+    if skills is not None:
+        lines.append(f"skills: {skills}")
+    if file_patterns is not None:
+        lines.append(f"file_patterns: {file_patterns}")
+    if domains is not None:
+        lines.append(f"domains: {domains}")
     lines.extend(["---", "", "Body"])
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -125,10 +134,18 @@ def test_prefers_current_or_workspace_plugin_agents_over_cached_duplicates(
     )
     rendered = render_discovery_output(repo_agents, plugin_agents)
 
+    payload = json.loads(rendered)
+
     assert repo_agents == []
     assert len(plugin_agents) == 1
     assert plugin_agents[0].description == "Local workspace implementation agent"
-    assert "@code:implementation-subagent | Local workspace implementation agent" in rendered
+    assert plugin_agents[0].trust_source == "workspace-plugin"
+    assert [a["invocation"] for a in payload["plugin_agents"]] == [
+        "code:implementation-subagent"
+    ]
+    assert payload["plugin_agents"][0]["description"] == (
+        "Local workspace implementation agent"
+    )
     assert "Cached implementation agent" not in rendered
 
 
@@ -188,3 +205,55 @@ def test_ignores_non_version_and_manifestless_cache_entries(tmp_path: Path) -> N
     )
 
     assert plugin_agents == []
+
+
+def test_emits_structured_implementation_capability_record(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    plugin_cache_root = tmp_path / "cache"
+
+    # Write-capable but NOT contract-honouring (no implementation-self-check skill).
+    _write_agent(
+        workspace_root / ".claude" / "agents" / "code-reviewer.md",
+        name="code-reviewer",
+        description="Reviews code",
+        tools="Read, Write, Edit",
+        skills="platform:claude-code-expert",
+    )
+    # Contract-honouring implementation agent with file patterns + domains.
+    _write_agent(
+        workspace_root / ".claude" / "agents" / "py-impl.md",
+        name="py-impl",
+        description="Implements Python",
+        tools="Read, Write, Edit, Skill",
+        skills="python-patterns, implementation-self-check",
+        file_patterns="**/*.py, **/test_*.py",
+        domains="python, tooling",
+    )
+    # Contract-honouring agent whose tools are inherited (cannot be classified
+    # from the tools string alone) must still be implementation_capable.
+    _write_agent(
+        workspace_root / ".claude" / "agents" / "inherited-impl.md",
+        name="inherited-impl",
+        description="Implements with inherited tools",
+        skills="implementation-self-check",
+    )
+
+    repo_agents, plugin_agents = discover_available_agents(
+        workspace_root=workspace_root,
+        plugin_root=None,
+        plugin_cache_root=plugin_cache_root,
+    )
+    payload = json.loads(render_discovery_output(repo_agents, plugin_agents))
+
+    by_invocation = {a["invocation"]: a for a in payload["repo_agents"]}
+
+    assert by_invocation["code-reviewer"]["implementation_capable"] is False
+    assert by_invocation["py-impl"]["implementation_capable"] is True
+    assert by_invocation["py-impl"]["file_patterns"] == "**/*.py, **/test_*.py"
+    assert by_invocation["py-impl"]["domains"] == "python, tooling"
+    assert by_invocation["py-impl"]["trust_source"] == "repo"
+    assert by_invocation["py-impl"]["fallback_rank"] == 0
+    # Inherited tools render as "inherited" but the skill marker still classifies
+    # the agent as implementation-capable.
+    assert by_invocation["inherited-impl"]["tools"] == "inherited"
+    assert by_invocation["inherited-impl"]["implementation_capable"] is True

--- a/plugins/code/tools/python/test_discover_available_agents.py
+++ b/plugins/code/tools/python/test_discover_available_agents.py
@@ -1,0 +1,132 @@
+"""Tests for discover_available_agents.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from discover_available_agents import discover_available_agents, render_discovery_output
+
+
+def _write_agent(
+    path: Path,
+    *,
+    name: str,
+    description: str,
+    tools: str | None = None,
+) -> None:
+    lines = [
+        "---",
+        f"name: {name}",
+        f"description: {description}",
+        "model: sonnet",
+        "color: blue",
+    ]
+    if tools is not None:
+        lines.append(f"tools: {tools}")
+    lines.extend(["---", "", "Body"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_plugin(plugin_root: Path, *, plugin_name: str) -> None:
+    manifest_dir = plugin_root / ".claude-plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": plugin_name,
+                "description": f"{plugin_name} plugin",
+                "version": "1.0.0",
+                "author": {"name": "ClosedLoop"},
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_discovers_repo_and_plugin_agents_across_workspace_and_cache(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    plugin_cache_root = tmp_path / "cache"
+
+    _write_agent(
+        workspace_root / ".claude" / "agents" / "repo-agent.md",
+        name="repo-agent",
+        description="Repo specialist",
+        tools="Read, Edit",
+    )
+
+    code_plugin_root = workspace_root / "plugins" / "code"
+    _write_plugin(code_plugin_root, plugin_name="code")
+    _write_agent(
+        code_plugin_root / "agents" / "implementation-subagent.md",
+        name="implementation-subagent",
+        description="General implementation fallback",
+        tools="Read, Write, Edit",
+    )
+
+    cached_plugin_root = plugin_cache_root / "closedloop-ai" / "db" / "1.2.3"
+    _write_plugin(cached_plugin_root, plugin_name="db")
+    _write_agent(
+        cached_plugin_root / "agents" / "schema-helper.md",
+        name="schema-helper",
+        description="Database schema specialist",
+    )
+
+    repo_agents, plugin_agents = discover_available_agents(
+        workspace_root=workspace_root,
+        plugin_root=code_plugin_root,
+        plugin_cache_root=plugin_cache_root,
+    )
+
+    assert [agent.invocation for agent in repo_agents] == ["repo-agent"]
+    assert [agent.invocation for agent in plugin_agents] == [
+        "code:implementation-subagent",
+        "db:schema-helper",
+    ]
+    assert plugin_agents[1].tools == "inherited"
+
+
+def test_prefers_current_or_workspace_plugin_agents_over_cached_duplicates(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    plugin_cache_root = tmp_path / "cache"
+
+    code_plugin_root = workspace_root / "plugins" / "code"
+    _write_plugin(code_plugin_root, plugin_name="code")
+    _write_agent(
+        code_plugin_root / "agents" / "implementation-subagent.md",
+        name="implementation-subagent",
+        description="Local workspace implementation agent",
+        tools="Read, Write, Edit, Skill",
+    )
+    (code_plugin_root / "agents" / "AGENT_FORMAT.md").write_text(
+        "# Not an agent\n", encoding="utf-8"
+    )
+
+    cached_plugin_root = plugin_cache_root / "closedloop-ai" / "code" / "9.9.9"
+    _write_plugin(cached_plugin_root, plugin_name="code")
+    _write_agent(
+        cached_plugin_root / "agents" / "implementation-subagent.md",
+        name="implementation-subagent",
+        description="Cached implementation agent",
+        tools="Read",
+    )
+
+    repo_agents, plugin_agents = discover_available_agents(
+        workspace_root=workspace_root,
+        plugin_root=code_plugin_root,
+        plugin_cache_root=plugin_cache_root,
+    )
+    rendered = render_discovery_output(repo_agents, plugin_agents)
+
+    assert repo_agents == []
+    assert len(plugin_agents) == 1
+    assert plugin_agents[0].description == "Local workspace implementation agent"
+    assert "@code:implementation-subagent | Local workspace implementation agent" in rendered
+    assert "Cached implementation agent" not in rendered

--- a/plugins/code/tools/python/test_discover_available_agents.py
+++ b/plugins/code/tools/python/test_discover_available_agents.py
@@ -130,3 +130,61 @@ def test_prefers_current_or_workspace_plugin_agents_over_cached_duplicates(
     assert plugin_agents[0].description == "Local workspace implementation agent"
     assert "@code:implementation-subagent | Local workspace implementation agent" in rendered
     assert "Cached implementation agent" not in rendered
+
+
+def test_selects_latest_cached_version_and_ignores_stale_versions(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    plugin_cache_root = tmp_path / "cache"
+
+    # Three cached versions of the same plugin; only the highest semver wins.
+    for version, description in (
+        ("1.2.0", "stale schema-helper v1.2.0"),
+        ("1.10.0", "current schema-helper v1.10.0"),
+        ("1.9.0", "stale schema-helper v1.9.0"),
+    ):
+        cached_root = plugin_cache_root / "closedloop-ai" / "db" / version
+        _write_plugin(cached_root, plugin_name="db")
+        _write_agent(
+            cached_root / "agents" / "schema-helper.md",
+            name="schema-helper",
+            description=description,
+        )
+
+    _, plugin_agents = discover_available_agents(
+        workspace_root=workspace_root,
+        plugin_root=None,
+        plugin_cache_root=plugin_cache_root,
+    )
+
+    assert [agent.invocation for agent in plugin_agents] == ["db:schema-helper"]
+    assert plugin_agents[0].description == "current schema-helper v1.10.0"
+
+
+def test_ignores_non_version_and_manifestless_cache_entries(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    plugin_cache_root = tmp_path / "cache"
+
+    # A loose file at the owner level and a non-version directory must be ignored
+    # rather than walked, so discovery is insensitive to junk in the cache tree.
+    (plugin_cache_root / "closedloop-ai").mkdir(parents=True)
+    (plugin_cache_root / "closedloop-ai" / "README.md").write_text(
+        "not a plugin\n", encoding="utf-8"
+    )
+    stray = plugin_cache_root / "closedloop-ai" / "db" / "not-a-version"
+    _write_agent(
+        stray / "agents" / "ghost.md",
+        name="ghost",
+        description="should not be discovered",
+    )
+    # A version dir without a manifest must also be skipped.
+    (plugin_cache_root / "closedloop-ai" / "db" / "2.0.0" / "agents").mkdir(parents=True)
+
+    _, plugin_agents = discover_available_agents(
+        workspace_root=workspace_root,
+        plugin_root=None,
+        plugin_cache_root=plugin_cache_root,
+    )
+
+    assert plugin_agents == []


### PR DESCRIPTION
## Summary

- Orchestrator Phase 3 now **dynamically discovers** all available agents (repo-level + plugin) at runtime and selects the best-fit specialist per implementation task via LLM reasoning
- 7 repo-level agents gain **dual-mode** (critic + implementation) with write-capable tools and the same self-verification gate pattern as `implementation-subagent`
- Phase 5.5 `code_drift` routing also uses dynamic selection instead of hardcoding `implementation-subagent`
- Works automatically with any agent — gStack, custom repo agents, installed plugins — no config changes needed

## Test plan

- [ ] Run `/code:code` on a feature touching Python files — verify orchestrator discovers and selects `python-script-reviewer` over generalist
- [ ] Run `/code:code` on a feature with no specialist match — verify fallback to `implementation-subagent`
- [ ] Install an additional plugin (e.g., gStack) and verify it appears in agent discovery output
- [ ] Verify critic mode still works normally for all 7 updated agents (no regression from added tools)
- [ ] Verify Phase 5.5 code_drift routes to specialists when applicable

Implements [PLN-626](https://app.closedloop.ai/implementation-plans/PLN-626)

🤖 Generated with [Claude Code](https://claude.com/claude-code)