### PR TITLE
chore: CLAUDE.md learnings from PR review (week of 2026-05-22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,13 @@ All commits MUST follow the conventions in `CONTRIBUTING.md`. Specifically:
 
 ### Code Quality
 - **[mistake]**: When modifying behavior, audit adjacent comments and docstrings for accuracy — remove or update references to non-existent files, incomplete field lists, or scope descriptions narrower than actual behavior. (context: comments|docstrings|accuracy)
+- **[mistake]**: Before adding helper logic, grep for adjacent helpers with the same responsibility and delegate instead of duplicating membership checks or fixture factories. (context: duplication|helpers|tests|shell)
+
+### Orchestration & State
+- **[mistake]**: When changing run-loop or self-learning resume/rate-limit logic, preserve persisted state contracts: iteration rows, session IDs, success counts, and terminal statuses. (context: run-loop|resume|state|rate-limit)
+
+### Correctness & Data Invariants
+- **[mistake]**: Guard boundary data before narrowing filters or status checks; failed reads, malformed entries, and defaulted fields can invert success/failure handling. (context: invariants|filters|error-handling)
 
 ### Documentation & Versioning
-- **[mistake]**: Never reference code, APIs, or schema fields that don't exist in the codebase or documented spec. Before writing CHANGELOG "Fixed" or "Replaces" entries, verify the prior implementation exists via grep. Before adding manifest fields, verify they're in the documented schema. (context: changelog|hallucination|verification)
+- **[mistake]**: Never hand-write CHANGELOG entries for plugin changes; when reviewing generated release notes, verify the version heading matches `plugin.json` and every `Fixed`/`Replaces` claim maps to behavior that existed before the PR. (context: changelog|versioning|hallucination|verification)


### PR DESCRIPTION
## Summary
Automated analysis of 17 PRs merged 2026-05-08-2026-05-22.
Processed 25 review comments (25 human, 0 bot).
Identified 4 recurring failure modes for `CLAUDE.md`.

## Feature Flags
None - documentation-only change.

## New Patterns

### CLAUDE.md
- **[mistake]**: Before adding helper logic, grep for adjacent helpers with the same responsibility and delegate instead of duplicating membership checks or fixture factories. (context: duplication|helpers|tests|shell)
  - PR #62 (mikeangstadt): `_base_data` duplicated the existing `make_minimal_data` fixture factory.
  - PR #86 (mikeangstadt): `mark_plugin_failed` duplicated the array-membership loop already in `plugin_failed`.

- **[mistake]**: When changing run-loop or self-learning resume/rate-limit logic, preserve persisted state contracts: iteration rows, session IDs, success counts, and terminal statuses. (context: run-loop|resume|state|rate-limit)
  - PR #73 (shafty023): repeated run rows caused later iterations to be scored with the first logged iteration.
  - PR #74 (shafty023): resumed loops lost successful iteration counts and session IDs at max-iteration exit.
  - PR #79 (peterulsteen): narrowed rate-limit detection dropped terminal non-rejected rate states.

- **[mistake]**: Guard boundary data before narrowing filters or status checks; failed reads, malformed entries, and defaulted fields can invert success/failure handling. (context: invariants|filters|error-handling)
  - PR #62 (mikeangstadt): filtering `openQuestions` called `.get()` on possible non-dict entries.
  - PR #86 (mikeangstadt): failed final plugin-list reads marked every plugin as failed.
  - PR #87 (mikeangstadt): error CaseScores could be included when `error_reason` defaulted to `None`.

## Amended Patterns
- `CLAUDE.md` Documentation & Versioning:
  - Old: Never reference code, APIs, or schema fields that don't exist in the codebase or documented spec. Before writing CHANGELOG "Fixed" or "Replaces" entries, verify the prior implementation exists via grep. Before adding manifest fields, verify they're in the documented schema.
  - New: Never hand-write CHANGELOG entries for plugin changes; when reviewing generated release notes, verify the version heading matches `plugin.json` and every `Fixed`/`Replaces` claim maps to behavior that existed before the PR.
  - PR #85 (mikeangstadt): `CHANGELOG.md` was manually edited despite repo convention.
  - PR #86 (mikeangstadt): the changelog version label did not match `plugin.json`.
  - PR #87 (mikeangstadt): changelog text fabricated a prior implementation.

## Deduplicated
- Test assertion/env isolation - already covered by the Testing pattern about sibling assertion coverage and ambient env vars.
- Misleading comments/docstrings - already covered by the Code Quality pattern about auditing adjacent comments and docstrings.
- Test helper duplication alone - already covered by the Testing helper-extraction pattern; the new Code Quality pattern covers the broader production-helper recurrence.
- Security override routing/audit-log comments - only appeared in PR #88, below the 2-PR frequency threshold.

## Stats
- PRs analyzed: 17
- Comments processed: 25 (25 human, 0 bot)
- New patterns: 3
- Amended patterns: 1
- Deduplicated: 4

## Verification
- Reviewed generated diff.
- Confirmed only `CLAUDE.md` changed.
