### PR TITLE
refactor(code-review): Phase 5 — relocate extract-patches; partition owns per-partition patches (PLN-719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code-review v2.1.0
+
+#### Changed
+- PLN-719 Phase 5 (pipeline reordering): `extract-patches` moves from after-partition to immediately after `parse-diff`. In its new position it produces only `patches_all.txt`, making the full diff available on disk before every downstream stage (hygiene, route, partition, BHB/Auditor/Premise reviewers, plus the plan-05-gated extract-signals + coverage chain). The `--partitions-file` flag is removed from `cmd_extract_patches`.
+- `partition` becomes the canonical producer of `patches_p<N>.txt`. New optional `--diff-scope`, `--cr-dir`, `--workdir` arguments trigger the per-partition `git diff`; when both `--diff-scope` and `--cr-dir` are supplied, partition emits `patches_p0.txt`, `patches_p1.txt`, … alongside `partitions.json`. Without them the call stays a pure partition-assignment helper, preserving backward compat for callers that only want the assignment.
+- `prepare-run` (run_plan.json generator): `stage_17_partition` now passes `--diff-scope` and `--cr-dir`, and its `expected_outputs` list includes `patches_p<N>.txt` alongside `partitions.json`. `stage_06_extract_patches` already matched the new contract.
+- `/start` command rewires Task 5 to call `extract-patches` right after `parse-diff` and Task 8 to call `partition` with the new patch-generation args. The "Pre-Extract Patches to Disk" section is renamed and explicitly documents the two-stage materialization.
+
 ### code-review v2.0.0
 
 #### Added

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -16,7 +16,7 @@ A multi-agent code review plugin for Claude Code that performs deep, partitioned
 
 ```
 plugins/code-review/
-  .claude-plugin/plugin.json         Plugin manifest (version 2.0.0)
+  .claude-plugin/plugin.json         Plugin manifest (version 2.1.0)
   SCHEMA.md                          Canonical Finding + ResultEnvelope schema (PLN-719)
   commands/
     start.md                         Main /start command (orchestrator)
@@ -125,17 +125,19 @@ The orchestrator executes these steps in order:
 1. **Parse flags and detect mode** — resolves `MODE` (local/github), `HYGIENE_ONLY`, `BASE_REF_OVERRIDE`, `SINCE_LAST_REVIEW`, `FULL_REVIEW`
 2. **Session setup** — resolves the helpers path, creates a session-scoped working directory (`.closedloop-ai/code-review/cr-<random>/`), and runs `setup` subcommand to capture `start_time`, `repo_name`, and `global_cache`
 3. **Parse scope and get diff data** — runs `parse-diff` subcommand to execute all git diff commands and produce a structured JSON blob with file statuses, LOC counts, changed line ranges, and patch content
-4. **Compute prompt hash and cache check** (if caching is active) — hashes the shared prompt and reviewer suffix, then checks the content-addressed cache for a prior result on this exact diff tip
-5. **Deterministic hygiene checks** — pattern-match for CI artifacts, sensitive files (`.env`, `.pem`), and path leakage; if `--hygiene-only`, stop here
-6. **Risk scoring and model routing** — scores each file by risk factors (LOC, file type, complexity); routes high-risk partitions to stronger models
-7. **File partitioning** — bin-packs files into agent-sized partitions balanced by LOC
-8. **Patch pre-extraction** — extracts diff patches to disk so reviewer agents can read them without Bash access
+4. **Materialize full-diff patches** — runs `extract-patches` immediately after `parse-diff` to write the consolidated `patches_all.txt` so downstream stages (and reviewer agents) can read the diff without Bash access
+5. **Compute prompt hash and cache check** (if caching is active) — hashes the shared prompt and reviewer suffix, then checks the content-addressed cache for a prior result on this exact diff tip
+6. **Deterministic hygiene checks** — pattern-match for CI artifacts, sensitive files (`.env`, `.pem`), and path leakage; if `--hygiene-only`, stop here
+7. **Risk scoring and model routing** — scores each file by risk factors (LOC, file type, complexity); routes high-risk partitions to stronger models
+8. **File partitioning and per-partition patches** — bin-packs files into agent-sized partitions balanced by LOC; when invoked with `--diff-scope` and `--cr-dir`, `partition` also writes the per-partition `patches_p<N>.txt` files alongside `partitions.json`
 9. **Spawn reviewer agents in parallel** — launches one `code:code-review-worker` sub-agent per partition; all run concurrently with `run_in_background: true`
 10. **Collect and validate findings** — collects all agent outputs, merges with hygiene findings, runs the `validate` subcommand (normalize severity, filter low-confidence, deduplicate, validate line numbers)
 11. **Cache update** (if caching is active) — writes validated findings to the cache for future incremental runs
 12. **Present results** — local mode: prints findings by severity in the terminal; GitHub mode: writes `.closedloop-ai/code-review-findings.json`, `.closedloop-ai/code-review-threads.json`, and `.closedloop-ai/code-review-summary.md` for the CI workflow to post
 13. **Review state write** — persists the current diff tip so future `--since-last-review` runs can narrow the scope
 14. **Footer** — prints elapsed time, token usage stats, and a deterministic `<pr_verdict>` tag
+
+(Step numbers in this list are illustrative; the canonical 30-stage ordering lives in `prepare-run`'s `run_plan.json`.)
 
 ## Helper CLI (`code_review_helpers.py`)
 
@@ -146,7 +148,7 @@ The helper script is a multi-subcommand Python CLI. The orchestrator invokes it 
 | `setup` | Emits start time, repo name, branch, and global cache flag as JSON |
 | `parse-diff` | Runs git diff commands and produces structured JSON with file statuses, LOC, ranges, and patch lines |
 | `hygiene` | Pattern-matches diff data for CI artifacts, sensitive files, and path leakage; emits findings JSON |
-| `partition` | Bin-packs files into agent-sized partitions balanced by LOC |
+| `partition` | Bin-packs files into agent-sized partitions balanced by LOC; when `--diff-scope` and `--cr-dir` are passed it also writes per-partition `patches_p<N>.txt` files alongside `partitions.json` (PLN-719 Phase 5) |
 | `route` | Computes risk scores and emits model routing decisions per partition |
 | `validate` | Normalizes severity, filters low-confidence findings, deduplicates via Jaccard similarity, validates line numbers |
 | `compute-hashes` | Computes `PROMPT_HASH` and `CONTEXT_KEY` from shared prompt and diff tip |
@@ -166,7 +168,7 @@ The helper script is a multi-subcommand Python CLI. The orchestrator invokes it 
 | `collect-findings` | Merges agent findings with hygiene findings into a single list |
 | `verdict` | Computes the PR verdict (APPROVED / NEEDS_ATTENTION / CHANGES_REQUESTED) from validated findings |
 | `prep-assets` | Copies prompt assets from the plugin root into the session CR_DIR |
-| `extract-patches` | Extracts git diff patches to per-file disk files for reviewer agents to read |
+| `extract-patches` | Materializes the full-diff `patches_all.txt` immediately after `parse-diff`; per-partition patches are now produced by `partition` (PLN-719 Phase 5) |
 | `finalize-result` | Consolidates validated findings + coverage state + verdict into the canonical `review_result.json` envelope (PLN-719) |
 | `arbitrate-budget` | Applies the canonical reviewer cap policy; emits coverage gaps for required reviewers that overflow (PLN-719) |
 | `prepare-run` | Emits a declarative `run_plan.json` describing the 30-stage pipeline (PLN-719) |

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -74,9 +74,10 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 - If `PR_AUTO_DETECTED` is true, print `"Auto-detected PR #<PR_NUMBER> for branch <REVIEW_BRANCH>."`
 - See: [Auto Incremental Mode](#auto-incremental-mode-phase-4--local-only)
 
-### Task 5: Get diff data + fetch intent (GitHub: also get PR metadata)
+### Task 5: Get diff data + extract patches + fetch intent (GitHub: also get PR metadata)
 - GitHub mode: follow PR Metadata section from `github-review.md`
 - Run Bash: `python3 <HELPERS> parse-diff --scope=<DIFF_SCOPE> > <CR_DIR>/diff_data.json`
+- Run Bash: `python3 <HELPERS> extract-patches --diff-scope=<DIFF_SCOPE> --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>` (PLN-719 Phase 5: produces `patches_all.txt` right after `parse-diff`; per-partition patches are emitted later by `partition`)
 - Run Bash: `python3 <HELPERS> fetch-intent --scope-kind <SCOPE_KIND> --cr-dir <CR_DIR> [--pr-number <N>] [--base-ref <BASE_REF>] [--diff-tip <DIFF_TIP>]`
 - Run Bash: `python3 <HELPERS> classify-intent --intent-context <CR_DIR>/intent_context.json --diff-data <CR_DIR>/diff_data.json > <CR_DIR>/intent.json`
 - Read `<CR_DIR>/intent.json` for `INTENT` value
@@ -100,19 +101,17 @@ Throughout this document, bash code blocks use `<ANGLE_BRACKET>` placeholders (e
 - **If HYGIENE_ONLY**: if `CACHE_DIR` is set and `CACHE_STATUS_MESSAGE` is non-empty, print `CACHE_STATUS_MESSAGE`. Then present hygiene findings and EXIT — skip all remaining tasks
 - See: [Step 2.5](#step-25-deterministic-hygiene-checks)
 
-### Task 8: Route models + partition + extract patches
+### Task 8: Route models + partition
 - Mark todo "Assess scope and route models" as `in_progress`
 - Run Bash: `python3 <HELPERS> route --diff-data <CR_DIR>/diff_data.json --critic-gates .closedloop-ai/settings/critic-gates.json --intent <INTENT> > <CR_DIR>/route.json`
 - Read `<CR_DIR>/route.json` for `models`, `domain_critics`, `max_bha_agents`, `fast_path`
 - **If `fast_path` is false (standard flow):**
   - Print `CACHE_STATUS_MESSAGE` if non-empty
-  - Run Bash: `python3 <HELPERS> partition --diff-data <CR_DIR>/diff_data.json --loc-budget 500 --max-files 25 --max-bha-agents <MAX_BHA_AGENTS> > <CR_DIR>/partitions.json` (use `uncached_diff_data.json` when caching is active)
-  - Run Bash: `python3 <HELPERS> extract-patches --partitions-file <CR_DIR>/partitions.json --diff-scope=<DIFF_SCOPE> --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>`
+  - Run Bash: `python3 <HELPERS> partition --diff-data <CR_DIR>/diff_data.json --loc-budget 500 --max-files 25 --max-bha-agents <MAX_BHA_AGENTS> --diff-scope=<DIFF_SCOPE> --cr-dir <CR_DIR> > <CR_DIR>/partitions.json` (PLN-719 Phase 5: partition now also writes `patches_p<N>.txt` for each partition. Use `uncached_diff_data.json` for `--diff-data` when caching is active.)
 - **If `fast_path` is true:**
   - Print `"Fast path selected: 1 reviewer (<MODEL>)."` where `<MODEL>` = `route.json -> models.fast_path_reviewer`
   - If `CACHE_DIR` is set, print `"BHA Cache: bypassed in fast-path mode."` and delete `<CR_DIR>/agent_cached_bha.json` if it exists
-  - Skip partition entirely (no `partitions.json` created)
-  - Run Bash: `python3 <HELPERS> extract-patches --diff-scope=<DIFF_SCOPE> --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>` (no `--partitions-file` -- only `patches_all.txt` is created)
+  - Skip partition entirely (no `partitions.json` or `patches_p<N>.txt` created; reviewers consume `patches_all.txt` already produced in Task 5)
   - Update TodoWrite: replace "Spawn reviewer agents in parallel" with "Run fast-path review"
 - Mark todo as `completed`
 - See: [Step 3](#step-3-assess-scope-and-route-models), [Step 4A](#step-4a-spawn-reviewer-agents-fast_path--false), [Step 4B](#step-4b-fast-path-single-agent-review-fast_path--true)
@@ -371,6 +370,16 @@ Read `<CR_DIR>/diff_data.json` with the Read tool and extract only the lightweig
 
 Use these values for `total_loc` and file count reporting. The full diff data (including `patch_lines` and `changed_ranges`) remains in `<CR_DIR>/diff_data.json` for downstream scripts.
 
+### Extract Full-Diff Patch (Both Modes)
+
+Immediately after `parse-diff`, materialize the full-diff patch file so every downstream stage (hygiene, route, partition, BHB/Auditor/Premise reviewers) has it on disk:
+
+```bash
+python3 <HELPERS> extract-patches --diff-scope=<DIFF_SCOPE> --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>
+```
+
+This produces `patches_all.txt` only. Per-partition patches (`patches_p<N>.txt`) are written later by the `partition` subcommand (PLN-719 Phase 5).
+
 Mark todo as `completed`.
 
 ### Fetch Intent Context + Classify Intent (for Premise Reviewer)
@@ -579,15 +588,14 @@ The script performs greedy bin-packing (sorted by LOC descending), splits oversi
 
 When constructing agent prompts, read each entry's `file` field for the path. Do NOT run ad-hoc Python one-liners against `partitions.json` — use the Read tool, then map `entry["file"]` directly into the prompt template.
 
-### Pre-Extract Patches to Disk (CRITICAL -- eliminates sub-agent Bash dependency)
+### Per-Partition Patches on Disk (CRITICAL -- eliminates sub-agent Bash dependency)
 
-After partitioning, extract patches to disk files so agents can Read them without needing Bash permissions. Run this BEFORE spawning any agents:
+PLN-719 Phase 5 splits patch materialization across two stages so the full diff is available immediately after `parse-diff` and per-partition patches are produced together with the partition assignment:
 
-```bash
-python3 <HELPERS> extract-patches --partitions-file <CR_DIR>/partitions.json --diff-scope=<DIFF_SCOPE> --diff-data <CR_DIR>/diff_data.json --cr-dir <CR_DIR>
-```
+- `patches_all.txt` — produced by **Task 5** (`extract-patches`, right after `parse-diff`). Always present before any agents spawn.
+- `patches_p{N}.txt` — produced by **Task 8** (`partition`, when both `--diff-scope` and `--cr-dir` are passed). One file per partition.
 
-This creates `patches_p{N}.txt` (one per partition) and `patches_all.txt` (full diff from all files in `diff_data.json`). When caching is active, partitions contain only uncached files, but `patches_all.txt` includes ALL files since BHB/Auditor/Premise review the full diff.
+When caching is active, the partition call uses `uncached_diff_data.json` so partitions contain only uncached files, but `patches_all.txt` (from Task 5) still includes ALL files since BHB/Auditor/Premise review the full diff.
 
 If a partition file entry has `line_range`, include that range in `<files_assigned>` for the agent and treat it as a hard scope fence.
 

--- a/plugins/code-review/tools/python/code_review_helpers.py
+++ b/plugins/code-review/tools/python/code_review_helpers.py
@@ -697,6 +697,41 @@ def cmd_hygiene(args: argparse.Namespace) -> int:
 # Subcommand: partition
 # ---------------------------------------------------------------------------
 
+
+def _write_per_partition_patches(
+    partitions: list[dict[str, Any]],
+    diff_scope: str,
+    cr_dir: Path,
+    workdir: str | None = None,
+) -> list[str]:
+    """Write ``patches_p<N>.txt`` for each partition and return their filenames.
+
+    PLN-719 Phase 5 makes the ``partition`` helper the canonical producer of
+    per-partition patch files (previously emitted by ``extract-patches``).
+    Strips any embedded pathspec (``-- file1 file2``) from ``diff_scope`` since
+    we always supply our own explicit file list.
+    """
+    run_kwargs: dict[str, Any] = {"capture_output": False, "text": True, "check": False}
+    if workdir:
+        run_kwargs["cwd"] = workdir
+
+    range_scope = diff_scope.split(" -- ")[0] if " -- " in diff_scope else diff_scope
+    range_parts = range_scope.split()
+
+    written: list[str] = []
+    for part in partitions:
+        part_id = part["id"]
+        files_in_part = [entry["file"] for entry in part.get("files", [])]
+        patch_name = f"patches_p{part_id}.txt"
+        patch_path = cr_dir / patch_name
+
+        cmd = ["git", "diff"] + range_parts + ["--"] + files_in_part
+        with open(patch_path, "w") as out:
+            subprocess.run(cmd, stdout=out, stderr=subprocess.DEVNULL, **run_kwargs)
+        written.append(patch_name)
+    return written
+
+
 def cmd_partition(args: argparse.Namespace) -> int:
     """Execute partition subcommand."""
     diff_data_path: str | None = getattr(args, "diff_data", None)
@@ -929,11 +964,27 @@ def cmd_partition(args: argparse.Namespace) -> int:
     for idx, part in enumerate(partitions):
         part["id"] = idx
 
-    json.dump(
-        {"partitions": partitions, "test_file_paths": test_file_paths, "force_merged_count": force_merged_count},
-        sys.stdout,
-        indent=2,
-    )
+    # PLN-719 Phase 5: partition is now the canonical producer of
+    # patches_p<N>.txt. Materialize per-partition patches when both
+    # --diff-scope and --cr-dir are provided.
+    diff_scope: str | None = getattr(args, "diff_scope", None)
+    cr_dir_arg: str | None = getattr(args, "cr_dir", None)
+    workdir: str | None = getattr(args, "workdir", None)
+    partition_patches: list[str] = []
+    if diff_scope and cr_dir_arg:
+        partition_patches = _write_per_partition_patches(
+            partitions, diff_scope, Path(cr_dir_arg), workdir,
+        )
+
+    output: dict[str, Any] = {
+        "partitions": partitions,
+        "test_file_paths": test_file_paths,
+        "force_merged_count": force_merged_count,
+    }
+    if partition_patches:
+        output["partition_patches"] = partition_patches
+
+    json.dump(output, sys.stdout, indent=2)
     sys.stdout.write("\n")
     return 0
 
@@ -3814,9 +3865,20 @@ def _build_run_plan_stages(
             "id": "stage_17_partition",
             "kind": "helper",
             "subcommand": "partition",
-            "args": ["--diff-data", f"{cr_dir}/diff_data.json"],
+            "args": [
+                "--diff-data", f"{cr_dir}/diff_data.json",
+                "--diff-scope", "<DIFF_SCOPE>",
+                "--cr-dir", cr_dir,
+            ],
             "stdout": f"{cr_dir}/partitions.json",
-            "expected_outputs": [f"{cr_dir}/partitions.json"],
+            # PLN-719 Phase 5: partition is the canonical producer of
+            # patches_p<N>.txt (previously emitted by extract-patches). The
+            # exact count is determined at runtime, so the glob pattern is
+            # an expected output template.
+            "expected_outputs": [
+                f"{cr_dir}/partitions.json",
+                f"{cr_dir}/patches_p<N>.txt",
+            ],
             # Actual data dependency is diff_data.json (stage_05_parse_diff).
             # stage_16_arbitrate_budget is plan-05-gated and disabled in Phase
             # A; depending on a disabled stage would make this foundation
@@ -4569,23 +4631,19 @@ _EXTRACT_PATCHES_BATCH_THRESHOLD = 200
 
 
 def cmd_extract_patches(args: argparse.Namespace) -> int:
-    """Extract git diff patches to disk files for each partition and full diff."""
-    partitions_file = args.partitions_file
+    """Materialize ``patches_all.txt`` from the full diff.
+
+    PLN-719 Phase 5 relocates this stage to run right after ``parse-diff``,
+    well before partitioning. It now produces only the full-diff artifact;
+    per-partition patches (``patches_p<N>.txt``) are emitted by the
+    ``partition`` subcommand.
+    """
     diff_scope: str = args.diff_scope
     cr_dir = Path(args.cr_dir)
     diff_data_path: str = args.diff_data
     workdir: str | None = getattr(args, "workdir", None)
     batch_size: int = getattr(args, "batch_size", _EXTRACT_PATCHES_BATCH_SIZE)
 
-    # Read partitions for per-partition patches
-    if partitions_file is not None:
-        with open(partitions_file) as f:
-            pdata = json.load(f)
-        partitions: list[dict[str, Any]] = pdata.get("partitions", [])
-    else:
-        partitions = []
-
-    # Read full diff_data for patches_all.txt (includes cached files too)
     with open(diff_data_path) as f:
         diff_data = json.load(f)
     all_files: list[str] = diff_data.get("files_to_review", [])
@@ -4598,25 +4656,10 @@ def cmd_extract_patches(args: argparse.Namespace) -> int:
     range_scope = diff_scope.split(" -- ")[0] if " -- " in diff_scope else diff_scope
     range_parts = range_scope.split()
 
-    # Per-partition patches
-    partition_patches: list[str] = []
-    for part in partitions:
-        part_id = part["id"]
-        files_in_part = [entry["file"] for entry in part.get("files", [])]
-        patch_name = f"patches_p{part_id}.txt"
-        patch_path = cr_dir / patch_name
-
-        cmd = ["git", "diff"] + range_parts + ["--"] + files_in_part
-        with open(patch_path, "w") as out:
-            subprocess.run(cmd, stdout=out, stderr=subprocess.DEVNULL, **run_kwargs)
-        partition_patches.append(patch_name)
-
-    # Full diff (for BHB, Auditor, Premise, Domain Critic)
     full_patch_name = "patches_all.txt"
     full_patch_path = cr_dir / full_patch_name
 
     if len(all_files) > _EXTRACT_PATCHES_BATCH_THRESHOLD:
-        # Batch extraction
         first_batch = True
         for i in range(0, len(all_files), batch_size):
             batch_files = all_files[i : i + batch_size]
@@ -4632,11 +4675,7 @@ def cmd_extract_patches(args: argparse.Namespace) -> int:
         with open(full_patch_path, "w") as out:
             subprocess.run(cmd, stdout=out, stderr=subprocess.DEVNULL, **run_kwargs)
 
-    json.dump(
-        {"partition_patches": partition_patches, "full_patch": full_patch_name},
-        sys.stdout,
-        indent=2,
-    )
+    json.dump({"full_patch": full_patch_name}, sys.stdout, indent=2)
     sys.stdout.write("\n")
     return 0
 
@@ -4666,6 +4705,13 @@ def _register_subparsers(subparsers: argparse._SubParsersAction) -> None:  # typ
     p_part.add_argument("--loc-budget", type=int, default=400, help="LOC budget per partition")
     p_part.add_argument("--max-files", type=int, default=20, help="Max files per partition")
     p_part.add_argument("--max-bha-agents", type=int, default=DEFAULT_MAX_BHA_AGENTS, help="Max BHA agent partitions (cap enforcement)")
+    # PLN-719 Phase 5: partition is the canonical producer of patches_p<N>.txt.
+    # When both --diff-scope and --cr-dir are supplied, partition writes them
+    # alongside partitions.json. Optional for backward compat with callers
+    # that only want the partition assignment.
+    p_part.add_argument("--diff-scope", default=None, help="Git diff scope for per-partition patch generation")
+    p_part.add_argument("--cr-dir", default=None, help="Directory to write patches_p<N>.txt into")
+    p_part.add_argument("--workdir", default=None, help="Git working directory")
     p_part.set_defaults(func=cmd_partition)
 
     # route
@@ -4874,7 +4920,8 @@ def _register_subparsers(subparsers: argparse._SubParsersAction) -> None:  # typ
 
     # extract-patches
     p_ep = subparsers.add_parser("extract-patches", help="Extract git diff patches to disk files")
-    p_ep.add_argument("--partitions-file", default=None, help="Path to partitions.json")
+    # PLN-719 Phase 5: --partitions-file removed; per-partition patches are
+    # emitted by the partition subcommand.
     p_ep.add_argument("--diff-scope", required=True, help="Git diff scope string")
     p_ep.add_argument("--diff-data", required=True, help="Path to full diff_data.json (for patches_all.txt)")
     p_ep.add_argument("--cr-dir", required=True, help="Output directory for patch files")

--- a/plugins/code-review/tools/python/code_review_helpers.py
+++ b/plugins/code-review/tools/python/code_review_helpers.py
@@ -725,6 +725,16 @@ def _write_per_partition_patches(
         patch_name = f"patches_p{part_id}.txt"
         patch_path = cr_dir / patch_name
 
+        # Guard against empty files lists: `git diff <range> --` with no
+        # pathspec is an unrestricted diff of every changed file, which would
+        # silently fold the entire diff into this partition's patch. Mirror
+        # the guard previously used in cmd_extract_patches: when a partition
+        # somehow has no files, write an empty patch and skip the git call.
+        if not files_in_part:
+            patch_path.write_text("")
+            written.append(patch_name)
+            continue
+
         cmd = ["git", "diff"] + range_parts + ["--"] + files_in_part
         with open(patch_path, "w") as out:
             subprocess.run(cmd, stdout=out, stderr=subprocess.DEVNULL, **run_kwargs)

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -4573,30 +4573,37 @@ class TestSetupCrDir:
 
 
 class TestExtractPatches:
-    def test_creates_partition_and_full_files(self, tmp_path: Path) -> None:
+    """PLN-719 Phase 5: extract-patches produces only patches_all.txt.
+
+    Per-partition patches are now emitted by the ``partition`` subcommand
+    (see TestPartitionPatches below).
+    """
+
+    def _ns(self, tmp_path: Path, diff_scope: str = "main...HEAD") -> Any:
         import argparse
+
+        cr_dir = tmp_path / "cr"
+        cr_dir.mkdir(exist_ok=True)
+        diff_data_file = tmp_path / "diff_data.json"
+        return argparse.Namespace(
+            diff_scope=diff_scope,
+            diff_data=str(diff_data_file),
+            cr_dir=str(cr_dir),
+            workdir=None,
+            batch_size=50,
+        ), cr_dir, diff_data_file
+
+    def test_writes_full_patch_only(self, tmp_path: Path) -> None:
         import io
         import sys as _sys
         from unittest.mock import patch as mock_patch
 
         from code_review_helpers import cmd_extract_patches
 
-        cr_dir = tmp_path / "cr"
-        cr_dir.mkdir()
-
-        partitions_data = {"partitions": [
-            {"id": 0, "files": [{"file": "a.ts"}]},
-            {"id": 1, "files": [{"file": "b.ts"}]},
-        ]}
-        partitions_file = tmp_path / "partitions.json"
-        partitions_file.write_text(json.dumps(partitions_data))
-
-        diff_data = {"files_to_review": ["a.ts", "b.ts", "c.ts"]}
-        diff_data_file = tmp_path / "diff_data.json"
-        diff_data_file.write_text(json.dumps(diff_data))
+        ns, cr_dir, diff_data_file = self._ns(tmp_path)
+        diff_data_file.write_text(json.dumps({"files_to_review": ["a.ts", "b.ts"]}))
 
         def mock_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
-            # Write something to stdout if it was redirected
             stdout = kwargs.get("stdout")
             if stdout and hasattr(stdout, "write"):
                 stdout.write(f"diff output for {' '.join(cmd)}\n")
@@ -4606,41 +4613,26 @@ class TestExtractPatches:
         _sys.stdout = io.StringIO()
         try:
             with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
-                ns = argparse.Namespace(
-                    partitions_file=str(partitions_file), diff_scope="main...HEAD",
-                    diff_data=str(diff_data_file), cr_dir=str(cr_dir),
-                    workdir=None, batch_size=50,
-                )
                 cmd_extract_patches(ns)
                 _sys.stdout.seek(0)
                 result = json.load(_sys.stdout)
         finally:
             _sys.stdout = old_stdout
 
-        assert "patches_p0.txt" in result["partition_patches"]
-        assert "patches_p1.txt" in result["partition_patches"]
-        assert result["full_patch"] == "patches_all.txt"
-        assert (cr_dir / "patches_p0.txt").exists()
+        assert result == {"full_patch": "patches_all.txt"}
         assert (cr_dir / "patches_all.txt").exists()
+        # extract-patches no longer touches per-partition files at all.
+        assert not list(cr_dir.glob("patches_p*.txt"))
 
     def test_strips_pathspec_from_scope(self, tmp_path: Path) -> None:
-        import argparse
         import io
         import sys as _sys
         from unittest.mock import patch as mock_patch
 
         from code_review_helpers import cmd_extract_patches
 
-        cr_dir = tmp_path / "cr"
-        cr_dir.mkdir()
-
-        partitions_data = {"partitions": [{"id": 0, "files": [{"file": "a.ts"}]}]}
-        partitions_file = tmp_path / "partitions.json"
-        partitions_file.write_text(json.dumps(partitions_data))
-
-        diff_data = {"files_to_review": ["a.ts"]}
-        diff_data_file = tmp_path / "diff_data.json"
-        diff_data_file.write_text(json.dumps(diff_data))
+        ns, _, diff_data_file = self._ns(tmp_path, diff_scope="main...HEAD -- a.ts b.ts")
+        diff_data_file.write_text(json.dumps({"files_to_review": ["a.ts"]}))
 
         captured_cmds: list[list[str]] = []
 
@@ -4655,36 +4647,22 @@ class TestExtractPatches:
         _sys.stdout = io.StringIO()
         try:
             with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
-                ns = argparse.Namespace(
-                    partitions_file=str(partitions_file),
-                    diff_scope="main...HEAD -- a.ts b.ts",  # pathspec embedded
-                    diff_data=str(diff_data_file), cr_dir=str(cr_dir),
-                    workdir=None, batch_size=50,
-                )
                 cmd_extract_patches(ns)
         finally:
             _sys.stdout = old_stdout
 
-        # Verify no double -- in any command
         for cmd in captured_cmds:
-            separator_count = cmd.count("--")
-            assert separator_count <= 1, f"Double pathspec separator in: {cmd}"
+            assert cmd.count("--") <= 1, f"Double pathspec separator in: {cmd}"
 
-    def test_full_diff_uses_diff_data_not_partitions(self, tmp_path: Path) -> None:
-        import argparse
+    def test_full_diff_uses_all_files_from_diff_data(self, tmp_path: Path) -> None:
         import io
         import sys as _sys
         from unittest.mock import patch as mock_patch
 
         from code_review_helpers import cmd_extract_patches
 
-        cr_dir = tmp_path / "cr"
-        cr_dir.mkdir()
-
-        # Partitions only have 1 file (uncached), but diff_data has 3 (full set)
-        partitions_data = {"partitions": [{"id": 0, "files": [{"file": "a.ts"}]}]}
-        (tmp_path / "partitions.json").write_text(json.dumps(partitions_data))
-        (tmp_path / "diff_data.json").write_text(json.dumps({"files_to_review": ["a.ts", "b.ts", "c.ts"]}))
+        ns, _, diff_data_file = self._ns(tmp_path)
+        diff_data_file.write_text(json.dumps({"files_to_review": ["a.ts", "b.ts", "c.ts"]}))
 
         captured_cmds: list[list[str]] = []
 
@@ -4699,37 +4677,24 @@ class TestExtractPatches:
         _sys.stdout = io.StringIO()
         try:
             with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
-                ns = argparse.Namespace(
-                    partitions_file=str(tmp_path / "partitions.json"), diff_scope="main...HEAD",
-                    diff_data=str(tmp_path / "diff_data.json"), cr_dir=str(cr_dir),
-                    workdir=None, batch_size=50,
-                )
                 cmd_extract_patches(ns)
         finally:
             _sys.stdout = old_stdout
 
-        # The full-diff command (last one) should include all 3 files from diff_data
-        full_diff_cmd = captured_cmds[-1]
-        assert "a.ts" in full_diff_cmd
-        assert "b.ts" in full_diff_cmd
-        assert "c.ts" in full_diff_cmd
+        assert len(captured_cmds) == 1
+        for f in ("a.ts", "b.ts", "c.ts"):
+            assert f in captured_cmds[0]
 
     def test_batches_large_diffs(self, tmp_path: Path) -> None:
-        import argparse
         import io
         import sys as _sys
         from unittest.mock import patch as mock_patch
 
         from code_review_helpers import cmd_extract_patches
 
-        cr_dir = tmp_path / "cr"
-        cr_dir.mkdir()
-
-        # 250 files -- above the 200 threshold
+        ns, _, diff_data_file = self._ns(tmp_path)
         all_files = [f"f{i}.ts" for i in range(250)]
-        partitions_data = {"partitions": [{"id": 0, "files": [{"file": all_files[0]}]}]}
-        (tmp_path / "partitions.json").write_text(json.dumps(partitions_data))
-        (tmp_path / "diff_data.json").write_text(json.dumps({"files_to_review": all_files}))
+        diff_data_file.write_text(json.dumps({"files_to_review": all_files}))
 
         captured_cmds: list[list[str]] = []
 
@@ -4744,61 +4709,126 @@ class TestExtractPatches:
         _sys.stdout = io.StringIO()
         try:
             with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
-                ns = argparse.Namespace(
-                    partitions_file=str(tmp_path / "partitions.json"), diff_scope="main...HEAD",
-                    diff_data=str(tmp_path / "diff_data.json"), cr_dir=str(cr_dir),
-                    workdir=None, batch_size=50,
-                )
                 cmd_extract_patches(ns)
         finally:
             _sys.stdout = old_stdout
 
-        # 1 partition cmd + 5 batched full-diff cmds (250 / 50 = 5)
-        full_diff_cmds = [c for c in captured_cmds if "patches_p" not in " ".join(str(x) for x in c)]
-        # Should be multiple batches (>1 command for the full diff)
-        assert len(full_diff_cmds) >= 5
+        # 250 files / 50 batch_size = 5 git diff invocations.
+        assert len(captured_cmds) == 5
 
-    def test_extract_patches_no_partitions_file(self, tmp_path: Path) -> None:
+
+class TestPartitionPatches:
+    """PLN-719 Phase 5: partition writes patches_p<N>.txt for each partition
+    when both --diff-scope and --cr-dir are supplied."""
+
+    def _run(self, tmp_path: Path, *, with_patches: bool) -> tuple[dict[str, Any], list[list[str]]]:
         import argparse
         import io
         import sys as _sys
         from unittest.mock import patch as mock_patch
 
-        from code_review_helpers import cmd_extract_patches
+        from code_review_helpers import cmd_partition
 
-        cr_dir = tmp_path / "cr"
-        cr_dir.mkdir()
+        diff_data = _make_diff_data(
+            files=["a.ts", "b.ts", "c.ts"],
+            loc={
+                "a.ts": {"added": 60, "removed": 10},
+                "b.ts": {"added": 50, "removed": 5},
+                "c.ts": {"added": 30, "removed": 5},
+            },
+        )
 
-        diff_data = {"files_to_review": ["a.ts", "b.ts"]}
-        diff_data_file = tmp_path / "diff_data.json"
-        diff_data_file.write_text(json.dumps(diff_data))
+        captured_cmds: list[list[str]] = []
 
         def mock_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+            captured_cmds.append(cmd)
             stdout = kwargs.get("stdout")
             if stdout and hasattr(stdout, "write"):
-                stdout.write(f"diff output for {' '.join(cmd)}\n")
+                stdout.write("")
             return subprocess.CompletedProcess(args=cmd, returncode=0)
 
+        old_stdin = _sys.stdin
         old_stdout = _sys.stdout
+        _sys.stdin = io.StringIO(json.dumps(diff_data))
         _sys.stdout = io.StringIO()
         try:
+            kwargs: dict[str, Any] = dict(
+                loc_budget=400, max_files=20, max_bha_agents=DEFAULT_MAX_BHA_AGENTS,
+                diff_data=None, workdir=None,
+            )
+            if with_patches:
+                kwargs["diff_scope"] = "main...HEAD"
+                kwargs["cr_dir"] = str(tmp_path)
+            else:
+                kwargs["diff_scope"] = None
+                kwargs["cr_dir"] = None
+            ns = argparse.Namespace(**kwargs)
             with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
-                ns = argparse.Namespace(
-                    partitions_file=None, diff_scope="main...HEAD",
-                    diff_data=str(diff_data_file), cr_dir=str(cr_dir),
-                    workdir=None, batch_size=50,
-                )
-                cmd_extract_patches(ns)
-                _sys.stdout.seek(0)
-                result = json.load(_sys.stdout)
+                cmd_partition(ns)
+            _sys.stdout.seek(0)
+            return json.load(_sys.stdout), captured_cmds
         finally:
+            _sys.stdin = old_stdin
             _sys.stdout = old_stdout
 
-        assert result["partition_patches"] == []
-        assert result["full_patch"] == "patches_all.txt"
-        assert (cr_dir / "patches_all.txt").exists()
-        # No partition patch files should exist
-        assert not list(cr_dir.glob("patches_p*.txt"))
+    def test_partition_writes_per_partition_patches(self, tmp_path: Path) -> None:
+        result, captured = self._run(tmp_path, with_patches=True)
+        # All files fit in one partition.
+        assert len(result["partitions"]) == 1
+        assert result["partition_patches"] == ["patches_p0.txt"]
+        assert (tmp_path / "patches_p0.txt").exists()
+        # One git diff invocation per partition.
+        assert len(captured) == 1
+        assert captured[0][:2] == ["git", "diff"]
+        for f in ("a.ts", "b.ts", "c.ts"):
+            assert f in captured[0]
+
+    def test_partition_skips_patches_without_diff_scope(self, tmp_path: Path) -> None:
+        result, captured = self._run(tmp_path, with_patches=False)
+        # Backward compatible: no diff_scope → no patch generation.
+        assert "partition_patches" not in result
+        assert captured == []
+        assert not list(tmp_path.glob("patches_p*.txt"))
+
+    def test_partition_strips_pathspec_from_diff_scope(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+        from unittest.mock import patch as mock_patch
+
+        from code_review_helpers import cmd_partition
+
+        diff_data = _make_diff_data(
+            files=["a.ts"], loc={"a.ts": {"added": 10, "removed": 0}},
+        )
+        captured_cmds: list[list[str]] = []
+
+        def mock_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+            captured_cmds.append(cmd)
+            stdout = kwargs.get("stdout")
+            if stdout and hasattr(stdout, "write"):
+                stdout.write("")
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        old_stdin = _sys.stdin
+        old_stdout = _sys.stdout
+        _sys.stdin = io.StringIO(json.dumps(diff_data))
+        _sys.stdout = io.StringIO()
+        try:
+            ns = argparse.Namespace(
+                loc_budget=400, max_files=20, max_bha_agents=DEFAULT_MAX_BHA_AGENTS,
+                diff_data=None, workdir=None,
+                diff_scope="main...HEAD -- a.ts",  # pathspec embedded
+                cr_dir=str(tmp_path),
+            )
+            with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
+                cmd_partition(ns)
+        finally:
+            _sys.stdin = old_stdin
+            _sys.stdout = old_stdout
+
+        for cmd in captured_cmds:
+            assert cmd.count("--") <= 1, f"Double pathspec separator in: {cmd}"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -4721,7 +4721,23 @@ class TestPartitionPatches:
     """PLN-719 Phase 5: partition writes patches_p<N>.txt for each partition
     when both --diff-scope and --cr-dir are supplied."""
 
-    def _run(self, tmp_path: Path, *, with_patches: bool) -> tuple[dict[str, Any], list[list[str]]]:
+    _DEFAULT_DIFF_DATA: dict[str, Any] = _make_diff_data(
+        files=["a.ts", "b.ts", "c.ts"],
+        loc={
+            "a.ts": {"added": 60, "removed": 10},
+            "b.ts": {"added": 50, "removed": 5},
+            "c.ts": {"added": 30, "removed": 5},
+        },
+    )
+
+    def _run(
+        self,
+        tmp_path: Path,
+        *,
+        with_patches: bool,
+        diff_scope: str = "main...HEAD",
+        diff_data: dict[str, Any] | None = None,
+    ) -> tuple[dict[str, Any], list[list[str]]]:
         import argparse
         import io
         import sys as _sys
@@ -4729,14 +4745,7 @@ class TestPartitionPatches:
 
         from code_review_helpers import cmd_partition
 
-        diff_data = _make_diff_data(
-            files=["a.ts", "b.ts", "c.ts"],
-            loc={
-                "a.ts": {"added": 60, "removed": 10},
-                "b.ts": {"added": 50, "removed": 5},
-                "c.ts": {"added": 30, "removed": 5},
-            },
-        )
+        diff_data = diff_data if diff_data is not None else self._DEFAULT_DIFF_DATA
 
         captured_cmds: list[list[str]] = []
 
@@ -4757,7 +4766,7 @@ class TestPartitionPatches:
                 diff_data=None, workdir=None,
             )
             if with_patches:
-                kwargs["diff_scope"] = "main...HEAD"
+                kwargs["diff_scope"] = diff_scope
                 kwargs["cr_dir"] = str(tmp_path)
             else:
                 kwargs["diff_scope"] = None
@@ -4791,44 +4800,53 @@ class TestPartitionPatches:
         assert not list(tmp_path.glob("patches_p*.txt"))
 
     def test_partition_strips_pathspec_from_diff_scope(self, tmp_path: Path) -> None:
-        import argparse
-        import io
-        import sys as _sys
-        from unittest.mock import patch as mock_patch
-
-        from code_review_helpers import cmd_partition
-
-        diff_data = _make_diff_data(
+        single_file = _make_diff_data(
             files=["a.ts"], loc={"a.ts": {"added": 10, "removed": 0}},
         )
+        _, captured = self._run(
+            tmp_path,
+            with_patches=True,
+            diff_scope="main...HEAD -- a.ts",  # pathspec embedded
+            diff_data=single_file,
+        )
+        # Match sibling assertion coverage: ensure the mock was exercised
+        # before inspecting command contents (otherwise the for-loop below
+        # passes vacuously when no git diff is captured).
+        assert len(captured) == 1, "expected exactly one git diff invocation"
+        for cmd in captured:
+            assert cmd.count("--") <= 1, f"Double pathspec separator in: {cmd}"
+
+    def test_write_per_partition_patches_empty_files_writes_empty_patch(
+        self, tmp_path: Path,
+    ) -> None:
+        """A partition with an empty ``files`` list must not invoke git diff.
+
+        Without the guard, ``git diff <range> --`` (no pathspec) is an
+        unrestricted diff that silently folds the entire change into the
+        partition's patch. The guard writes an empty patch and skips the
+        subprocess call instead.
+        """
+        from unittest.mock import patch as mock_patch
+
+        from code_review_helpers import _write_per_partition_patches
+
         captured_cmds: list[list[str]] = []
 
         def mock_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
             captured_cmds.append(cmd)
-            stdout = kwargs.get("stdout")
-            if stdout and hasattr(stdout, "write"):
-                stdout.write("")
             return subprocess.CompletedProcess(args=cmd, returncode=0)
 
-        old_stdin = _sys.stdin
-        old_stdout = _sys.stdout
-        _sys.stdin = io.StringIO(json.dumps(diff_data))
-        _sys.stdout = io.StringIO()
-        try:
-            ns = argparse.Namespace(
-                loc_budget=400, max_files=20, max_bha_agents=DEFAULT_MAX_BHA_AGENTS,
-                diff_data=None, workdir=None,
-                diff_scope="main...HEAD -- a.ts",  # pathspec embedded
-                cr_dir=str(tmp_path),
+        partitions = [{"id": 0, "files": []}, {"id": 1, "files": [{"file": "a.ts"}]}]
+        with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
+            written = _write_per_partition_patches(
+                partitions, "main...HEAD", tmp_path,
             )
-            with mock_patch("code_review_helpers.subprocess.run", side_effect=mock_run):
-                cmd_partition(ns)
-        finally:
-            _sys.stdin = old_stdin
-            _sys.stdout = old_stdout
 
-        for cmd in captured_cmds:
-            assert cmd.count("--") <= 1, f"Double pathspec separator in: {cmd}"
+        assert written == ["patches_p0.txt", "patches_p1.txt"]
+        assert (tmp_path / "patches_p0.txt").read_text() == ""
+        # Only the non-empty partition invokes git.
+        assert len(captured_cmds) == 1
+        assert "a.ts" in captured_cmds[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PLN-719 Phase 5 (Pipeline Reordering). Two coordinated changes so the canonical declarative \`run_plan.json\` matches the actual orchestrator order, with the existing artifact set preserved but split across stages:

- **\`extract-patches\` moves from after-partition → right after \`parse-diff\`**. In its new position it produces only \`patches_all.txt\`. The \`--partitions-file\` flag is removed. This makes the full diff materialized on disk before every downstream stage that needs it (hygiene, route, partition, BHB/Auditor/Premise reviewers, plus the plan-05-gated extract-signals + coverage chain).
- **\`partition\` becomes the canonical producer of \`patches_p<N>.txt\`**. New optional \`--diff-scope\`, \`--cr-dir\`, \`--workdir\` args trigger the per-partition \`git diff\`; when both \`--diff-scope\` and \`--cr-dir\` are supplied, partition emits \`patches_p0.txt\`, \`patches_p1.txt\`, … alongside \`partitions.json\`. Without them the call stays a pure partition-assignment helper, preserving backward compat for callers that only want the assignment.

This unblocks Phase 4b (start.md → ~200 lines walking run_plan.json) by stabilizing the canonical pipeline order, and derisks Phase 8 (golden fixtures) which freezes stage order.

### Helper-level changes

- \`_write_per_partition_patches\` extracted as a shared helper inside \`code_review_helpers.py\`.
- \`cmd_extract_patches\` shrinks: drops \`--partitions-file\` and the per-partition loop. Stdout JSON is \`{\"full_patch\": \"patches_all.txt\"}\`.
- \`cmd_partition\` gains optional \`--diff-scope\`, \`--cr-dir\`, \`--workdir\` and includes \`partition_patches: [...]\` in its output when patches are written.
- \`_build_run_plan_stages\` (prepare-run): \`stage_17_partition\` now passes \`--diff-scope\` + \`--cr-dir\` and lists \`patches_p<N>.txt\` in its \`expected_outputs\`. \`stage_06_extract_patches\` already matched.

### Orchestrator (start.md)

Task 5 (right after \`parse-diff\`) gains a single \`extract-patches\` call producing \`patches_all.txt\`. Task 8 calls \`partition\` with the new patch-generation args; the standalone per-partition \`extract-patches\` invocations are removed. The \"Pre-Extract Patches to Disk\" section is renamed and explicitly documents the two-stage materialization.

### Tests

- \`TestExtractPatches\` refactored to reflect the trimmed surface (\`test_writes_full_patch_only\`, \`test_full_diff_uses_all_files_from_diff_data\`, \`test_batches_large_diffs\`, \`test_strips_pathspec_from_scope\`).
- New \`TestPartitionPatches\`: \`test_partition_writes_per_partition_patches\`, \`test_partition_skips_patches_without_diff_scope\`, \`test_partition_strips_pathspec_from_diff_scope\`.
- Existing \`TestRunPlanStages.test_extract_patches_runs_after_parse_diff\` and the universal \`test_enabled_stages_do_not_depend_on_disabled_stages\` continue to pass.

379 tests pass (was 377). ruff + uv pyright clean.

### Version

2.0.0 → **2.1.0**. Additive partition arg; \`extract-patches\` CLI is a breaking change for direct external callers (the \`--partitions-file\` flag is gone), but the canonical \`/start\` orchestrator, \`run_plan.json\` generator, and all in-tree consumers are updated in this PR.

### Docs

CHANGELOG.md and \`plugins/code-review/README.md\` updated via \`/update-documentation\` in a separate commit (cb08bc7).

## Test plan
- [ ] CI: \`Plugin Version Bump\`, \`Lint\`, \`Type Check\`, \`Tests\` all green
- [ ] Spot-check \`run_plan.json\` shape via \`python helpers.py prepare-run --cr-dir /tmp/cr --mode local\` (stage_06 + stage_17 args)
- [ ] Spot-check \`/start\` end-to-end on a small local diff (partition still writes per-file patches; reviewers still read \`patches_all.txt\` / \`patches_p<N>.txt\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)