### PR TITLE
fix(code-review): add "Code Quality" to CATEGORIES enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code-review v2.1.1
+
+#### Fixed
+- `"Code Quality"` is now in the canonical `CATEGORIES` enum. The shared reviewer prompt at `tools/prompts/shared_prompt.txt` documents it as the example category for MEDIUM-tier DRY/maintainability findings, but the schema enum at `code_review_schema.py` omitted it. Reviewer-emitted Code Quality findings caused `finalize-result` to reject the canonical envelope; verdict fell back to `validate_output.json` as designed, but the envelope path silently dropped those findings. `SCHEMA.md` Section 1 (category enum line) is updated to match. Adds three regression tests (`test_categories_include_code_quality`, `test_code_quality_finding_passes_validation`, `test_code_quality_finding_in_envelope_passes_validation`).
+
 ### code-review v2.1.0
 
 #### Changed

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/SCHEMA.md
+++ b/plugins/code-review/SCHEMA.md
@@ -37,7 +37,7 @@ shape. Producers may emit dicts directly; the Python convenience type lives in
   "system_marker": "<from the canonical enum (Section 3); null when finding_scope == 'diff'>",
 
   // ── Classification ────────────────────────────────────────
-  "category": "Correctness | Hygiene | Repo Hygiene | Premise | ImpactAnalysis | TestQuality | Coverage | InjectionAttempt | CompanionChange | Security",
+  "category": "Correctness | Code Quality | Hygiene | Repo Hygiene | Premise | ImpactAnalysis | TestQuality | Coverage | InjectionAttempt | CompanionChange | Security",
   "subcategory": "<category-specific; nullable>",
 
   // ── Severity ──────────────────────────────────────────────

--- a/plugins/code-review/tools/python/code_review_schema.py
+++ b/plugins/code-review/tools/python/code_review_schema.py
@@ -45,9 +45,14 @@ PRIORITIES: frozenset[int] = frozenset({0, 1, 2})
 
 # Categories — section 1 of the plan. Includes legacy "Repo Hygiene" as an
 # accepted alias so the hygiene helper can keep its historical category
-# string until plan 04 / Phase D rewrites it.
+# string until plan 04 / Phase D rewrites it. "Code Quality" is the
+# canonical category for DRY/maintainability/style findings (MEDIUM-tier
+# duplication, smell, or convention violations) — already documented as
+# the example category in the shared reviewer prompt (shared_prompt.txt)
+# for MEDIUM DRY findings.
 CATEGORIES: frozenset[str] = frozenset({
     "Correctness",
+    "Code Quality",
     "Hygiene",
     "Repo Hygiene",
     "Premise",

--- a/plugins/code-review/tools/python/test_code_review_schema.py
+++ b/plugins/code-review/tools/python/test_code_review_schema.py
@@ -58,6 +58,37 @@ def test_categories_include_canonical_and_legacy_alias():
     assert "Coverage" in CATEGORIES
 
 
+def test_categories_include_code_quality():
+    """Code Quality is the canonical category for DRY/maintainability findings.
+
+    The shared reviewer prompt (tools/prompts/shared_prompt.txt) documents
+    ``"category": "Code Quality"`` as the example category for MEDIUM-tier
+    DRY violations; if the enum drops it, finalize-result rejects the
+    envelope and verdict silently falls back to validate_output.json.
+    """
+    assert "Code Quality" in CATEGORIES
+
+
+def test_code_quality_finding_passes_validation():
+    """A reviewer-emitted Code Quality finding must validate end-to-end."""
+    f = _minimal_diff_finding(
+        category="Code Quality",
+        severity="MEDIUM",
+        priority=2,
+        issue="EditableDescription duplicates EditableTitle",
+    )
+    assert validate_finding(f) == []
+
+
+def test_code_quality_finding_in_envelope_passes_validation():
+    """A Code Quality finding bucketed into verified[] must not reject the envelope."""
+    f = _minimal_diff_finding(
+        category="Code Quality", severity="MEDIUM", priority=2,
+    )
+    env = _minimal_envelope(verified=[f])
+    assert validate_result_envelope(env) == []
+
+
 def test_sources():
     assert "agent" in SOURCES
     assert "hygiene" in SOURCES


### PR DESCRIPTION
## Summary

Hotfix for a production warning surfaced during a code review:

> ⚠️ Note: finalize-result rejected the canonical envelope because the existing finding uses category: \"Code Quality\", which is not in the schema's allowed enum (Correctness | Coverage | Hygiene | … | TestQuality). Verdict fell back to validate_output.json as designed.

### Root cause

The shared reviewer prompt at [shared_prompt.txt:74](plugins/code-review/tools/prompts/shared_prompt.txt#L74) documents \`\"category\": \"Code Quality\"\` as the canonical example for MEDIUM-tier DRY/maintainability findings — but the schema enum at [code_review_schema.py:49](plugins/code-review/tools/python/code_review_schema.py#L49) omitted it. Both are foundation-owned and they disagreed.

When a reviewer emitted a Code Quality finding:
1. \`validate_finding\` flagged the category as unknown.
2. \`finalize-result\` recorded the validation error but still wrote the envelope (for operator inspection) and returned exit code 1.
3. \`cmd_verdict\` fell back to \`validate_output.json\`, which doesn't apply the canonical category gate — so the verdict computed correctly, but the canonical envelope path silently dropped the finding.

### Fix

Smallest correct change: add \`\"Code Quality\"\` to \`CATEGORIES\`. The reviewer prompt's choice was semantically right — DRY/maintainability isn't a Correctness bug — and the enum was the thing that drifted. \`SCHEMA.md\` line 40 (which mirrors the enum verbatim) is updated to match.

Considered + rejected: mapping Code Quality → Correctness in \`normalize_legacy_finding\`. That would have collapsed two legitimately distinct semantic categories and hidden the contract violation behind a normalizer.

### Tests (+3)

- \`test_categories_include_code_quality\`
- \`test_code_quality_finding_passes_validation\`
- \`test_code_quality_finding_in_envelope_passes_validation\`

### Version

2.1.0 → **2.1.1** (PATCH — additive enum entry, fixes a real production warning).

383 tests pass (was 380). ruff + uv pyright clean.

## Test plan
- [ ] CI green
- [ ] Spot-check: run \`/start\` on a small diff where a reviewer emits a Code Quality finding; verify no warning surfaces and the envelope path retains the finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)