### PR TITLE
refactor(code-review): Phase 7 — cache uniformity + BHA hit-rate telemetry (PLN-719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code-review v2.3.0
+
+#### Added
+- PLN-719 Phase 7 (Cache uniformity): `CACHE_TTL_DAYS` constant on `code_review_schema.py` declares the per-namespace TTLs from PLN-719 §9 (`bha`=30d, `signals`=7d, `coverage_critic`=7d, `verifications`=30d, `overrides`=90d), plus a `cache_ttl_days(namespace)` lookup helper that returns `None` for unknown namespaces. The whitelist is pinned to the canonical 5 cache namespaces via a new `test_cache_ttl_days_covers_every_namespace` regression test.
+- `_is_entry_fresh(entry, namespace, *, now=None)` helper in `code_review_helpers.py` enforces **sweep-on-read** TTL eviction. Stale `cached_at` → cache miss → next review regenerates fresh findings. Missing/malformed `cached_at` values and unknown namespaces count as fresh (caller handles its own corruption fallback). Wired into both the v1 and v2 cache-check paths after `_entry_matches`, so existing miss reasons (schema_version, model_id, prompt_hash, patch_hash) short-circuit before the TTL check.
+- `_extract_bha_cache_hit_rate(cr_dir)` reads `<cr_dir>/cache_result.json` (written by `cache-check`) and normalizes `stats.hit_rate_pct` (0–100) into the canonical `[0, 1]` range enforced by `validate_telemetry`. `_build_telemetry_block` populates `telemetry.cache_hit_rate["bha"]` when a cache_result.json exists — this is the first end-to-end producer for the `cache_hit_rate` field that Phase 9 declared. Hygiene-only and no-cache runs leave the field empty (legal under the open-additionalProperties schema).
+- 13 new tests covering: `_is_entry_fresh` unit semantics (within/past TTL, missing/malformed timestamps, unknown namespaces), end-to-end TTL eviction for both v1 and v2 cache-check paths, `telemetry.cache_hit_rate["bha"]` population (present when cache_result.json exists; absent otherwise; defensively dropped when `hit_rate_pct` is out of `[0, 100]`), and schema-level whitelist coverage tests.
+
+#### Changed
+- Cache test fixtures: hardcoded `cached_at: "2026-01-01T..."` timestamps replaced with a module-level `_FRESH_CACHED_AT` constant computed at collection time, so hit-expecting tests stay within the BHA 30-day TTL window indefinitely. Added a `_stale_cached_at(days_ago=N)` helper for the new eviction tests. Miss-expecting tests are unchanged — they short-circuit on `_entry_matches` before the TTL check.
+- SCHEMA.md §9: gains a paragraph documenting sweep-on-read TTL enforcement and Phase 7's BHA-only end-to-end status; notes that the canonical per-file path layout (`<CACHE_DIR>/bha/<file_hash>.json`) is a future migration — the current implementation still uses a single `<CACHE_DIR>/manifest.json` with per-file entries sharing the same key inputs and invalidation contract.
+
 ### code-review v2.2.0
 
 #### Added

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -16,7 +16,7 @@ A multi-agent code review plugin for Claude Code that performs deep, partitioned
 
 ```
 plugins/code-review/
-  .claude-plugin/plugin.json         Plugin manifest (version 2.2.0)
+  .claude-plugin/plugin.json         Plugin manifest (version 2.3.0)
   SCHEMA.md                          Canonical Finding + ResultEnvelope schema (PLN-719)
   commands/
     start.md                         Main /start command (orchestrator)
@@ -152,7 +152,7 @@ The helper script is a multi-subcommand Python CLI. The orchestrator invokes it 
 | `route` | Computes risk scores and emits model routing decisions per partition |
 | `validate` | Normalizes severity, filters low-confidence findings, deduplicates via Jaccard similarity, validates line numbers |
 | `compute-hashes` | Computes `PROMPT_HASH` and `CONTEXT_KEY` from shared prompt and diff tip |
-| `cache-check` | Checks the content-addressed cache for a prior result matching the current context key |
+| `cache-check` | Checks the content-addressed cache for a prior result matching the current context key; enforces per-namespace TTL sweep-on-read so stale entries count as a miss (PLN-719 Phase 7) |
 | `cache-update` | Writes validated findings to the cache after a successful run |
 | `auto-incremental` | Evaluates whether the diff scope can be narrowed to commits since the last successful review |
 | `finalize-cache` | Resolves the final cache directory path after scope and PR number are known |
@@ -169,7 +169,7 @@ The helper script is a multi-subcommand Python CLI. The orchestrator invokes it 
 | `verdict` | Computes the PR verdict (APPROVED / NEEDS_ATTENTION / CHANGES_REQUESTED) from validated findings |
 | `prep-assets` | Copies prompt assets from the plugin root into the session CR_DIR |
 | `extract-patches` | Materializes the full-diff `patches_all.txt` immediately after `parse-diff`; per-partition patches are now produced by `partition` (PLN-719 Phase 5) |
-| `finalize-result` | Consolidates validated findings + coverage state + verdict into the canonical `review_result.json` envelope; deep-merges `<cr_dir>/telemetry.json` into the canonical `telemetry` block (PLN-719 Phase 9) |
+| `finalize-result` | Consolidates validated findings + coverage state + verdict into the canonical `review_result.json` envelope; deep-merges `<cr_dir>/telemetry.json` into the canonical `telemetry` block and populates `telemetry.cache_hit_rate["bha"]` from `cache_result.json` (PLN-719 Phase 7/9) |
 | `arbitrate-budget` | Applies the canonical reviewer cap policy; emits coverage gaps for required reviewers that overflow (PLN-719) |
 | `prepare-run` | Emits a declarative `run_plan.json` describing the 30-stage pipeline (PLN-719) |
 

--- a/plugins/code-review/SCHEMA.md
+++ b/plugins/code-review/SCHEMA.md
@@ -372,6 +372,23 @@ A MAJOR `schema_version` bump invalidates every cache namespace at once.
 | Verification        | `<CACHE_DIR>/verifications/<finding_id>.json`     | finding_id + file_content_hash + verifier_model + verifier_prompt_hash | 30 d |
 | Overrides           | `<CACHE_DIR>/overrides/<finding_id>.json`         | finding_id (file content change invalidates)                  | 90 d   |
 
+TTLs are declared in `code_review_schema.CACHE_TTL_DAYS` and enforced
+**sweep-on-read** by `_is_entry_fresh(entry, namespace)` in the
+helpers. Stale entries count as a cache miss; the next review
+regenerates fresh findings.
+
+Phase 7 ships the BHA producer end-to-end (canonical `prompt_hash`,
+TTL enforcement on read, `telemetry.cache_hit_rate["bha"]` populated
+from `cache_result.json` by `finalize-result`). The other four
+namespaces have their key inputs, paths, and TTLs declared but ship
+real producers with plans 03 (verifications, overrides) and 05
+(signals, coverage_critic).
+
+The canonical on-disk file layout `<CACHE_DIR>/bha/<file_hash>.json`
+(per-file caches) is a future migration; the current implementation
+uses a single `<CACHE_DIR>/manifest.json` with per-file entries, which
+shares the same key inputs and invalidation contract.
+
 ---
 
 ## 10. Schema migration policy (PLN-719 Section 12)

--- a/plugins/code-review/tools/python/code_review_helpers.py
+++ b/plugins/code-review/tools/python/code_review_helpers.py
@@ -25,12 +25,14 @@ import sys
 import uuid
 from collections.abc import Generator
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 from code_review_schema import (
+    CACHE_NAMESPACE_BHA,
     SCHEMA_VERSION,
+    cache_ttl_days,
     empty_telemetry,
     is_valid_system_marker,
     make_finding_id,
@@ -1518,6 +1520,38 @@ def _entry_matches(
     )
 
 
+def _is_entry_fresh(
+    entry: dict[str, Any],
+    namespace: str,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Return True iff ``entry["cached_at"]`` is within the namespace TTL.
+
+    PLN-719 Phase 7 — sweep-on-read TTL enforcement. The canonical TTLs
+    live in ``code_review_schema.CACHE_TTL_DAYS``; unknown namespaces or
+    missing/malformed ``cached_at`` timestamps count as fresh (callers
+    handle their own corruption fallback).
+    """
+    ttl = cache_ttl_days(namespace)
+    if ttl is None:
+        return True
+    cached_at_raw = entry.get("cached_at")
+    if not isinstance(cached_at_raw, str):
+        return True
+    try:
+        # fromisoformat tolerates the trailing "Z" used by datetime.isoformat()
+        # only on Python 3.11+; normalize manually for safety.
+        normalized = cached_at_raw.replace("Z", "+00:00")
+        cached_at = datetime.fromisoformat(normalized)
+    except ValueError:
+        return True
+    if cached_at.tzinfo is None:
+        cached_at = cached_at.replace(tzinfo=timezone.utc)
+    current = now if now is not None else datetime.now(timezone.utc)
+    return (current - cached_at) <= timedelta(days=ttl)
+
+
 # ---------------------------------------------------------------------------
 # V2 Cache helpers (content-addressed, cross-PR)
 # ---------------------------------------------------------------------------
@@ -1882,8 +1916,11 @@ def _cmd_cache_check_v1(  # noqa: PLR0913
         patch_hash = _compute_patch_hash(filepath, file_patch)
         entry = manifest.get(filepath)
 
-        if entry and isinstance(entry, dict) and _entry_matches(
-            entry, schema_version, model_id, prompt_hash, patch_hash
+        if (
+            entry
+            and isinstance(entry, dict)
+            and _entry_matches(entry, schema_version, model_id, prompt_hash, patch_hash)
+            and _is_entry_fresh(entry, CACHE_NAMESPACE_BHA)
         ):
             cached_files.append(filepath)
             cached_findings.extend(entry.get("findings", []))
@@ -1940,8 +1977,11 @@ def _cmd_cache_check_v2(  # noqa: PLR0913
                 slots = manifest.get(filepath, {})
                 entry = slots.get(composite) if isinstance(slots, dict) else None
 
-                if entry and isinstance(entry, dict) and _entry_matches_v2(
-                    entry, model_id, prompt_hash, patch_hash, context_key,
+                if (
+                    entry
+                    and isinstance(entry, dict)
+                    and _entry_matches_v2(entry, model_id, prompt_hash, patch_hash, context_key)
+                    and _is_entry_fresh(entry, CACHE_NAMESPACE_BHA)
                 ):
                     cached_files.append(filepath)
                     cached_findings.extend(entry.get("findings", []))
@@ -4452,6 +4492,29 @@ def _stats_from_findings(
     }
 
 
+def _extract_bha_cache_hit_rate(cr_dir: Path) -> float | None:
+    """Return the BHA cache hit rate (0.0-1.0) from cache_result.json, or None.
+
+    PLN-719 Phase 7 wires the first ``cache_hit_rate`` namespace producer.
+    ``cache_result.json`` records ``stats.hit_rate_pct`` (0-100) per cache-check;
+    we normalize to the canonical [0, 1] domain that ``validate_telemetry``
+    enforces. Missing or malformed files degrade silently to None so legacy
+    runs (e.g. ``--hygiene-only`` without a cache-check) don't crash finalize.
+    """
+    doc = _read_optional_json(cr_dir / "cache_result.json", None)
+    if not isinstance(doc, dict):
+        return None
+    stats = doc.get("stats")
+    if not isinstance(stats, dict):
+        return None
+    pct = stats.get("hit_rate_pct")
+    if not isinstance(pct, (int, float)) or isinstance(pct, bool):
+        return None
+    if pct < 0 or pct > 100:
+        return None
+    return round(pct / 100.0, 4)
+
+
 def _build_telemetry_block(cr_dir: Path) -> dict[str, Any]:
     """Assemble the canonical telemetry block for the result envelope.
 
@@ -4459,12 +4522,17 @@ def _build_telemetry_block(cr_dir: Path) -> dict[str, Any]:
     when present, so the orchestrator (or any helper that wraps a stage) can
     record per-run metrics by writing partial telemetry. Always forces the
     ``schema_versions_seen`` block to this run's canonical schema version so
-    it cannot be silently spoofed by a stale upstream file.
+    it cannot be silently spoofed by a stale upstream file. PLN-719 Phase 7:
+    populate ``cache_hit_rate["bha"]`` from ``cache_result.json`` when a
+    cache-check ran for this review.
     """
     base = empty_telemetry()
     overlay_raw = _read_optional_json(cr_dir / "telemetry.json", None)
     overlay = overlay_raw if isinstance(overlay_raw, dict) else {}
     block = merge_telemetry(base, overlay)
+    bha_rate = _extract_bha_cache_hit_rate(cr_dir)
+    if bha_rate is not None:
+        block["cache_hit_rate"][CACHE_NAMESPACE_BHA] = bha_rate
     block["schema_versions_seen"] = {
         "finding": SCHEMA_VERSION,
         "result": SCHEMA_VERSION,

--- a/plugins/code-review/tools/python/code_review_schema.py
+++ b/plugins/code-review/tools/python/code_review_schema.py
@@ -415,18 +415,25 @@ def merge_telemetry(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, 
     without overriding the whole ``tokens`` block. Every other key —
     including dict-typed fields not on the whitelist — is overwritten
     wholesale by ``overlay``.
+
+    Whitelisted keys preserve their type invariant: if ``overlay`` supplies a
+    non-dict (e.g. ``{"cache_hit_rate": null}``) for a whitelisted key, the
+    overlay is **ignored for that key** and the base dict value survives.
+    Otherwise a malformed overlay could corrupt the field's type and trip
+    downstream writers that assume the whitelist contract holds (e.g.
+    ``block["cache_hit_rate"][NAMESPACE] = rate`` in finalize-result).
     """
     out = {k: (dict(v) if isinstance(v, dict) else v) for k, v in base.items()}
     for k, v in overlay.items():
-        if (
-            k in TELEMETRY_DEEP_MERGE_KEYS
-            and isinstance(v, dict)
-            and isinstance(out.get(k), dict)
-        ):
-            merged = dict(out[k])
-            for sk, sv in v.items():
-                merged[sk] = sv
-            out[k] = merged
+        if k in TELEMETRY_DEEP_MERGE_KEYS:
+            if isinstance(v, dict) and isinstance(out.get(k), dict):
+                merged = dict(out[k])
+                for sk, sv in v.items():
+                    merged[sk] = sv
+                out[k] = merged
+            # Non-dict overlay for a whitelisted key: keep the base value
+            # so the type invariant survives. validate_telemetry on the
+            # final envelope still catches the malformed input upstream.
         else:
             out[k] = v
     return out

--- a/plugins/code-review/tools/python/code_review_schema.py
+++ b/plugins/code-review/tools/python/code_review_schema.py
@@ -203,6 +203,22 @@ CACHE_NAMESPACES: frozenset[str] = frozenset({
     CACHE_NAMESPACE_OVERRIDES,
 })
 
+# Per-namespace TTL in days (PLN-719 Section 9). Entries older than the
+# TTL are treated as a cache miss on read. Sweep-on-read is the canonical
+# enforcement point; explicit GC remains as a separate cleanup pass.
+CACHE_TTL_DAYS: dict[str, int] = {
+    CACHE_NAMESPACE_BHA: 30,
+    CACHE_NAMESPACE_SIGNALS: 7,
+    CACHE_NAMESPACE_COVERAGE_CRITIC: 7,
+    CACHE_NAMESPACE_VERIFICATIONS: 30,
+    CACHE_NAMESPACE_OVERRIDES: 90,
+}
+
+
+def cache_ttl_days(namespace: str) -> int | None:
+    """Return the canonical TTL in days for a cache namespace, or None if unknown."""
+    return CACHE_TTL_DAYS.get(namespace)
+
 
 # ---------------------------------------------------------------------------
 # Telemetry (PLN-719 Phase 9 / Section 11)

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -5492,6 +5492,42 @@ class TestFinalizeResult:
         t = json.loads((tmp_path / "review_result.json").read_text())["telemetry"]
         assert "bha" not in t["cache_hit_rate"]
 
+    def test_null_cache_hit_rate_overlay_does_not_crash_finalize(self, tmp_path: Path) -> None:
+        """Regression for a TypeError when telemetry.json declares cache_hit_rate=null.
+
+        Reported by reviewer (PR #104): a producer writing
+        ``{"cache_hit_rate": null}`` to telemetry.json combined with a
+        valid cache_result.json would crash finalize-result with
+        ``'NoneType' object does not support item assignment``. The fix
+        is at the merge layer (whitelist keys preserve their type
+        invariant), but this test pins the end-to-end behavior.
+        """
+        (tmp_path / "telemetry.json").write_text(json.dumps({
+            "cache_hit_rate": None,
+        }))
+        (tmp_path / "cache_result.json").write_text(json.dumps({
+            "stats": {"hit_rate_pct": 50.0},
+        }))
+        # Must not raise.
+        self._run_finalize(tmp_path, [])
+        t = json.loads((tmp_path / "review_result.json").read_text())["telemetry"]
+        # cache_hit_rate is still a dict (the malformed null was discarded)
+        # and the BHA producer's value lands cleanly.
+        assert isinstance(t["cache_hit_rate"], dict)
+        assert t["cache_hit_rate"]["bha"] == 0.5
+
+    def test_scalar_tokens_overlay_does_not_corrupt_tokens_block(self, tmp_path: Path) -> None:
+        """Same invariant: a non-dict overlay for tokens leaves the base intact."""
+        (tmp_path / "telemetry.json").write_text(json.dumps({
+            "tokens": "garbage",
+        }))
+        self._run_finalize(tmp_path, [])
+        t = json.loads((tmp_path / "review_result.json").read_text())["telemetry"]
+        assert isinstance(t["tokens"], dict)
+        # All canonical token sub-keys still present from the zero-valued base.
+        for key in ("input_uncached", "input_cached", "output", "by_model"):
+            assert key in t["tokens"]
+
 
 class TestVerdictReadsEnvelope:
     """cmd_verdict prefers review_result.json when provided."""

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import subprocess
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -81,6 +82,18 @@ from code_review_helpers import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+# A `cached_at` timestamp always within the BHA cache TTL (30 days).
+# PLN-719 Phase 7 added sweep-on-read TTL eviction; fixtures that want a hit
+# must use a fresh timestamp. Tests that want eviction behavior should use
+# an explicitly-stale timestamp via ``_stale_cached_at()``.
+_FRESH_CACHED_AT = datetime.now(timezone.utc).isoformat()
+
+
+def _stale_cached_at(days_ago: int = 365) -> str:
+    """Return an ISO timestamp ``days_ago`` days in the past (default: 1 year)."""
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
 
 
 def _make_diff_data(
@@ -1740,7 +1753,7 @@ class TestCmdCacheCheck:
                 "prompt_hash": "abc123",
                 "patch_hash": patch_hash,
                 "findings": [{"file": "a.ts", "line": 5, "severity": "HIGH", "issue": "bug"}],
-                "cached_at": "2026-01-01T00:00:00Z",
+                "cached_at": _FRESH_CACHED_AT,
             }
         }
         _write_manifest(cache_dir, manifest)
@@ -1772,7 +1785,7 @@ class TestCmdCacheCheck:
                 "prompt_hash": "abc123",
                 "patch_hash": patch_hash_a,
                 "findings": [],
-                "cached_at": "2026-01-01T00:00:00Z",
+                "cached_at": _FRESH_CACHED_AT,
             }
         }
         _write_manifest(cache_dir, manifest)
@@ -1797,7 +1810,7 @@ class TestCmdCacheCheck:
                 "prompt_hash": "abc123",
                 "patch_hash": "stale_hash",
                 "findings": [],
-                "cached_at": "2026-01-01T00:00:00Z",
+                "cached_at": _FRESH_CACHED_AT,
             }
         }
         _write_manifest(cache_dir, manifest)
@@ -1821,7 +1834,7 @@ class TestCmdCacheCheck:
                 "prompt_hash": "old_prompt_hash",
                 "patch_hash": patch_hash,
                 "findings": [],
-                "cached_at": "2026-01-01T00:00:00Z",
+                "cached_at": _FRESH_CACHED_AT,
             }
         }
         _write_manifest(cache_dir, manifest)
@@ -1844,7 +1857,7 @@ class TestCmdCacheCheck:
                 "prompt_hash": "abc123",
                 "patch_hash": patch_hash,
                 "findings": [],
-                "cached_at": "2026-01-01T00:00:00Z",
+                "cached_at": _FRESH_CACHED_AT,
             }
         }
         _write_manifest(cache_dir, manifest)
@@ -1867,7 +1880,7 @@ class TestCmdCacheCheck:
                 "prompt_hash": "abc123",
                 "patch_hash": patch_hash,
                 "findings": [],
-                "cached_at": "2026-01-01T00:00:00Z",
+                "cached_at": _FRESH_CACHED_AT,
             }
         }
         _write_manifest(cache_dir, manifest)
@@ -1906,7 +1919,7 @@ class TestCmdCacheCheck:
                 "prompt_hash": "abc123",
                 "patch_hash": patch_hash_a,
                 "findings": [],
-                "cached_at": "2026-01-01T00:00:00Z",
+                "cached_at": _FRESH_CACHED_AT,
             }
         }
         _write_manifest(cache_dir, manifest)
@@ -1926,6 +1939,111 @@ class TestCmdCacheCheck:
         assert result["stats"]["total_files"] == 0
         assert result["stats"]["cached"] == 0
         assert result["stats"]["uncached"] == 0
+
+
+class TestCacheTtlEviction:
+    """PLN-719 Phase 7: entries older than the BHA TTL (30d) miss on read.
+
+    Schema-version and prompt-hash mismatch short-circuit before the TTL
+    check, but otherwise-valid stale entries must be treated as a miss so
+    the next review regenerates fresh findings.
+    """
+
+    def test_stale_entry_within_ttl_hits(self, tmp_path: Path) -> None:
+        from code_review_helpers import _is_entry_fresh, CACHE_NAMESPACE_BHA
+
+        # 29 days old: under the 30-day BHA TTL.
+        entry = {"cached_at": _stale_cached_at(days_ago=29)}
+        assert _is_entry_fresh(entry, CACHE_NAMESPACE_BHA) is True
+
+    def test_stale_entry_past_ttl_misses(self, tmp_path: Path) -> None:
+        from code_review_helpers import _is_entry_fresh, CACHE_NAMESPACE_BHA
+
+        # 31 days old: past the 30-day BHA TTL.
+        entry = {"cached_at": _stale_cached_at(days_ago=31)}
+        assert _is_entry_fresh(entry, CACHE_NAMESPACE_BHA) is False
+
+    def test_missing_cached_at_treated_as_fresh(self, tmp_path: Path) -> None:
+        """Missing or malformed timestamps don't crash; caller handles other fields."""
+        from code_review_helpers import _is_entry_fresh, CACHE_NAMESPACE_BHA
+
+        assert _is_entry_fresh({}, CACHE_NAMESPACE_BHA) is True
+        assert _is_entry_fresh({"cached_at": "not-a-date"}, CACHE_NAMESPACE_BHA) is True
+        assert _is_entry_fresh({"cached_at": 42}, CACHE_NAMESPACE_BHA) is True
+
+    def test_unknown_namespace_skips_ttl_check(self, tmp_path: Path) -> None:
+        from code_review_helpers import _is_entry_fresh
+
+        entry = {"cached_at": _stale_cached_at(days_ago=365 * 10)}
+        assert _is_entry_fresh(entry, "future-namespace") is True
+
+    def test_v1_cache_check_evicts_stale_entry(self, tmp_path: Path) -> None:
+        """End-to-end: a stale-but-otherwise-matching entry produces a miss."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        diff_data = _make_cache_diff_data(files=["a.ts"])
+        patch_hash = _compute_patch_hash("a.ts", diff_data["patch_lines"]["a.ts"])
+
+        manifest = {
+            "a.ts": {
+                "schema_version": 1,
+                "model_id": "opus",
+                "prompt_hash": "abc123",
+                "patch_hash": patch_hash,
+                "findings": [{"file": "a.ts", "line": 1, "issue": "stale"}],
+                "cached_at": _stale_cached_at(days_ago=45),
+            }
+        }
+        _write_manifest(cache_dir, manifest)
+
+        result = TestCmdCacheCheck()._run_cache_check(cache_dir, diff_data, out)
+        assert result["stats"]["cached"] == 0
+        assert result["stats"]["uncached"] == 1
+
+    def test_v2_cache_check_evicts_stale_entry(self, tmp_path: Path) -> None:
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        diff_data = _make_cache_diff_data(files=["a.ts"])
+        patch_hash = _compute_patch_hash("a.ts", diff_data["patch_lines"]["a.ts"])
+        composite = _compute_composite_key("opus", "abc123", patch_hash, "ctx")
+
+        stale = _stale_cached_at(days_ago=45)
+        v2_manifest = {
+            "a.ts": {
+                composite: {
+                    "schema_version": CACHE_SCHEMA_VERSION_V2,
+                    "model_id": "opus",
+                    "prompt_hash": "abc123",
+                    "patch_hash": patch_hash,
+                    "context_key": "ctx",
+                    "findings": [],
+                    "cached_at": stale,
+                    "last_hit_at": stale,
+                    "hit_count": 0,
+                }
+            }
+        }
+        _write_manifest(cache_dir, v2_manifest)
+
+        ns_kwargs = dict(
+            cache_dir=str(cache_dir),
+            diff_data=str(out / "diff_data.json"),
+            prompt_hash="abc123",
+            model_id="opus",
+            schema_version=CACHE_SCHEMA_VERSION_V2,
+            output_dir=str(out),
+            global_cache=1,
+            context_key="ctx",
+        )
+        (out / "diff_data.json").write_text(json.dumps(diff_data))
+        import argparse
+        cmd_cache_check(argparse.Namespace(**ns_kwargs))
+        result = json.loads((out / "cache_result.json").read_text())
+        assert result["stats"]["cached"] == 0
 
 
 class TestCmdCacheUpdate:
@@ -2351,7 +2469,7 @@ class TestMigrateV1EntryToV2:
             "prompt_hash": "ph",
             "patch_hash": "pah",
             "findings": [{"file": "a.ts", "line": 1}],
-            "cached_at": "2026-01-01T00:00:00+00:00",
+            "cached_at": _FRESH_CACHED_AT,
         }
         result = _migrate_v1_entry_to_v2("a.ts", v1)
         assert isinstance(result, dict)
@@ -2365,21 +2483,21 @@ class TestMigrateV1EntryToV2:
 
     def test_hit_count_init_zero(self) -> None:
         v1 = {"schema_version": 1, "model_id": "opus", "prompt_hash": "ph",
-               "patch_hash": "pah", "findings": [], "cached_at": "2026-01-01T00:00:00+00:00"}
+               "patch_hash": "pah", "findings": [], "cached_at": _FRESH_CACHED_AT}
         result = _migrate_v1_entry_to_v2("a.ts", v1)
         entry = next(iter(result.values()))
         assert entry["hit_count"] == 0
 
     def test_context_key_defaults_to_empty(self) -> None:
         v1 = {"schema_version": 1, "model_id": "opus", "prompt_hash": "ph",
-               "patch_hash": "pah", "findings": [], "cached_at": "2026-01-01T00:00:00+00:00"}
+               "patch_hash": "pah", "findings": [], "cached_at": _FRESH_CACHED_AT}
         result = _migrate_v1_entry_to_v2("a.ts", v1)
         entry = next(iter(result.values()))
         assert entry["context_key"] == ""
 
     def test_composite_key_is_valid(self) -> None:
         v1 = {"schema_version": 1, "model_id": "opus", "prompt_hash": "ph",
-               "patch_hash": "pah", "findings": [], "cached_at": "2026-01-01T00:00:00+00:00"}
+               "patch_hash": "pah", "findings": [], "cached_at": _FRESH_CACHED_AT}
         result = _migrate_v1_entry_to_v2("a.ts", v1)
         key = next(iter(result.keys()))
         assert len(key) == 64
@@ -2416,7 +2534,7 @@ class TestLoadManifestV2:
                 "prompt_hash": "ph",
                 "patch_hash": "pah",
                 "findings": [],
-                "cached_at": "2026-01-01T00:00:00+00:00",
+                "cached_at": _FRESH_CACHED_AT,
             }
         }
         (tmp_path / CACHE_MANIFEST_FILENAME).write_text(json.dumps(v1))
@@ -2440,7 +2558,7 @@ class TestLoadManifestV2:
                     "patch_hash": "pah",
                     "context_key": "ctx",
                     "findings": [],
-                    "cached_at": "2026-01-01T00:00:00+00:00",
+                    "cached_at": _FRESH_CACHED_AT,
                     "last_hit_at": "2026-01-01T00:00:00+00:00",
                     "hit_count": 0,
                 }
@@ -2461,7 +2579,7 @@ class TestLoadManifestV2:
                 "prompt_hash": "ph",
                 "patch_hash": "pah",
                 "findings": [],
-                "cached_at": "2026-01-01T00:00:00+00:00",
+                "cached_at": _FRESH_CACHED_AT,
             },
             "b.ts": {
                 composite: {
@@ -2471,7 +2589,7 @@ class TestLoadManifestV2:
                     "patch_hash": "pah",
                     "context_key": "ctx",
                     "findings": [],
-                    "cached_at": "2026-01-01T00:00:00+00:00",
+                    "cached_at": _FRESH_CACHED_AT,
                     "last_hit_at": "2026-01-01T00:00:00+00:00",
                     "hit_count": 0,
                 }
@@ -2702,7 +2820,7 @@ class TestCmdCacheCheckV2:
                     "patch_hash": patch_hash,
                     "context_key": "ctx123",
                     "findings": [{"file": "a.ts", "line": 5, "severity": "HIGH"}],
-                    "cached_at": "2026-01-01T00:00:00+00:00",
+                    "cached_at": _FRESH_CACHED_AT,
                     "last_hit_at": "2026-01-01T00:00:00+00:00",
                     "hit_count": 1,
                 }
@@ -2733,7 +2851,7 @@ class TestCmdCacheCheckV2:
                     "patch_hash": patch_hash,
                     "context_key": "old_ctx",
                     "findings": [],
-                    "cached_at": "2026-01-01T00:00:00+00:00",
+                    "cached_at": _FRESH_CACHED_AT,
                     "last_hit_at": "2026-01-01T00:00:00+00:00",
                     "hit_count": 0,
                 }
@@ -2760,7 +2878,7 @@ class TestCmdCacheCheckV2:
                 "prompt_hash": "abc123",
                 "patch_hash": _compute_patch_hash("a.ts", diff_data["patch_lines"]["a.ts"]),
                 "findings": [],
-                "cached_at": "2026-01-01T00:00:00+00:00",
+                "cached_at": _FRESH_CACHED_AT,
             }
         }
         _write_manifest(cache_dir, v1_manifest)
@@ -2785,7 +2903,7 @@ class TestCmdCacheCheckV2:
                 "prompt_hash": "abc123",
                 "patch_hash": patch_hash,
                 "findings": [{"file": "a.ts", "line": 1}],
-                "cached_at": "2026-01-01T00:00:00+00:00",
+                "cached_at": _FRESH_CACHED_AT,
             }
         }
         _write_manifest(cache_dir, v1_manifest)
@@ -2842,7 +2960,9 @@ class TestCmdCacheCheckV2:
         patch_hash = _compute_patch_hash("a.ts", diff_data["patch_lines"]["a.ts"])
         composite = _compute_composite_key("opus", "abc123", patch_hash, "ctx123")
 
-        old_hit = "2026-01-01T00:00:00+00:00"
+        # Pre-existing entry seeded fresh enough to remain within TTL but
+        # still serve as a baseline for verifying last_hit_at updates.
+        prior_hit = _FRESH_CACHED_AT
         v2_manifest = {
             "a.ts": {
                 composite: {
@@ -2852,8 +2972,8 @@ class TestCmdCacheCheckV2:
                     "patch_hash": patch_hash,
                     "context_key": "ctx123",
                     "findings": [],
-                    "cached_at": old_hit,
-                    "last_hit_at": old_hit,
+                    "cached_at": prior_hit,
+                    "last_hit_at": prior_hit,
                     "hit_count": 1,
                 }
             }
@@ -2884,7 +3004,7 @@ class TestCmdCacheCheckV2:
                     "patch_hash": patch_hash_a,
                     "context_key": "ctx123",
                     "findings": [],
-                    "cached_at": "2026-01-01T00:00:00+00:00",
+                    "cached_at": _FRESH_CACHED_AT,
                     "last_hit_at": "2026-01-01T00:00:00+00:00",
                     "hit_count": 0,
                 }
@@ -3237,7 +3357,7 @@ class TestGitHubNonRegression:
                     "model_id": "opus", "prompt_hash": "ph",
                     "patch_hash": patch_hash, "context_key": "ctx",
                     "findings": [{"file": "a.ts", "line": 1, "severity": "HIGH"}],
-                    "cached_at": "2026-01-01T00:00:00+00:00",
+                    "cached_at": _FRESH_CACHED_AT,
                     "last_hit_at": "2026-01-01T00:00:00+00:00", "hit_count": 0,
                 }
             }
@@ -3296,7 +3416,7 @@ class TestGitHubNonRegression:
                 "schema_version": 1, "model_id": "opus",
                 "prompt_hash": "ph", "patch_hash": patch_hash,
                 "findings": [{"file": "a.ts", "line": 1}],
-                "cached_at": "2026-01-01T00:00:00+00:00",
+                "cached_at": _FRESH_CACHED_AT,
             }
         }
         _write_manifest(cache_dir, v1)
@@ -5341,6 +5461,36 @@ class TestFinalizeResult:
         t = json.loads((tmp_path / "review_result.json").read_text())["telemetry"]
         assert t["duration_ms"] == 0
         assert t["schema_versions_seen"]["result"] == SCHEMA_VERSION
+
+    def test_cache_hit_rate_bha_populated_from_cache_result(self, tmp_path: Path) -> None:
+        """PLN-719 Phase 7: BHA cache_hit_rate is sourced from cache_result.json.
+
+        finalize-result reads ``stats.hit_rate_pct`` (0-100) and normalizes
+        to the canonical [0, 1] domain enforced by validate_telemetry.
+        """
+        (tmp_path / "cache_result.json").write_text(json.dumps({
+            "cached_files": ["a.ts", "b.ts"],
+            "uncached_files": ["c.ts"],
+            "stats": {"total_files": 3, "cached": 2, "uncached": 1, "hit_rate_pct": 66.7},
+        }))
+        self._run_finalize(tmp_path, [])
+        t = json.loads((tmp_path / "review_result.json").read_text())["telemetry"]
+        assert t["cache_hit_rate"]["bha"] == 0.667
+
+    def test_cache_hit_rate_bha_absent_when_no_cache_result(self, tmp_path: Path) -> None:
+        """Without cache_result.json, cache_hit_rate stays empty (legacy / hygiene-only runs)."""
+        self._run_finalize(tmp_path, [])
+        t = json.loads((tmp_path / "review_result.json").read_text())["telemetry"]
+        assert t["cache_hit_rate"] == {}
+
+    def test_cache_hit_rate_bha_ignored_when_out_of_range(self, tmp_path: Path) -> None:
+        """Defensive: a malformed hit_rate_pct (>100) is dropped, not clamped."""
+        (tmp_path / "cache_result.json").write_text(json.dumps({
+            "stats": {"hit_rate_pct": 150.0},
+        }))
+        self._run_finalize(tmp_path, [])
+        t = json.loads((tmp_path / "review_result.json").read_text())["telemetry"]
+        assert "bha" not in t["cache_hit_rate"]
 
 
 class TestVerdictReadsEnvelope:

--- a/plugins/code-review/tools/python/test_code_review_schema.py
+++ b/plugins/code-review/tools/python/test_code_review_schema.py
@@ -496,6 +496,41 @@ def test_signal_extraction_failed_marker_exists():
 
 
 # ---------------------------------------------------------------------------
+# Cache namespaces + TTLs (PLN-719 Phase 7 / Section 9)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_ttl_days_matches_pln719_section_9():
+    """The canonical TTLs from PLN-719 Section 9.
+
+    BHA: 30d, signals: 7d, coverage_critic: 7d, verifications: 30d,
+    overrides: 90d. Any drift between this test and the plan is a
+    documentation/schema bug.
+    """
+    from code_review_schema import CACHE_TTL_DAYS
+    assert CACHE_TTL_DAYS == {
+        "bha": 30,
+        "signals": 7,
+        "coverage_critic": 7,
+        "verifications": 30,
+        "overrides": 90,
+    }
+
+
+def test_cache_ttl_days_covers_every_namespace():
+    """Every namespace in CACHE_NAMESPACES has a declared TTL."""
+    from code_review_schema import CACHE_NAMESPACES, CACHE_TTL_DAYS
+    assert set(CACHE_TTL_DAYS) == set(CACHE_NAMESPACES)
+
+
+def test_cache_ttl_days_helper():
+    from code_review_schema import cache_ttl_days
+    assert cache_ttl_days("bha") == 30
+    assert cache_ttl_days("overrides") == 90
+    assert cache_ttl_days("future-namespace") is None
+
+
+# ---------------------------------------------------------------------------
 # Telemetry (PLN-719 Phase 9)
 # ---------------------------------------------------------------------------
 

--- a/plugins/code-review/tools/python/test_code_review_schema.py
+++ b/plugins/code-review/tools/python/test_code_review_schema.py
@@ -720,6 +720,55 @@ def test_merge_telemetry_overlay_dict_replaces_scalar_base():
     assert merged["duration_ms"] == {"unexpected": "shape"}
 
 
+def test_merge_telemetry_preserves_whitelisted_dict_on_null_overlay():
+    """Overlay supplying null for a whitelisted dict field is ignored.
+
+    Regression for a finalize-result crash: when telemetry.json contains
+    ``{"cache_hit_rate": null}`` (a producer signaling "no data"), the
+    previous merge logic overwrote the base dict with None. The next
+    writer in finalize-result then did
+    ``block["cache_hit_rate"][NAMESPACE] = rate`` and crashed with
+    ``TypeError: 'NoneType' object does not support item assignment``.
+    Now the whitelist contract is preserved: the base dict survives.
+    """
+    from code_review_schema import empty_telemetry, merge_telemetry
+    base = empty_telemetry()
+    # Seed the base with a value so we can verify it survives.
+    base["cache_hit_rate"] = {"signals": 0.5}
+    merged = merge_telemetry(base, {"cache_hit_rate": None})
+    assert merged["cache_hit_rate"] == {"signals": 0.5}
+
+
+def test_merge_telemetry_preserves_whitelisted_dict_on_scalar_overlay():
+    """Same invariant for other scalar shapes (int, str, list)."""
+    from code_review_schema import empty_telemetry, merge_telemetry
+    base = empty_telemetry()
+    base["tokens"] = {
+        "input_uncached": 100, "input_cached": 0, "output": 0, "by_model": {},
+    }
+    for malformed in (0, "garbage", [1, 2, 3], False):
+        merged = merge_telemetry(base, {"tokens": malformed})
+        assert isinstance(merged["tokens"], dict), (
+            f"tokens type invariant broken by overlay value {malformed!r}"
+        )
+        assert merged["tokens"]["input_uncached"] == 100
+
+
+def test_merge_telemetry_non_whitelisted_key_still_replaces_on_non_dict():
+    """The whitelist guard is scoped to whitelisted keys.
+
+    Non-whitelisted keys retain wholesale-replace semantics for any value,
+    including non-dict overlays — they don't have a type invariant to
+    preserve.
+    """
+    from code_review_schema import empty_telemetry, merge_telemetry
+    base = empty_telemetry()
+    base["future_config"] = {"version": 1}
+    # Non-whitelisted key + non-dict overlay → replace.
+    merged = merge_telemetry(base, {"future_config": None})
+    assert merged["future_config"] is None
+
+
 def test_telemetry_json_schema_declares_required_keys():
     """The exported JSON Schema lists telemetry as a typed object with required keys."""
     from code_review_schema import result_envelope_json_schema


### PR DESCRIPTION
## Summary

PLN-719 Phase 7 (Cache uniformity). Aligns the existing BHA cache with the canonical contract in SCHEMA.md §9 and wires the first \`telemetry.cache_hit_rate\` namespace producer end-to-end.

### Schema (\`code_review_schema.py\`)
- \`CACHE_TTL_DAYS\` constant declares per-namespace TTLs from PLN-719 §9: \`bha\`=30d, \`signals\`=7d, \`coverage_critic\`=7d, \`verifications\`=30d, \`overrides\`=90d.
- \`cache_ttl_days(namespace)\` helper for runtime lookups; \`None\` for unknown namespaces.

### Helpers (\`code_review_helpers.py\`)
- \`_is_entry_fresh(entry, namespace, *, now=None)\` — sweep-on-read TTL eviction. Stale \`cached_at\` → cache miss → next review regenerates fresh findings. Missing/malformed timestamps and unknown namespaces count as fresh (caller handles its own corruption fallback). Wired into both v1 and v2 cache-check paths **after** \`_entry_matches\`, so existing miss reasons (schema_version, model_id, prompt_hash, patch_hash) short-circuit before the TTL check.
- \`_extract_bha_cache_hit_rate(cr_dir)\` reads \`<cr_dir>/cache_result.json\` and normalizes \`stats.hit_rate_pct\` (0–100) into the canonical [0, 1] range that \`validate_telemetry\` enforces. \`_build_telemetry_block\` populates \`cache_hit_rate[\"bha\"]\` when a cache_result.json exists. Hygiene-only / no-cache runs leave the field empty (legal under the open-additionalProperties schema).

### Tests (+13)
- \`TestCacheTtlEviction\`: unit tests for \`_is_entry_fresh\` (within/past TTL, missing/malformed timestamps, unknown namespaces) plus end-to-end eviction for both v1 and v2 cache-check paths.
- \`TestFinalizeResult.test_cache_hit_rate_bha_*\`: populated when cache_result.json exists; absent otherwise; defensively dropped when hit_rate_pct is out of [0, 100].
- Schema tests: \`CACHE_TTL_DAYS\` matches PLN-719 §9, whitelist coverage vs \`CACHE_NAMESPACES\`, \`cache_ttl_days()\` helper.

### Test-data churn
Existing cache fixtures used hardcoded \`cached_at: \"2026-01-01T...\"\` timestamps which are now stale (>30d) and would flip every hit-expecting test to a miss. Replaced with a \`_FRESH_CACHED_AT\` module-level constant computed at test-collection time; miss-expecting tests are untouched (they short-circuit on \`_entry_matches\` before the TTL check). Added a \`_stale_cached_at(days_ago=N)\` helper for the new eviction tests.

### Docs
SCHEMA.md §9 gains a paragraph documenting sweep-on-read TTL enforcement, the Phase 7 BHA-only end-to-end status, and a note that the canonical per-file path layout (\`<CACHE_DIR>/bha/<file_hash>.json\`) is a future migration — current impl still uses a single \`manifest.json\` with the same key inputs and invalidation contract.

### Out of scope (Phase 7B follow-up)
- Per-file cache file layout (\`<CACHE_DIR>/bha/<file_hash>.json\`).
- \`file_content_hash\` vs \`patch_hash\` migration.
- Producers for the four future namespaces (ship with plans 03/05).

### Version
2.2.0 → **2.3.0** (MINOR — additive TTL enforcement + new telemetry producer; no external API break, cache-check output shape unchanged).

416 tests pass (was 404). ruff + uv pyright clean.

## Test plan
- [ ] CI green
- [ ] Spot-check: run \`/start\` on a small diff with caching enabled; verify finalize-result writes \`telemetry.cache_hit_rate[\"bha\"]\` consistent with the cache_result.json hit rate.
- [ ] Spot-check TTL: simulate a >30d-old manifest entry; confirm cache_check treats it as a miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)