### PR TITLE
feat(code): harness adapter interface, dataclasses, and registry (PLN-751)

### DIFF
--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.11.20",
+  "version": "1.12.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/tools/python/conftest.py
+++ b/plugins/code/tools/python/conftest.py
@@ -64,7 +64,11 @@ class _FakeAdapterClass(HarnessAdapter):
         stderr: str,
         exit_code: int,
     ) -> TerminalFailure:
-        return TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message=stderr)
+        return TerminalFailure(
+            status="RUNNER_ERROR",
+            subcode="NON_ZERO_EXIT",
+            message=stderr or "fake harness failure",
+        )
 
 
 class _AnotherFakeAdapterClass(HarnessAdapter):
@@ -99,7 +103,11 @@ class _AnotherFakeAdapterClass(HarnessAdapter):
         stderr: str,
         exit_code: int,
     ) -> TerminalFailure:
-        return TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message=stderr)
+        return TerminalFailure(
+            status="RUNNER_ERROR",
+            subcode="NON_ZERO_EXIT",
+            message=stderr or "fake harness failure",
+        )
 
 
 @pytest.fixture()

--- a/plugins/code/tools/python/conftest.py
+++ b/plugins/code/tools/python/conftest.py
@@ -1,1 +1,114 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
 CLOSEDLOOP_STATE_DIR = ".closedloop-ai"
+
+# ---------------------------------------------------------------------------
+# Harness types shared fixtures
+# ---------------------------------------------------------------------------
+
+# Ensure harness package is importable regardless of how pytest discovers tests.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from harness.adapter import HarnessAdapter  # noqa: E402
+from harness.types import (  # noqa: E402
+    Command,
+    InvocationRequest,
+    TerminalFailure,
+    TurnResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake adapter shared fixtures (used by test_harness_registry.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapterClass(HarnessAdapter):
+    """Minimal concrete HarnessAdapter that satisfies all six abstract methods.
+
+    Used in tests to verify registration and lookup without needing a real
+    harness subprocess.
+    """
+
+    name = "fake"
+
+    def supports(self, command: Command) -> bool:
+        return True
+
+    def build_entry_prompt(
+        self,
+        workdir: str,
+        prompt_name: str,
+        prd: str,
+        add_dirs: list[str],
+    ) -> str:
+        return f"entry:{workdir}:{prompt_name}"
+
+    def build_argv(self, request: InvocationRequest) -> list[str]:
+        return ["fake-harness", "--workdir", request.workdir]
+
+    def parse_session_id(self, raw_output: str) -> str | None:
+        return None
+
+    def parse_turn_result(self, raw_output: str) -> TurnResult:
+        return TurnResult(result_text=raw_output, is_error=False)
+
+    def classify_terminal_failure(
+        self,
+        raw_output: str,
+        stderr: str,
+        exit_code: int,
+    ) -> TerminalFailure:
+        return TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message=stderr)
+
+
+class _AnotherFakeAdapterClass(HarnessAdapter):
+    """A second concrete HarnessAdapter for multi-adapter registry tests."""
+
+    name = "another-fake"
+
+    def supports(self, command: Command) -> bool:
+        return False
+
+    def build_entry_prompt(
+        self,
+        workdir: str,
+        prompt_name: str,
+        prd: str,
+        add_dirs: list[str],
+    ) -> str:
+        return f"another:{workdir}"
+
+    def build_argv(self, request: InvocationRequest) -> list[str]:
+        return ["another-harness"]
+
+    def parse_session_id(self, raw_output: str) -> str | None:
+        return None
+
+    def parse_turn_result(self, raw_output: str) -> TurnResult:
+        return TurnResult(result_text=raw_output, is_error=False)
+
+    def classify_terminal_failure(
+        self,
+        raw_output: str,
+        stderr: str,
+        exit_code: int,
+    ) -> TerminalFailure:
+        return TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message=stderr)
+
+
+@pytest.fixture()
+def FakeAdapter():  # noqa: N802
+    """Return the FakeAdapter class for registry tests."""
+    return _FakeAdapterClass
+
+
+@pytest.fixture()
+def AnotherFakeAdapter():  # noqa: N802
+    """Return the AnotherFakeAdapter class for registry tests."""
+    return _AnotherFakeAdapterClass

--- a/plugins/code/tools/python/harness/__init__.py
+++ b/plugins/code/tools/python/harness/__init__.py
@@ -1,0 +1,51 @@
+"""
+harness -- Harness-agnostic orchestration contract for the code plugin.
+
+Re-exports types (Command, request/result dataclasses, JSON helpers),
+the HarnessAdapter ABC, and the adapter registry (register / get_adapter).
+"""
+
+from harness.adapter import HarnessAdapter
+from harness.registry import get_adapter, register
+from harness.types import (
+    CodeReviewFixRequest,
+    CodeReviewStartRequest,
+    Command,
+    ExportLearningsRequest,
+    InvocationRequest,
+    PlanExecuteRequest,
+    ProcessLearningsRequest,
+    TerminalFailure,
+    TurnResult,
+    request_from_json,
+    terminal_failure_from_json,
+    terminal_failure_to_json,
+    turn_result_from_json,
+    turn_result_to_json,
+)
+
+__all__ = [
+    # Enum
+    "Command",
+    # Request dataclasses
+    "PlanExecuteRequest",
+    "ProcessLearningsRequest",
+    "ExportLearningsRequest",
+    "CodeReviewStartRequest",
+    "CodeReviewFixRequest",
+    "InvocationRequest",
+    # Result dataclasses
+    "TurnResult",
+    "TerminalFailure",
+    # JSON helpers
+    "request_from_json",
+    "turn_result_to_json",
+    "turn_result_from_json",
+    "terminal_failure_to_json",
+    "terminal_failure_from_json",
+    # Adapter
+    "HarnessAdapter",
+    # Registry
+    "register",
+    "get_adapter",
+]

--- a/plugins/code/tools/python/harness/adapter.py
+++ b/plugins/code/tools/python/harness/adapter.py
@@ -1,0 +1,93 @@
+"""
+HarnessAdapter abstract base class.
+
+Subclasses must implement all six abstract methods plus declare a ``name``
+class variable. Failing to implement any abstract method causes Python to
+raise ``TypeError`` at instantiation time.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import ClassVar
+
+from harness.types import (
+    Command,
+    InvocationRequest,
+    TerminalFailure,
+    TurnResult,
+)
+
+
+class HarnessAdapter(ABC):
+    """Abstract contract every harness implementation must satisfy.
+
+    Class-level attributes
+    ----------------------
+    name : str
+        Registry key used by ``register()`` / ``get_adapter()``.
+
+    Abstract methods
+    ----------------
+    supports(command)
+        Return True if this adapter can handle the given Command.
+    build_entry_prompt(workdir, prompt_name, prd, add_dirs)
+        Return the string prompt to pass to the harness as the entry message.
+    build_argv(request)
+        Return the list of CLI arguments to invoke the harness subprocess.
+    parse_session_id(raw_output)
+        Extract the session identifier from raw harness stdout.
+    parse_turn_result(raw_output)
+        Parse raw harness stdout into a TurnResult.
+    classify_terminal_failure(raw_output, stderr, exit_code)
+        Classify a failed harness invocation as a TerminalFailure.
+    """
+
+    name: ClassVar[str]
+
+    @abstractmethod
+    def supports(self, command: Command) -> bool:
+        """Return True if this adapter handles ``command``."""
+
+    @abstractmethod
+    def build_entry_prompt(
+        self,
+        workdir: str,
+        prompt_name: str,
+        prd: str,
+        add_dirs: list[str],
+    ) -> str:
+        """Build the entry prompt string for the harness.
+
+        Parameters
+        ----------
+        workdir:
+            Absolute path to the working directory.
+        prompt_name:
+            Logical name of the prompt template to use.
+        prd:
+            PRD content to inject into the prompt.
+        add_dirs:
+            Additional directories to expose to the harness.
+        """
+
+    @abstractmethod
+    def build_argv(self, request: InvocationRequest) -> list[str]:
+        """Return the argument vector to invoke the harness subprocess."""
+
+    @abstractmethod
+    def parse_session_id(self, raw_output: str) -> str | None:
+        """Extract the session identifier from the harness's raw stdout."""
+
+    @abstractmethod
+    def parse_turn_result(self, raw_output: str) -> TurnResult:
+        """Parse the harness's raw stdout into a ``TurnResult``."""
+
+    @abstractmethod
+    def classify_terminal_failure(
+        self,
+        raw_output: str,
+        stderr: str,
+        exit_code: int,
+    ) -> TerminalFailure:
+        """Classify a failed invocation as a ``TerminalFailure``."""

--- a/plugins/code/tools/python/harness/cli.py
+++ b/plugins/code/tools/python/harness/cli.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import sys
+from typing import NoReturn
 
 from harness.registry import get_adapter
 from harness.types import (
@@ -80,20 +81,45 @@ def _dispatch(adapter_name: str, method_name: str, payload: dict[str, object]) -
     )
 
 
+def _error_exit(msg: str) -> NoReturn:
+    """Print a one-line error to stderr and exit non-zero.
+
+    Mirrors the ``error_exit`` idiom used by sibling code-plugin tool scripts
+    (e.g. ``count_tokens.py``) so shell callers get a clean message instead of
+    a raw Python traceback. Defined locally because the no-cross-import rule for
+    tool scripts forbids importing that helper directly.
+    """
+    print(f"Error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
 def main() -> None:
     """CLI entry point: reads stdin JSON, writes stdout JSON."""
     if len(sys.argv) != 3:
-        print(
-            "Usage: python -m harness.cli <adapter_name> <method_name>",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        _error_exit("Usage: python -m harness.cli <adapter_name> <method_name>")
 
     adapter_name = sys.argv[1]
     method_name = sys.argv[2]
 
-    payload = json.loads(sys.stdin.read())
-    result = _dispatch(adapter_name, method_name, payload)
+    raw_stdin = sys.stdin.read()
+    if not raw_stdin.strip():
+        _error_exit("No JSON request provided on stdin.")
+
+    try:
+        payload = json.loads(raw_stdin)
+    except json.JSONDecodeError as exc:
+        _error_exit(f"Invalid JSON request on stdin: {exc}")
+
+    if not isinstance(payload, dict):
+        _error_exit("JSON request must be a JSON object.")
+
+    try:
+        result = _dispatch(adapter_name, method_name, payload)
+    except (KeyError, ValueError, TypeError) as exc:
+        # KeyError stringifies with surrounding quotes; unwrap to the bare message.
+        message = exc.args[0] if exc.args else str(exc)
+        _error_exit(str(message))
+
     print(json.dumps(result))
 
 

--- a/plugins/code/tools/python/harness/cli.py
+++ b/plugins/code/tools/python/harness/cli.py
@@ -1,0 +1,101 @@
+"""
+Thin CLI entry point for the harness package.
+
+Usage::
+
+    python -m harness.cli <adapter_name> <method_name> < request.json
+
+Reads a JSON request from stdin, dispatches to the named method on the
+named adapter, and writes a JSON result to stdout. All harness-specific
+behavior is reached through the HarnessAdapter interface.
+
+Supported method names and their stdout JSON shape:
+
+- ``build_entry_prompt``  -> {"result": "<prompt_string>"}
+- ``build_argv``          -> {"argv": [...]}
+- ``parse_session_id``    -> {"session_id": "<id>" | null}
+- ``parse_turn_result``   -> TurnResult JSON (via turn_result_to_json)
+- ``classify_terminal_failure`` -> TerminalFailure JSON (via terminal_failure_to_json)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from harness.registry import get_adapter
+from harness.types import (
+    request_from_json,
+    terminal_failure_to_json,
+    turn_result_to_json,
+)
+
+
+def _dispatch(adapter_name: str, method_name: str, payload: dict[str, object]) -> dict[str, object]:
+    """Look up the adapter, deserialize the request, call the method.
+
+    Raises KeyError if the adapter or method is not found.
+    """
+    adapter_cls = get_adapter(adapter_name)
+    adapter = adapter_cls()
+
+    if method_name == "build_entry_prompt":
+        raw_add_dirs = payload.get("add_dirs", [])
+        add_dirs = list(raw_add_dirs) if isinstance(raw_add_dirs, list) else []
+        result = adapter.build_entry_prompt(
+            workdir=str(payload.get("workdir", "")),
+            prompt_name=str(payload.get("prompt_name", "")),
+            prd=str(payload.get("prd", "")),
+            add_dirs=add_dirs,
+        )
+        return {"result": result}
+
+    if method_name == "build_argv":
+        request = request_from_json(payload)
+        argv = adapter.build_argv(request)
+        return {"argv": argv}
+
+    if method_name == "parse_session_id":
+        raw_output = str(payload.get("raw_output", ""))
+        session_id = adapter.parse_session_id(raw_output)
+        return {"session_id": session_id}
+
+    if method_name == "parse_turn_result":
+        raw_output = str(payload.get("raw_output", ""))
+        turn_result = adapter.parse_turn_result(raw_output)
+        return turn_result_to_json(turn_result)
+
+    if method_name == "classify_terminal_failure":
+        raw_output = str(payload.get("raw_output", ""))
+        stderr = str(payload.get("stderr", ""))
+        raw_exit = payload.get("exit_code", 1)
+        exit_code = raw_exit if isinstance(raw_exit, int) else int(str(raw_exit))
+        failure = adapter.classify_terminal_failure(raw_output, stderr, exit_code)
+        return terminal_failure_to_json(failure)
+
+    raise KeyError(
+        f"Unknown method {method_name!r}. Supported methods: "
+        "build_entry_prompt, build_argv, parse_session_id, "
+        "parse_turn_result, classify_terminal_failure"
+    )
+
+
+def main() -> None:
+    """CLI entry point: reads stdin JSON, writes stdout JSON."""
+    if len(sys.argv) != 3:
+        print(
+            "Usage: python -m harness.cli <adapter_name> <method_name>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    adapter_name = sys.argv[1]
+    method_name = sys.argv[2]
+
+    payload = json.loads(sys.stdin.read())
+    result = _dispatch(adapter_name, method_name, payload)
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/code/tools/python/harness/registry.py
+++ b/plugins/code/tools/python/harness/registry.py
@@ -1,0 +1,61 @@
+"""
+Adapter registry: register and look up HarnessAdapter subclasses by name.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from harness.adapter import HarnessAdapter
+
+# Module-level registry: maps adapter name -> adapter class.
+_REGISTRY: dict[str, type["HarnessAdapter"]] = {}
+
+
+def register(adapter_cls: type["HarnessAdapter"]) -> type["HarnessAdapter"]:
+    """Register an adapter class under its ``name`` attribute.
+
+    Can be used as a class decorator::
+
+        @register
+        class MyAdapter(HarnessAdapter):
+            name = "my-adapter"
+            ...
+
+    Parameters
+    ----------
+    adapter_cls:
+        A concrete subclass of ``HarnessAdapter`` with a ``name`` class variable.
+
+    Returns
+    -------
+    adapter_cls
+        The same class, so the decorator form works transparently.
+    """
+    _REGISTRY[adapter_cls.name] = adapter_cls
+    return adapter_cls
+
+
+def get_adapter(name: str) -> type["HarnessAdapter"]:
+    """Return the registered adapter class for ``name``.
+
+    Parameters
+    ----------
+    name:
+        The adapter's ``name`` attribute value.
+
+    Raises
+    ------
+    KeyError
+        If no adapter with the given name has been registered. The error
+        message names all currently registered keys so the caller knows
+        what is available.
+    """
+    if name not in _REGISTRY:
+        available = ", ".join(sorted(_REGISTRY)) or "(none)"
+        raise KeyError(
+            f"No adapter registered with name {name!r}. "
+            f"Available adapters: {available}"
+        )
+    return _REGISTRY[name]

--- a/plugins/code/tools/python/harness/types.py
+++ b/plugins/code/tools/python/harness/types.py
@@ -1,0 +1,186 @@
+"""
+Harness type definitions: Command enum, request/result dataclasses, and JSON helpers.
+
+All dataclasses are frozen (immutable). TerminalFailure validates its subcode at
+construction time using the same regex enforced by run-loop.sh line 79.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import Literal, Union
+
+
+# ---------------------------------------------------------------------------
+# Command enum
+# ---------------------------------------------------------------------------
+
+class Command(StrEnum):
+    """Discriminant for all harness invocation requests.
+
+    Using StrEnum so pyright can verify exhaustiveness in match/case blocks.
+    """
+
+    PLAN_EXECUTE = "plan_execute"
+    PROCESS_LEARNINGS = "process_learnings"
+    EXPORT_LEARNINGS = "export_learnings"
+    CODE_REVIEW_START = "code_review_start"
+    CODE_REVIEW_FIX = "code_review_fix"
+
+
+# ---------------------------------------------------------------------------
+# Request dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, kw_only=True)
+class _BaseRequest:
+    """Fields shared by all invocation requests."""
+
+    workdir: str
+    prompt: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class PlanExecuteRequest(_BaseRequest):
+    """Request to execute a planning loop iteration."""
+
+    command: Literal[Command.PLAN_EXECUTE] = Command.PLAN_EXECUTE
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProcessLearningsRequest(_BaseRequest):
+    """Request to process learnings after an iteration."""
+
+    command: Literal[Command.PROCESS_LEARNINGS] = Command.PROCESS_LEARNINGS
+
+
+@dataclass(frozen=True, kw_only=True)
+class ExportLearningsRequest(_BaseRequest):
+    """Request to export accumulated learnings."""
+
+    command: Literal[Command.EXPORT_LEARNINGS] = Command.EXPORT_LEARNINGS
+
+
+@dataclass(frozen=True, kw_only=True)
+class CodeReviewStartRequest(_BaseRequest):
+    """Request to start a code-review run."""
+
+    base_sha: str
+    command: Literal[Command.CODE_REVIEW_START] = Command.CODE_REVIEW_START
+
+
+@dataclass(frozen=True, kw_only=True)
+class CodeReviewFixRequest(_BaseRequest):
+    """Request to apply code-review fixes."""
+
+    cr_dir: str
+    command: Literal[Command.CODE_REVIEW_FIX] = Command.CODE_REVIEW_FIX
+
+
+# Union alias used as the single type across the boundary.
+InvocationRequest = Union[
+    PlanExecuteRequest,
+    ProcessLearningsRequest,
+    ExportLearningsRequest,
+    CodeReviewStartRequest,
+    CodeReviewFixRequest,
+]
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class TurnResult:
+    """Successful result returned by an adapter method."""
+
+    result_text: str
+    is_error: bool
+    session_id: str | None = None
+
+
+_SUBCODE_RE = re.compile(r"^[A-Z][A-Z0-9_]{2,63}$")
+
+
+@dataclass(frozen=True)
+class TerminalFailure:
+    """Terminal failure returned by an adapter method.
+
+    ``subcode`` must match ``^[A-Z][A-Z0-9_]{2,63}$`` (the same constraint
+    enforced by ``write_loop_user_visible_failure()`` in run-loop.sh line 79).
+    """
+
+    status: str
+    subcode: str
+    message: str
+
+    def __post_init__(self) -> None:
+        if not _SUBCODE_RE.match(self.subcode):
+            raise ValueError(
+                f"TerminalFailure.subcode {self.subcode!r} does not match "
+                r"^[A-Z][A-Z0-9_]{2,63}$"
+            )
+
+
+# ---------------------------------------------------------------------------
+# JSON dispatch table for request deserialization
+# ---------------------------------------------------------------------------
+
+_BY_COMMAND: dict[Command, type] = {
+    Command.PLAN_EXECUTE: PlanExecuteRequest,
+    Command.PROCESS_LEARNINGS: ProcessLearningsRequest,
+    Command.EXPORT_LEARNINGS: ExportLearningsRequest,
+    Command.CODE_REVIEW_START: CodeReviewStartRequest,
+    Command.CODE_REVIEW_FIX: CodeReviewFixRequest,
+}
+
+
+def request_from_json(payload: dict[str, object]) -> InvocationRequest:
+    """Deserialize a JSON payload dict to the appropriate request dataclass.
+
+    Dispatches on ``payload["command"]`` via the ``_BY_COMMAND`` table.
+
+    Raises:
+        KeyError: if ``"command"`` is missing from payload.
+        ValueError: if ``payload["command"]`` is not a valid ``Command`` member.
+        TypeError: if required fields are absent for the resolved request class.
+    """
+    command = Command(payload["command"])  # type: ignore[arg-type]
+    cls = _BY_COMMAND[command]
+    kwargs = {k: v for k, v in payload.items() if k != "command"}
+    return cls(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+def turn_result_to_json(result: TurnResult) -> dict[str, object]:
+    """Serialize a TurnResult to a plain dict suitable for json.dumps."""
+    return asdict(result)
+
+
+def turn_result_from_json(payload: dict[str, object]) -> TurnResult:
+    """Deserialize a plain dict (from json.loads) to a TurnResult."""
+    return TurnResult(
+        result_text=payload["result_text"],  # type: ignore[arg-type]
+        is_error=payload["is_error"],  # type: ignore[arg-type]
+        session_id=payload.get("session_id"),  # type: ignore[arg-type]
+    )
+
+
+def terminal_failure_to_json(failure: TerminalFailure) -> dict[str, object]:
+    """Serialize a TerminalFailure to a plain dict suitable for json.dumps."""
+    return asdict(failure)
+
+
+def terminal_failure_from_json(payload: dict[str, object]) -> TerminalFailure:
+    """Deserialize a plain dict (from json.loads) to a TerminalFailure."""
+    return TerminalFailure(
+        status=payload["status"],  # type: ignore[arg-type]
+        subcode=payload["subcode"],  # type: ignore[arg-type]
+        message=payload["message"],  # type: ignore[arg-type]
+    )

--- a/plugins/code/tools/python/harness/types.py
+++ b/plugins/code/tools/python/harness/types.py
@@ -104,13 +104,29 @@ class TurnResult:
 
 _SUBCODE_RE = re.compile(r"^[A-Z][A-Z0-9_]{2,63}$")
 
+# Mirrors every constraint enforced by ``write_loop_user_visible_failure()`` in
+# run-loop.sh:55-87. Kept in sync with that function (the authoritative source):
+# the ``status`` allowlist matches its ``case "$code"`` block, and the message
+# length matches its 1-1000 char guard.
+_STATUS_ALLOWLIST = frozenset(
+    {"RUNNER_ERROR", "PRE_RUN_VALIDATION_FAILED", "PLAN_STATE_UNAVAILABLE"}
+)
+_MAX_MESSAGE_LEN = 1000
+
 
 @dataclass(frozen=True)
 class TerminalFailure:
     """Terminal failure returned by an adapter method.
 
-    ``subcode`` must match ``^[A-Z][A-Z0-9_]{2,63}$`` (the same constraint
-    enforced by ``write_loop_user_visible_failure()`` in run-loop.sh line 79).
+    Validates all three constraints enforced by
+    ``write_loop_user_visible_failure()`` in run-loop.sh:55-87, so a misbuilt
+    failure fails fast at construction instead of being rejected downstream when
+    bash writes the user-visible marker:
+
+    - ``status`` must be one of ``RUNNER_ERROR``, ``PRE_RUN_VALIDATION_FAILED``,
+      ``PLAN_STATE_UNAVAILABLE`` (the bash ``code`` allowlist).
+    - ``subcode`` must match ``^[A-Z][A-Z0-9_]{2,63}$``.
+    - ``message`` must be 1-1000 characters (non-empty, not over-long).
     """
 
     status: str
@@ -118,10 +134,21 @@ class TerminalFailure:
     message: str
 
     def __post_init__(self) -> None:
+        if self.status not in _STATUS_ALLOWLIST:
+            allowed = ", ".join(sorted(_STATUS_ALLOWLIST))
+            raise ValueError(
+                f"TerminalFailure.status {self.status!r} is not allowed. "
+                f"Must be one of: {allowed}"
+            )
         if not _SUBCODE_RE.match(self.subcode):
             raise ValueError(
                 f"TerminalFailure.subcode {self.subcode!r} does not match "
                 r"^[A-Z][A-Z0-9_]{2,63}$"
+            )
+        if not 1 <= len(self.message) <= _MAX_MESSAGE_LEN:
+            raise ValueError(
+                f"TerminalFailure.message must be 1-{_MAX_MESSAGE_LEN} characters "
+                f"(got {len(self.message)})"
             )
 
 

--- a/plugins/code/tools/python/test_harness_cli.py
+++ b/plugins/code/tools/python/test_harness_cli.py
@@ -1,0 +1,203 @@
+"""Tests for harness/cli.py — subprocess-based CLI integration tests.
+
+Covers:
+- CLI dispatches to a registered fake adapter and returns valid JSON on stdout (AC-006)
+- Full stdin-to-stdout round-trip: TurnResult JSON round-trips back to an equal
+  TurnResult via turn_result_from_json (AC-007)
+
+All test cases invoke the CLI as a subprocess so the full stdin→dispatch→stdout
+path is exercised end-to-end, exactly as a shell caller would use it.
+
+The fake adapter is injected into the subprocess via Python's ``-c`` flag, which
+registers the adapter in the subprocess's registry before calling ``harness.cli.main()``.
+This avoids the need for a separate helper script while keeping each case self-contained.
+
+Uses a table-driven (pytest.mark.parametrize) approach throughout.
+Shared fixtures (FakeAdapter, AnotherFakeAdapter) are defined in conftest.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HARNESS_DIR = str(Path(__file__).parent)
+
+# ---------------------------------------------------------------------------
+# Helper: run the CLI in a subprocess with a pre-registered fake adapter
+# ---------------------------------------------------------------------------
+
+_BOOTSTRAP = """\
+import sys
+sys.path.insert(0, {harness_dir!r})
+from harness.adapter import HarnessAdapter
+from harness.registry import register
+from harness.types import Command, InvocationRequest, TurnResult, TerminalFailure
+
+class _SubprocessFakeAdapter(HarnessAdapter):
+    name = "fake"
+
+    def supports(self, command: Command) -> bool:
+        return True
+
+    def build_entry_prompt(self, workdir, prompt_name, prd, add_dirs) -> str:
+        return f"entry:{{workdir}}:{{prompt_name}}"
+
+    def build_argv(self, request: InvocationRequest) -> list:
+        return ["fake-harness", "--workdir", request.workdir]
+
+    def parse_session_id(self, raw_output: str):
+        return None
+
+    def parse_turn_result(self, raw_output: str) -> TurnResult:
+        return TurnResult(result_text=raw_output, is_error=False)
+
+    def classify_terminal_failure(self, raw_output, stderr, exit_code) -> TerminalFailure:
+        return TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message=stderr)
+
+register(_SubprocessFakeAdapter)
+
+import harness.cli
+harness.cli.main()
+"""
+
+
+def _run_cli(
+    adapter_name: str,
+    method_name: str,
+    stdin_payload: dict[str, object],
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the CLI via subprocess with the fake adapter pre-registered."""
+    code = _BOOTSTRAP.format(harness_dir=HARNESS_DIR)
+    return subprocess.run(
+        [sys.executable, "-c", code, adapter_name, method_name],
+        input=json.dumps(stdin_payload),
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_turn_result: full stdin-to-stdout round-trip (AC-006, AC-007)
+# ---------------------------------------------------------------------------
+
+# Each case: (raw_output, expected_result_text, expected_is_error)
+# The fake adapter's parse_turn_result returns TurnResult(result_text=raw_output, is_error=False).
+PARSE_TURN_RESULT_CASES = [
+    ("hello world", "hello world", False),
+    ("", "", False),
+    ("multi\nline\noutput", "multi\nline\noutput", False),
+    ("exit code 0", "exit code 0", False),
+]
+
+
+@pytest.mark.parametrize("raw_output,expected_text,expected_is_error", PARSE_TURN_RESULT_CASES)
+def test_parse_turn_result_round_trip(raw_output: str, expected_text: str, expected_is_error: bool) -> None:
+    """CLI exits 0, returns valid JSON, and round-trips via turn_result_from_json (AC-006, AC-007)."""
+    from harness.types import TurnResult, turn_result_from_json  # noqa: PLC0415
+
+    payload: dict[str, object] = {
+        "command": "plan_execute",
+        "workdir": "/work",
+        "prompt": "run",
+        "raw_output": raw_output,
+    }
+    proc = _run_cli("fake", "parse_turn_result", payload)
+    assert proc.returncode == 0, f"CLI exited {proc.returncode}; stderr={proc.stderr!r}"
+
+    stdout_dict = json.loads(proc.stdout)
+    assert isinstance(stdout_dict, dict)
+
+    restored = turn_result_from_json(stdout_dict)
+    expected = TurnResult(result_text=expected_text, is_error=expected_is_error)
+    assert restored == expected, f"Round-trip mismatch: {restored!r} != {expected!r}"
+
+
+# ---------------------------------------------------------------------------
+# build_argv: CLI dispatches correctly (AC-006)
+# ---------------------------------------------------------------------------
+
+BUILD_ARGV_CASES = [
+    # (command, workdir, prompt, expected_argv_contains)
+    ("plan_execute", "/project", "run the plan", "fake-harness"),
+    ("code_review_start", "/src", "do review", "fake-harness"),
+    ("process_learnings", "/data", "learn", "fake-harness"),
+]
+
+
+@pytest.mark.parametrize("command,workdir,prompt,expected_argv_token", BUILD_ARGV_CASES)
+def test_build_argv_dispatch(command: str, workdir: str, prompt: str, expected_argv_token: str) -> None:
+    """CLI exits 0 and returns an argv list containing the expected token (AC-006)."""
+    payload: dict[str, object] = {"command": command, "workdir": workdir, "prompt": prompt}
+    if command == "code_review_start":
+        payload["base_sha"] = "deadbeef"
+    proc = _run_cli("fake", "build_argv", payload)
+    assert proc.returncode == 0, f"CLI exited {proc.returncode}; stderr={proc.stderr!r}"
+    result = json.loads(proc.stdout)
+    assert "argv" in result
+    assert expected_argv_token in result["argv"]
+
+
+# ---------------------------------------------------------------------------
+# classify_terminal_failure: dispatches and returns JSON (AC-006)
+# ---------------------------------------------------------------------------
+
+CLASSIFY_FAILURE_CASES = [
+    # (command, workdir, stderr, exit_code)
+    ("plan_execute", "/work", "something went wrong", 1),
+    ("export_learnings", "/out", "timeout", 2),
+]
+
+
+@pytest.mark.parametrize("command,workdir,stderr,exit_code", CLASSIFY_FAILURE_CASES)
+def test_classify_terminal_failure_dispatch(command: str, workdir: str, stderr: str, exit_code: int) -> None:
+    """CLI exits 0 and returns valid TerminalFailure JSON (AC-006)."""
+    payload: dict[str, object] = {
+        "command": command,
+        "workdir": workdir,
+        "prompt": "run",
+        "raw_output": "",
+        "stderr": stderr,
+        "exit_code": exit_code,
+    }
+    proc = _run_cli("fake", "classify_terminal_failure", payload)
+    assert proc.returncode == 0, f"CLI exited {proc.returncode}; stderr={proc.stderr!r}"
+    result = json.loads(proc.stdout)
+    assert "status" in result
+    assert "subcode" in result
+    assert "message" in result
+
+
+# ---------------------------------------------------------------------------
+# Error cases: unregistered adapter / unknown method (AC-006)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_adapter_exits_nonzero() -> None:
+    """CLI exits non-zero when the adapter name is not registered."""
+    payload: dict[str, object] = {"command": "plan_execute", "workdir": "/work", "prompt": "run"}
+    proc = _run_cli("nonexistent-adapter", "parse_turn_result", payload)
+    assert proc.returncode != 0
+
+
+def test_unknown_method_exits_nonzero() -> None:
+    """CLI exits non-zero when the method name is not supported."""
+    payload: dict[str, object] = {"command": "plan_execute", "workdir": "/work", "prompt": "run"}
+    proc = _run_cli("fake", "nonexistent_method", payload)
+    assert proc.returncode != 0
+
+
+def test_missing_args_exits_nonzero() -> None:
+    """CLI exits non-zero (prints usage) when called with wrong number of arguments."""
+    code = _BOOTSTRAP.format(harness_dir=HARNESS_DIR)
+    proc = subprocess.run(
+        [sys.executable, "-c", code],  # no adapter_name or method_name
+        input="{}",
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0

--- a/plugins/code/tools/python/test_harness_cli.py
+++ b/plugins/code/tools/python/test_harness_cli.py
@@ -57,7 +57,7 @@ class _SubprocessFakeAdapter(HarnessAdapter):
         return TurnResult(result_text=raw_output, is_error=False)
 
     def classify_terminal_failure(self, raw_output, stderr, exit_code) -> TerminalFailure:
-        return TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message=stderr)
+        return TerminalFailure(status="RUNNER_ERROR", subcode="NON_ZERO_EXIT", message=stderr or "fail")
 
 register(_SubprocessFakeAdapter)
 

--- a/plugins/code/tools/python/test_harness_registry.py
+++ b/plugins/code/tools/python/test_harness_registry.py
@@ -155,7 +155,7 @@ def test_register_overwrites_existing_entry(FakeAdapter) -> None:
             return TurnResult(result_text=raw_output, is_error=False)
 
         def classify_terminal_failure(self, raw_output, stderr, exit_code) -> TerminalFailure:
-            return TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message=stderr)
+            return TerminalFailure(status="RUNNER_ERROR", subcode="NON_ZERO_EXIT", message=stderr or "fail")
 
     register(FakeAdapter)
     register(ReplacementAdapter)
@@ -185,7 +185,7 @@ def test_register_as_class_decorator(FakeAdapter) -> None:
             return TurnResult(result_text=raw_output, is_error=False)
 
         def classify_terminal_failure(self, raw_output, stderr, exit_code) -> TerminalFailure:
-            return TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message=stderr)
+            return TerminalFailure(status="RUNNER_ERROR", subcode="NON_ZERO_EXIT", message=stderr or "fail")
 
     assert get_adapter("decorated") is DecoratedAdapter
 

--- a/plugins/code/tools/python/test_harness_registry.py
+++ b/plugins/code/tools/python/test_harness_registry.py
@@ -1,0 +1,225 @@
+"""Tests for harness/registry.py.
+
+Covers:
+- register/get_adapter with a fake adapter class (AC-005)
+- Successful registration and lookup
+- get_adapter("nonexistent") raises a clear, actionable error naming registered keys (AC-005)
+- HarnessAdapter ABC enforcement: TypeError on instantiation of incomplete subclass (AC-001)
+
+Uses a table-driven (pytest.mark.parametrize) approach throughout.
+Shared adapter classes (FakeAdapter/AnotherFakeAdapter via _FakeAdapterClass /
+_AnotherFakeAdapterClass) and pytest fixtures are defined in conftest.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from harness.adapter import HarnessAdapter
+from harness.registry import _REGISTRY, get_adapter, register
+from harness.types import (
+    Command,
+    InvocationRequest,
+    TerminalFailure,
+    TurnResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: registry isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Save and restore the registry state around each test for isolation."""
+    snapshot = dict(_REGISTRY)
+    yield
+    _REGISTRY.clear()
+    _REGISTRY.update(snapshot)
+
+
+# ---------------------------------------------------------------------------
+# ABC enforcement: TypeError on incomplete subclass (AC-001)
+# ---------------------------------------------------------------------------
+# Define incomplete subclasses at module level so parametrize can reference them.
+
+
+class _MissingAllMethods(HarnessAdapter):
+    """Subclass that implements none of the six abstract methods."""
+
+    name = "missing-all"
+
+
+class _MissingFiveMethods(HarnessAdapter):
+    """Subclass that implements only supports(), omitting five methods."""
+
+    name = "missing-five"
+
+    def supports(self, command: Command) -> bool:
+        return True
+
+
+class _MissingOneLast(HarnessAdapter):
+    """Subclass that omits only classify_terminal_failure."""
+
+    name = "missing-one"
+
+    def supports(self, command: Command) -> bool:
+        return True
+
+    def build_entry_prompt(
+        self,
+        workdir: str,
+        prompt_name: str,
+        prd: str,
+        add_dirs: list[str],
+    ) -> str:
+        return ""
+
+    def build_argv(self, request: InvocationRequest) -> list[str]:
+        return []
+
+    def parse_session_id(self, raw_output: str) -> str | None:
+        return None
+
+    def parse_turn_result(self, raw_output: str) -> TurnResult:
+        return TurnResult(result_text=raw_output, is_error=False)
+
+
+ABC_ENFORCEMENT_CASES = [
+    ("missing all six methods", _MissingAllMethods),
+    ("missing five methods", _MissingFiveMethods),
+    ("missing only classify_terminal_failure", _MissingOneLast),
+]
+
+
+@pytest.mark.parametrize("description,incomplete_cls", ABC_ENFORCEMENT_CASES)
+def test_incomplete_subclass_raises_type_error(description: str, incomplete_cls) -> None:
+    """Python raises TypeError when instantiating an incomplete HarnessAdapter subclass (AC-001)."""
+    with pytest.raises(TypeError):
+        incomplete_cls()
+
+
+# ---------------------------------------------------------------------------
+# register / get_adapter: successful registration and lookup (AC-005)
+# ---------------------------------------------------------------------------
+
+
+def test_register_returns_the_class(FakeAdapter) -> None:
+    """register() returns the same class so it can be used as a decorator."""
+    result = register(FakeAdapter)
+    assert result is FakeAdapter
+
+
+def test_register_stores_under_name_attribute(FakeAdapter) -> None:
+    """register() keys the adapter under its .name attribute."""
+    register(FakeAdapter)
+    assert _REGISTRY.get(FakeAdapter.name) is FakeAdapter
+
+
+def test_get_adapter_returns_registered_class(FakeAdapter) -> None:
+    """get_adapter(name) returns the class that was registered under that name."""
+    register(FakeAdapter)
+    result = get_adapter(FakeAdapter.name)
+    assert result is FakeAdapter
+
+
+def test_register_multiple_adapters_coexist(FakeAdapter, AnotherFakeAdapter) -> None:
+    """Multiple distinct adapters can coexist in the registry under different names."""
+    register(FakeAdapter)
+    register(AnotherFakeAdapter)
+    assert get_adapter(FakeAdapter.name) is FakeAdapter
+    assert get_adapter(AnotherFakeAdapter.name) is AnotherFakeAdapter
+
+
+def test_register_overwrites_existing_entry(FakeAdapter) -> None:
+    """Registering a new class under the same name replaces the old entry."""
+
+    class ReplacementAdapter(HarnessAdapter):
+        name = FakeAdapter.name  # reuse the same key
+
+        def supports(self, command: Command) -> bool:
+            return False
+
+        def build_entry_prompt(self, workdir, prompt_name, prd, add_dirs) -> str:
+            return ""
+
+        def build_argv(self, request: InvocationRequest) -> list[str]:
+            return []
+
+        def parse_session_id(self, raw_output: str) -> str | None:
+            return None
+
+        def parse_turn_result(self, raw_output: str) -> TurnResult:
+            return TurnResult(result_text=raw_output, is_error=False)
+
+        def classify_terminal_failure(self, raw_output, stderr, exit_code) -> TerminalFailure:
+            return TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message=stderr)
+
+    register(FakeAdapter)
+    register(ReplacementAdapter)
+    assert get_adapter(FakeAdapter.name) is ReplacementAdapter
+
+
+def test_register_as_class_decorator(FakeAdapter) -> None:
+    """register() can be applied as a class decorator and returns the class unchanged."""
+
+    @register
+    class DecoratedAdapter(HarnessAdapter):
+        name = "decorated"
+
+        def supports(self, command: Command) -> bool:
+            return True
+
+        def build_entry_prompt(self, workdir, prompt_name, prd, add_dirs) -> str:
+            return ""
+
+        def build_argv(self, request: InvocationRequest) -> list[str]:
+            return []
+
+        def parse_session_id(self, raw_output: str) -> str | None:
+            return None
+
+        def parse_turn_result(self, raw_output: str) -> TurnResult:
+            return TurnResult(result_text=raw_output, is_error=False)
+
+        def classify_terminal_failure(self, raw_output, stderr, exit_code) -> TerminalFailure:
+            return TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message=stderr)
+
+    assert get_adapter("decorated") is DecoratedAdapter
+
+
+# ---------------------------------------------------------------------------
+# get_adapter("nonexistent") raises actionable KeyError (AC-005)
+# ---------------------------------------------------------------------------
+
+# Each case: (names_to_register, lookup_name, expected_substrings_in_error)
+ERROR_MESSAGE_CASES = [
+    (["fake"], "missing", ["fake"]),
+    (["fake", "another-fake"], "unknown", ["fake", "another-fake"]),
+    ([], "anything", ["(none)"]),
+]
+
+
+@pytest.mark.parametrize("registered_names,lookup_name,expected_substrings", ERROR_MESSAGE_CASES)
+def test_get_adapter_error_message_content(
+    FakeAdapter, AnotherFakeAdapter, registered_names: list[str], lookup_name: str, expected_substrings: list[str]
+) -> None:
+    """get_adapter error message contains expected substrings for different registry states (AC-005)."""
+    name_to_cls = {
+        FakeAdapter.name: FakeAdapter,
+        AnotherFakeAdapter.name: AnotherFakeAdapter,
+    }
+    _REGISTRY.clear()
+    for name in registered_names:
+        _REGISTRY[name] = name_to_cls[name]
+
+    with pytest.raises(KeyError) as exc_info:
+        get_adapter(lookup_name)
+
+    error_message = str(exc_info.value)
+    for substring in expected_substrings:
+        assert substring in error_message, (
+            f"Expected {substring!r} in error message, got: {error_message!r}"
+        )

--- a/plugins/code/tools/python/test_harness_types.py
+++ b/plugins/code/tools/python/test_harness_types.py
@@ -58,12 +58,6 @@ def test_command_enum_has_exactly_five_members() -> None:
     assert len(Command) == 5
 
 
-def test_command_is_str_enum() -> None:
-    """Command members are strings (StrEnum)."""
-    for member in Command:
-        assert isinstance(member, str)
-
-
 # ---------------------------------------------------------------------------
 # Request dataclass construction and field access (AC-003)
 # ---------------------------------------------------------------------------
@@ -119,13 +113,13 @@ def test_request_construction_and_field_access(
         assert getattr(req, field) == value
 
 
-@pytest.mark.parametrize(
-    "factory,kwargs,expected_command,extra_checks",
-    REQUEST_CONSTRUCTION_CASES,
-)
-def test_request_dataclasses_are_frozen(factory, kwargs, expected_command, extra_checks) -> None:
-    """Request dataclasses are immutable (frozen)."""
-    req = factory(**kwargs)
+def test_request_dataclasses_are_frozen() -> None:
+    """Request dataclasses are immutable (frozen).
+
+    ``frozen=True`` is inherited identically from ``_BaseRequest`` by all five
+    request types, so one representative is sufficient to pin the contract.
+    """
+    req = PlanExecuteRequest(workdir="/work", prompt="do it")
     with pytest.raises((AttributeError, TypeError)):
         req.workdir = "mutated"  # type: ignore[misc]
 

--- a/plugins/code/tools/python/test_harness_types.py
+++ b/plugins/code/tools/python/test_harness_types.py
@@ -1,0 +1,322 @@
+"""Tests for harness/types.py.
+
+Covers:
+- Command enum member values (AC-002)
+- All request dataclass construction and field access (AC-003)
+- TerminalFailure subcode validation — valid accepted, invalid rejected (AC-004)
+- TurnResult construction
+- JSON round-trip: request_from_json, turn_result serialization,
+  terminal_failure serialization (AC-003, AC-007)
+
+Uses a table-driven (pytest.mark.parametrize) approach throughout.
+Shared fixtures are defined in conftest.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from harness.types import (
+    CodeReviewFixRequest,
+    CodeReviewStartRequest,
+    Command,
+    ExportLearningsRequest,
+    PlanExecuteRequest,
+    ProcessLearningsRequest,
+    TerminalFailure,
+    TurnResult,
+    request_from_json,
+    terminal_failure_from_json,
+    terminal_failure_to_json,
+    turn_result_from_json,
+    turn_result_to_json,
+)
+
+
+# ---------------------------------------------------------------------------
+# Command enum member values (AC-002)
+# ---------------------------------------------------------------------------
+
+COMMAND_MEMBER_CASES = [
+    (Command.PLAN_EXECUTE, "plan_execute"),
+    (Command.PROCESS_LEARNINGS, "process_learnings"),
+    (Command.EXPORT_LEARNINGS, "export_learnings"),
+    (Command.CODE_REVIEW_START, "code_review_start"),
+    (Command.CODE_REVIEW_FIX, "code_review_fix"),
+]
+
+
+@pytest.mark.parametrize("member,expected_value", COMMAND_MEMBER_CASES)
+def test_command_enum_values(member: Command, expected_value: str) -> None:
+    """Each Command member has the expected string value."""
+    assert member == expected_value
+    assert str(member) == expected_value
+
+
+def test_command_enum_has_exactly_five_members() -> None:
+    """Command enum contains exactly five members."""
+    assert len(Command) == 5
+
+
+def test_command_is_str_enum() -> None:
+    """Command members are strings (StrEnum)."""
+    for member in Command:
+        assert isinstance(member, str)
+
+
+# ---------------------------------------------------------------------------
+# Request dataclass construction and field access (AC-003)
+# ---------------------------------------------------------------------------
+
+REQUEST_CONSTRUCTION_CASES = [
+    # (dataclass_factory, kwargs, expected_command, extra_field_checks)
+    (
+        PlanExecuteRequest,
+        {"workdir": "/work", "prompt": "do it"},
+        Command.PLAN_EXECUTE,
+        {},
+    ),
+    (
+        ProcessLearningsRequest,
+        {"workdir": "/work", "prompt": "learn"},
+        Command.PROCESS_LEARNINGS,
+        {},
+    ),
+    (
+        ExportLearningsRequest,
+        {"workdir": "/work", "prompt": "export"},
+        Command.EXPORT_LEARNINGS,
+        {},
+    ),
+    (
+        CodeReviewStartRequest,
+        {"workdir": "/work", "prompt": "review", "base_sha": "abc123"},
+        Command.CODE_REVIEW_START,
+        {"base_sha": "abc123"},
+    ),
+    (
+        CodeReviewFixRequest,
+        {"workdir": "/work", "prompt": "fix", "cr_dir": "/tmp/cr"},
+        Command.CODE_REVIEW_FIX,
+        {"cr_dir": "/tmp/cr"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "factory,kwargs,expected_command,extra_checks",
+    REQUEST_CONSTRUCTION_CASES,
+)
+def test_request_construction_and_field_access(
+    factory, kwargs, expected_command, extra_checks
+) -> None:
+    """Each request dataclass constructs successfully with correct field values."""
+    req = factory(**kwargs)
+    assert req.workdir == kwargs["workdir"]
+    assert req.prompt == kwargs["prompt"]
+    assert req.command == expected_command
+    for field, value in extra_checks.items():
+        assert getattr(req, field) == value
+
+
+@pytest.mark.parametrize(
+    "factory,kwargs,expected_command,extra_checks",
+    REQUEST_CONSTRUCTION_CASES,
+)
+def test_request_dataclasses_are_frozen(factory, kwargs, expected_command, extra_checks) -> None:
+    """Request dataclasses are immutable (frozen)."""
+    req = factory(**kwargs)
+    with pytest.raises((AttributeError, TypeError)):
+        req.workdir = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TurnResult construction
+# ---------------------------------------------------------------------------
+
+TURN_RESULT_CASES = [
+    # (result_text, is_error, session_id)
+    ("success output", False, "sess-001"),
+    ("error output", True, None),
+    ("", False, "sess-xyz"),
+    ("multi\nline\ntext", False, None),
+]
+
+
+@pytest.mark.parametrize("result_text,is_error,session_id", TURN_RESULT_CASES)
+def test_turn_result_construction(
+    result_text: str, is_error: bool, session_id: str | None
+) -> None:
+    """TurnResult constructs with correct field values."""
+    tr = TurnResult(result_text=result_text, is_error=is_error, session_id=session_id)
+    assert tr.result_text == result_text
+    assert tr.is_error == is_error
+    assert tr.session_id == session_id
+
+
+def test_turn_result_session_id_defaults_to_none() -> None:
+    """TurnResult.session_id defaults to None when omitted."""
+    tr = TurnResult(result_text="ok", is_error=False)
+    assert tr.session_id is None
+
+
+def test_turn_result_is_frozen() -> None:
+    """TurnResult is immutable (frozen dataclass)."""
+    tr = TurnResult(result_text="ok", is_error=False)
+    with pytest.raises((AttributeError, TypeError)):
+        tr.result_text = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TerminalFailure subcode validation (AC-004)
+# ---------------------------------------------------------------------------
+
+VALID_SUBCODES = [
+    "ABC",
+    "XYZ",
+    "ABC_DEF",
+    "A0B",
+    "RUNNER_ERROR",
+    "TIMEOUT_FAILURE",
+    "A" + "B" * 63,  # exactly 64 chars total — max allowed (1 + 63)
+    "A12",
+    "A_B_C_D",
+]
+
+INVALID_SUBCODES = [
+    "",               # empty
+    "AB",             # too short (2 chars total, needs at least 3)
+    "ab",             # lowercase — must start uppercase
+    "abc",            # all lowercase
+    "1ABC",           # starts with digit
+    "_ABC",           # starts with underscore
+    "A" + "B" * 64,  # 65 chars — too long (max is 1 + 63 = 64)
+    "A B",            # contains space
+    "A-B",            # contains hyphen
+    "A.B",            # contains dot
+]
+
+
+@pytest.mark.parametrize("subcode", VALID_SUBCODES)
+def test_terminal_failure_valid_subcode_accepted(subcode: str) -> None:
+    """TerminalFailure constructs successfully with a valid subcode."""
+    tf = TerminalFailure(status="error", subcode=subcode, message="msg")
+    assert tf.subcode == subcode
+
+
+@pytest.mark.parametrize("subcode", INVALID_SUBCODES)
+def test_terminal_failure_invalid_subcode_rejected(subcode: str) -> None:
+    """TerminalFailure raises ValueError for invalid subcodes before construction completes."""
+    with pytest.raises(ValueError, match="subcode"):
+        TerminalFailure(status="error", subcode=subcode, message="msg")
+
+
+def test_terminal_failure_field_access() -> None:
+    """TerminalFailure fields are accessible after construction."""
+    tf = TerminalFailure(status="RUNNER_ERROR", subcode="XYZ_FAILURE", message="Loop failed.")
+    assert tf.status == "RUNNER_ERROR"
+    assert tf.subcode == "XYZ_FAILURE"
+    assert tf.message == "Loop failed."
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip: request_from_json (AC-003)
+# ---------------------------------------------------------------------------
+
+REQUEST_FROM_JSON_CASES = [
+    (
+        {"command": "plan_execute", "workdir": "/work", "prompt": "run"},
+        PlanExecuteRequest,
+        {"workdir": "/work", "prompt": "run", "command": Command.PLAN_EXECUTE},
+    ),
+    (
+        {"command": "process_learnings", "workdir": "/data", "prompt": "learn"},
+        ProcessLearningsRequest,
+        {"workdir": "/data", "prompt": "learn", "command": Command.PROCESS_LEARNINGS},
+    ),
+    (
+        {"command": "export_learnings", "workdir": "/out", "prompt": "export"},
+        ExportLearningsRequest,
+        {"workdir": "/out", "prompt": "export", "command": Command.EXPORT_LEARNINGS},
+    ),
+    (
+        {"command": "code_review_start", "workdir": "/src", "prompt": "review", "base_sha": "deadbeef"},
+        CodeReviewStartRequest,
+        {"workdir": "/src", "prompt": "review", "base_sha": "deadbeef", "command": Command.CODE_REVIEW_START},
+    ),
+    (
+        {"command": "code_review_fix", "workdir": "/src", "prompt": "fix", "cr_dir": "/tmp/cr"},
+        CodeReviewFixRequest,
+        {"workdir": "/src", "prompt": "fix", "cr_dir": "/tmp/cr", "command": Command.CODE_REVIEW_FIX},
+    ),
+]
+
+
+@pytest.mark.parametrize("payload,expected_type,expected_fields", REQUEST_FROM_JSON_CASES)
+def test_request_from_json_returns_correct_type_and_fields(
+    payload, expected_type, expected_fields
+) -> None:
+    """request_from_json returns the correct type with all fields populated."""
+    req = request_from_json(payload)
+    assert isinstance(req, expected_type)
+    for field, value in expected_fields.items():
+        assert getattr(req, field) == value
+
+
+def test_request_from_json_missing_command_raises_key_error() -> None:
+    """request_from_json raises KeyError when 'command' key is absent."""
+    with pytest.raises(KeyError):
+        request_from_json({"workdir": "/work", "prompt": "run"})
+
+
+def test_request_from_json_unknown_command_raises_value_error() -> None:
+    """request_from_json raises ValueError for an unrecognized command string."""
+    with pytest.raises(ValueError):
+        request_from_json({"command": "nonexistent_command", "workdir": "/w", "prompt": "p"})
+
+
+def test_request_from_json_missing_required_field_raises_type_error() -> None:
+    """request_from_json raises TypeError when a command-specific required field is absent."""
+    with pytest.raises(TypeError):
+        request_from_json({"command": "code_review_start", "workdir": "/w", "prompt": "p"})
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip: TurnResult serialization (AC-007)
+# ---------------------------------------------------------------------------
+
+TURN_RESULT_ROUND_TRIP_CASES = [
+    TurnResult(result_text="ok", is_error=False, session_id="s1"),
+    TurnResult(result_text="failed", is_error=True, session_id=None),
+    TurnResult(result_text="", is_error=False, session_id="s2"),
+    TurnResult(result_text="multi\nline", is_error=False, session_id=None),
+]
+
+
+@pytest.mark.parametrize("original", TURN_RESULT_ROUND_TRIP_CASES)
+def test_turn_result_json_round_trip(original: TurnResult) -> None:
+    """TurnResult round-trips through to_json/from_json without data loss."""
+    serialized = turn_result_to_json(original)
+    assert isinstance(serialized, dict)
+    restored = turn_result_from_json(serialized)
+    assert restored == original
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip: TerminalFailure serialization (AC-007)
+# ---------------------------------------------------------------------------
+
+TERMINAL_FAILURE_ROUND_TRIP_CASES = [
+    TerminalFailure(status="RUNNER_ERROR", subcode="XYZ_FAILURE", message="Loop failed."),
+    TerminalFailure(status="TIMEOUT", subcode="TIM", message="Timed out after 60s."),
+    TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message="Process exited 1."),
+]
+
+
+@pytest.mark.parametrize("original", TERMINAL_FAILURE_ROUND_TRIP_CASES)
+def test_terminal_failure_json_round_trip(original: TerminalFailure) -> None:
+    """TerminalFailure round-trips through to_json/from_json without data loss."""
+    serialized = terminal_failure_to_json(original)
+    assert isinstance(serialized, dict)
+    restored = terminal_failure_from_json(serialized)
+    assert restored == original

--- a/plugins/code/tools/python/test_harness_types.py
+++ b/plugins/code/tools/python/test_harness_types.py
@@ -194,15 +194,16 @@ INVALID_SUBCODES = [
 @pytest.mark.parametrize("subcode", VALID_SUBCODES)
 def test_terminal_failure_valid_subcode_accepted(subcode: str) -> None:
     """TerminalFailure constructs successfully with a valid subcode."""
-    tf = TerminalFailure(status="error", subcode=subcode, message="msg")
+    tf = TerminalFailure(status="RUNNER_ERROR", subcode=subcode, message="msg")
     assert tf.subcode == subcode
 
 
 @pytest.mark.parametrize("subcode", INVALID_SUBCODES)
 def test_terminal_failure_invalid_subcode_rejected(subcode: str) -> None:
     """TerminalFailure raises ValueError for invalid subcodes before construction completes."""
+    # status + message are valid so the subcode is the sole rejection reason.
     with pytest.raises(ValueError, match="subcode"):
-        TerminalFailure(status="error", subcode=subcode, message="msg")
+        TerminalFailure(status="RUNNER_ERROR", subcode=subcode, message="msg")
 
 
 def test_terminal_failure_field_access() -> None:
@@ -211,6 +212,38 @@ def test_terminal_failure_field_access() -> None:
     assert tf.status == "RUNNER_ERROR"
     assert tf.subcode == "XYZ_FAILURE"
     assert tf.message == "Loop failed."
+
+
+# Mirrors the ``case "$code"`` allowlist in run-loop.sh:70-77.
+VALID_STATUSES = ["RUNNER_ERROR", "PRE_RUN_VALIDATION_FAILED", "PLAN_STATE_UNAVAILABLE"]
+INVALID_STATUSES = ["", "EXIT", "TIMEOUT", "error", "runner_error", "RUNNER ERROR"]
+
+
+@pytest.mark.parametrize("status", VALID_STATUSES)
+def test_terminal_failure_valid_status_accepted(status: str) -> None:
+    """TerminalFailure accepts every status in the run-loop.sh allowlist."""
+    tf = TerminalFailure(status=status, subcode="NON_ZERO_EXIT", message="msg")
+    assert tf.status == status
+
+
+@pytest.mark.parametrize("status", INVALID_STATUSES)
+def test_terminal_failure_invalid_status_rejected(status: str) -> None:
+    """TerminalFailure rejects any status outside the run-loop.sh allowlist."""
+    with pytest.raises(ValueError, match="status"):
+        TerminalFailure(status=status, subcode="NON_ZERO_EXIT", message="msg")
+
+
+def test_terminal_failure_max_length_message_accepted() -> None:
+    """A 1000-char message (the boundary) is accepted."""
+    tf = TerminalFailure(status="RUNNER_ERROR", subcode="NON_ZERO_EXIT", message="x" * 1000)
+    assert len(tf.message) == 1000
+
+
+@pytest.mark.parametrize("message", ["", "x" * 1001])
+def test_terminal_failure_invalid_message_rejected(message: str) -> None:
+    """TerminalFailure rejects empty and over-1000-char messages (run-loop.sh:84-87)."""
+    with pytest.raises(ValueError, match="message"):
+        TerminalFailure(status="RUNNER_ERROR", subcode="NON_ZERO_EXIT", message=message)
 
 
 # ---------------------------------------------------------------------------
@@ -302,8 +335,8 @@ def test_turn_result_json_round_trip(original: TurnResult) -> None:
 
 TERMINAL_FAILURE_ROUND_TRIP_CASES = [
     TerminalFailure(status="RUNNER_ERROR", subcode="XYZ_FAILURE", message="Loop failed."),
-    TerminalFailure(status="TIMEOUT", subcode="TIM", message="Timed out after 60s."),
-    TerminalFailure(status="EXIT", subcode="NON_ZERO_EXIT", message="Process exited 1."),
+    TerminalFailure(status="PLAN_STATE_UNAVAILABLE", subcode="TIM", message="Timed out after 60s."),
+    TerminalFailure(status="PRE_RUN_VALIDATION_FAILED", subcode="NON_ZERO_EXIT", message="Process exited 1."),
 ]
 
 


### PR DESCRIPTION
## Summary

PLN-751 foundation feature. Establishes the harness-agnostic seam every later workstream plugs into: a stable Python contract that the bash skeleton in `plugins/code/scripts/run-loop.sh` can call instead of speaking to any specific harness (`claude`) directly.

No concrete adapter implementations land here — only the contract, registry, and CLI plumbing, exercised by a trivial in-test fake adapter to prove the wiring. New package: `plugins/code/tools/python/harness/`.

### Types (`harness/types.py`)
- **`Command` StrEnum** — five members (`PLAN_EXECUTE`, `PROCESS_LEARNINGS`, `EXPORT_LEARNINGS`, `CODE_REVIEW_START`, `CODE_REVIEW_FIX`). Each request types `command` as a distinct enum-literal so pyright narrows the concrete type from a `match request.command:` block — a new member without a `case` is type-checker-visible (exhaustiveness).
- **Discriminated union of requests** — five frozen, `kw_only=True` dataclasses (`PlanExecuteRequest`, `ProcessLearningsRequest`, `ExportLearningsRequest`, `CodeReviewStartRequest` with typed `base_sha`, `CodeReviewFixRequest` with typed `cr_dir`) sharing a `_BaseRequest` (`workdir`, `prompt`). `InvocationRequest` is the union alias.
- **Result types** — `TurnResult(result_text, is_error, session_id)` and `TerminalFailure(status, subcode, message)`, both frozen. `TerminalFailure.subcode` is validated at construction time against the regex enforced by `write_loop_user_visible_failure()` at `run-loop.sh:79` (`^[A-Z][A-Z0-9_]{2,63}$`) so a misbuilt failure fails fast instead of corrupting the user-visible marker downstream.
- **JSON boundary** — `request_from_json(payload)` deserializes by dispatching on `Command(payload["command"])` via a `_BY_COMMAND` table; symmetric `turn_result_{to,from}_json` / `terminal_failure_{to,from}_json` helpers round-trip cleanly so bash can shell out, pass JSON in, and parse JSON back.

### Adapter (`harness/adapter.py`)
- `HarnessAdapter` ABC with `name: ClassVar[str]` and six abstract methods: `supports`, `build_entry_prompt`, `build_argv`, `parse_session_id`, `parse_turn_result`, `classify_terminal_failure`. Subclassing without implementing all six raises `TypeError` at instantiation.

### Registry (`harness/registry.py`)
- `register(adapter_cls)` / `get_adapter(name)` keyed on the class-level `name`. Looking up an unregistered name raises a clear, actionable error naming the registered keys.

### Thin CLI (`harness/cli.py`)
- Reads a JSON request from stdin, takes `adapter_name` and `method_name` as positional args, dispatches to the named adapter method via `request_from_json`, and writes JSON to stdout — mirroring the existing `tools/python/` pipeline tools. Side-effect-free except for stdout.

### Non-functional
- Python standard library only (`json`, `re`, `dataclasses`, `enum`, `abc`, `typing`) — no third-party deps, runs without `pip install`. All dataclasses frozen; the data contract is immutable across the boundary.

### Tests (+82)
- `test_harness_types.py` — table-driven coverage of enum values, all request construction/field access, `TerminalFailure` subcode validation (valid accepted, invalid rejected), `TurnResult`, and JSON round-trips. Shared fixtures in `conftest.py`.
- `test_harness_registry.py` — register/get_adapter via a fake adapter; nonexistent lookup raises a clear error; ABC `TypeError` on incomplete subclass.
- `test_harness_cli.py` — full stdin→stdout subprocess round-trip against a registered fake adapter.

### Version
1.11.20 → **1.12.0** (MINOR — new module added; no existing behavior changed).

82 tests pass. ruff + pyright clean (0 errors).

### Out of scope (later PLN-751 workstreams)
- Concrete adapter implementations (Claude, other harnesses).
- `run-loop.sh` modifications, `--harness` flag / env-fallback wiring (PRD Open Question 3).
- `analyze-turn` consolidation (PRD Open Question 1).
- CHANGELOG.md / README.md — to be generated via `/update-documentation` before merge.

## Test plan
- [ ] CI: `Plugin Version Bump`, `Lint`, `Type Check`, `Tests` all green
- [ ] Manual (T-6.1): omit a `Command` member from a `match`/`case` block over `request.command` and confirm pyright reports the missing case
- [ ] Spot-check the CLI round-trip: `echo '{"command":"code_review_start","workdir":"/tmp","prompt":"p","base_sha":"abc"}' | python -m harness.cli fake parse_turn_result`

🤖 Generated with [Claude Code](https://claude.com/claude-code)