### PR TITLE
fix(code-review): sharpen partitions.json access prose + add top-level-dict contract test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code-review v2.6.5
+
+#### Fixed
+- `start.md` § Reviewer Fleet — the prose at line ~328 previously said only "do NOT run ad-hoc Python one-liners against `partitions.json`". Real `/start` runs showed the walker model ignoring that directive, indexing `data[0]` against the top-level dict, and crashing with `KeyError: 0`. The same systemic pattern that drove the rest of the PLN-719 follow-ups — prose alone doesn't beat the model's default behavior. Sharpened the section to (a) prescribe the canonical access path (`cat` / `Read`, then key-mapping; `python` is allowed *if* it indexes `data["partitions"][N]` not `data[N]`) and (b) inline the actual top-level shape so even an ignored directive lands on the right indexing. A new contract test `test_partitions_json_is_top_level_dict_not_list` in `TestPartitionPostProcessing` pins `cmd_partition`'s output as a top-level dict with `partitions` / `test_file_paths` / `force_merged_count` keys, so if anyone restructures the producer the prose breaks first instead of a real /start crash surfacing it.
+
 ### code-review v2.6.4
 
 #### Fixed

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -324,7 +324,22 @@ The orchestrator assigns each agent a unique `AGENT_ID` (e.g., `bha_p0`, `bhb`, 
 
 **Important:** When constructing agent prompts, substitute the resolved `CR_DIR` path (e.g., `.closedloop-ai/code-review/cr-38291`) into `{CR_DIR}` — agents run in separate processes and do not have access to the orchestrator's shell variables.
 
-**Placeholder source mapping** (read from the partition entry — do NOT run ad-hoc Python one-liners against `partitions.json`):
+**Reading `partitions.json` (read the file once with `cat` or `Read`, then map keys; do NOT reach for `python -c "json.load(...)[0]"`).**
+
+The shape is a **top-level dict**, not a list:
+
+```
+{
+  "partitions": [ {id, files: [...], total_loc, is_test_only}, ... ],
+  "test_file_paths": ["test/foo.ts", ...],
+  "force_merged_count": 0,
+  "partition_patches": { "p0": "...patch text...", ... }   // optional
+}
+```
+
+So `data["partitions"]` is the list. `data[0]` is a `KeyError`. If you do reach for Python anyway, use `data["partitions"][N]["files"]` — never `data[N]`. (A regression test in `TestPartitionPostProcessing` pins this top-level shape so the prose above can't silently drift away from reality.)
+
+**Placeholder source mapping** (each key resolves from the partition entry):
 - `{filepath_N}` ← `partition["files"][N]["file"]` (key is `file`, NOT `path`)
 - `{loc_N}` ← `partition["files"][N]["loc"]`
 - `{status_N}` ← `diff_data["file_statuses"][filepath]` (added/modified/removed)

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -826,6 +826,44 @@ class TestPartitionPostProcessing:
             _sys.stdin = old_stdin
             _sys.stdout = old_stdout
 
+    def test_partitions_json_is_top_level_dict_not_list(self) -> None:
+        """Pin the top-level shape of partitions.json so the prose in
+        ``start.md`` § Reviewer Fleet stays accurate.
+
+        The walker's per-stage notes tell operators that ``partitions.json``
+        is a top-level dict with keys ``partitions`` / ``test_file_paths`` /
+        ``force_merged_count`` (so ``data["partitions"][N]`` is the right
+        access pattern, NOT ``data[N]``). A real /start run hit a
+        ``KeyError: 0`` when the operator's ad-hoc Python one-liner indexed
+        the file as if it were a bare list — the prose warned against
+        Python but did nothing to ensure the shape stayed dict-shaped if a
+        future change ever inverted it. This test is the structural
+        backstop: if anyone restructures ``cmd_partition`` to emit a bare
+        list, the prose at ``start.md`` line ~328 becomes wrong and this
+        test fails first, surfacing the docs gap before a real /start
+        crash does.
+        """
+        data = _make_diff_data(
+            files=["a.ts"],
+            loc={"a.ts": {"added": 10, "removed": 0}},
+        )
+        result = self._run_partition(data)
+        assert isinstance(result, dict), (
+            f"partitions.json must be a top-level dict (the start.md walker "
+            f"prose says `data['partitions'][N]`, which only works if the "
+            f"top level is a dict). Got: {type(result).__name__}"
+        )
+        assert "partitions" in result and isinstance(result["partitions"], list), (
+            "partitions.json must contain a 'partitions' key whose value is a list"
+        )
+        assert "test_file_paths" in result and isinstance(
+            result["test_file_paths"], list,
+        ), "partitions.json must contain a 'test_file_paths' list"
+        assert "force_merged_count" in result, (
+            "partitions.json must include 'force_merged_count' (consumed by the "
+            "stage_17 telemetry)"
+        )
+
     def test_trivial_partition_merged(self) -> None:
         data = _make_diff_data(
             files=["a.ts", "b.ts", "c.ts"],


### PR DESCRIPTION
## Summary

A real `/start` run had the walker model ignore the existing "do NOT run ad-hoc Python one-liners against `partitions.json`" directive at [start.md:328](plugins/code-review/commands/start.md#L328) — indexed the file as `data[0]`, got `KeyError: 0`, worked around it by cat'ing the file.

This is round 5 of the same systemic pattern that drove all the post-PLN-719 follow-ups: **prose alone doesn't beat the model's default behavior, structural constraints do**. Each prior round (argparse gaps, `on_failure: abort` vs prose, enum drift, stdout mismatch) was resolved with a test or a schema check — never with a louder prose directive. Round 5 is the same shape.

## The fix

Two-pronged. Doesn't claim to make the model stop ignoring directives — just removes the cliff at the end of the "wrong choice" path.

1. **Sharpen the prose so the next-best path is correct.** Inline the actual top-level shape of `partitions.json` (`{partitions: [...], test_file_paths: [...], force_merged_count, partition_patches?}`) right above the placeholder mapping. If a model reaches for Python anyway, it sees `data["partitions"][N]` literally adjacent to the dict layout. The wrong indexing becomes the harder choice; the right one is one line above.

2. **Add a producer-side contract test** (`test_partitions_json_is_top_level_dict_not_list` in `TestPartitionPostProcessing`). Asserts `cmd_partition`'s output is a top-level dict with `partitions` / `test_file_paths` / `force_merged_count` keys. If anyone ever restructures the producer, the prose at `start.md` becomes wrong — and this test fails BEFORE a real `/start` crash surfaces the docs gap.

## Three-tier proposal status

This is the cheap tier-1 fix the user accepted. The remaining tiers are queued for later:

- **Tier 1 (this PR)** — sharpen prose + contract test. ✓
- **Tier 2 (queued)** — `partition-summary` subcommand emitting a flat per-partition representation so Python indexing is safe by construction.
- **Tier 3 (queued)** — `cmd_partition` writes per-partition prompt fragments directly, so the walker doesn't inspect `partitions.json` at all (same principle as `cmd_fetch_intent` writing `intent_context.json`).

Tier 3 is the actually-correct long-term answer and belongs on the PRD-409 to-do list as Phase B; it's a bigger refactor than this hotfix should carry.

## Test plan

- [x] `test_partitions_json_is_top_level_dict_not_list` pins shape
- [x] Full code-review test suite: 443 pass, 6 skipped, ruff clean
- [x] Manually verified the sharpened prose at [start.md:327-345](plugins/code-review/commands/start.md#L327-L345) reads cleanly and the dict-shape example is correct (matches the actual output of `cmd_partition`)

## Version

code-review 2.6.4 → 2.6.5 (PATCH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)