### PR TITLE
feat(code-review): PLN-768 Phase 1 — Companion-Change Validator (schema_to_orm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code-review v2.13.0
+
+#### Added
+- New `companion-check` subcommand (`cmd_companion_check`) in `code_review_helpers.py` that runs deterministic companion-change rules against `diff_data.json` and emits `<cr-dir>/companion_findings.json`. Findings use `category="CompanionChange"`, `source="companion-validator"`, `reviewer="companion-validator"`, and canonical finding ids.
+- New `companion_rules.py` library module: JSON rule descriptor loader (validates required fields, `schema_version`, predicate binding; deterministic filename-sorted iteration) plus the `schema_to_orm` predicate. Predicate recognizes Alembic `op.add_column`, PostgreSQL `ALTER TABLE ... ADD COLUMN`, Django `migrations.AddField`, and Rails `add_column` patterns; resolves `snake_case` ↔ `camelCase` symbols across model files.
+- New rule registry directory `plugins/code-review/tools/companion_rules/` with `01_schema_to_orm.json` descriptor.
+- New `stage_05a_companion_check` slot in `_build_run_plan_stages` between `stage_05_parse_diff` and `stage_06_extract_patches`. Helper-kind, `on_failure: continue` (validator is additive). Distinct from the still-disabled PLN-726 `stage_13_validate_companions` (LLM-driven cross-file impact analyzer).
+- New `--companion-findings` flag on `cmd_collect_findings`; merges `companion_findings.json` alongside agent and hygiene sources via `normalize_legacy_finding`. `stage_21_collect_findings` now passes the flag and adds `stage_05a_companion_check` to `depends_on`. The collect summary gains a `companion_included` boolean.
+- `companion-check` registered as `DETERMINISM_TIER_DETERMINISTIC` in `STAGE_DETERMINISM_TIERS`.
+- 26 new tests across five classes: `TestCompanionRulesLoader` (loader contract), `TestSchemaToOrmPredicate` (positive/negative coverage for Alembic/PostgreSQL/Django/Rails patterns, camelCase resolution, multi-column emission), `TestCompanionCheckSubcommand` (output envelope, canonical ids, cr-dir auto-create, malformed rule pack returns 1), `TestCollectFindingsCompanionMerge` (three-source merge, missing-file safety, Namespace back-compat), `TestRunPlanCompanionStage` (stage presence, dependency, ordering, expected outputs, distinctness from PLN-726, stage_21 consumption).
+
+#### Changed
+- `cmd_collect_findings` docstring updated to "Merge agent, hygiene, and companion findings into a single JSON file."
+- `test_emits_thirty_two_stages` → `test_emits_thirty_three_stages`; stage-count contract bumped 32 → 33 to reflect the new `stage_05a_companion_check` slot.
+- `test_extract_patches_runs_after_parse_diff` loosened: no longer requires `extract_idx == parse_idx + 1`. Now asserts `parse_idx < extract_idx` AND that any intervening stage must be `kind="helper"` (preserves diff-data semantics while allowing other deterministic helpers to slot between).
+
 ### code-review v2.12.0
 
 #### Added

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/tools/companion_rules/01_schema_to_orm.json
+++ b/plugins/code-review/tools/companion_rules/01_schema_to_orm.json
@@ -1,0 +1,11 @@
+{
+  "id": "schema_to_orm",
+  "name": "Schema ↔ ORM symmetry",
+  "description": "Migration adds a column without a matching ORM model update.",
+  "severity": "HIGH",
+  "category": "CompanionChange",
+  "issue_template": "[P1] Migration adds column {symbol} without ORM model update",
+  "recommendation_template": "Update the corresponding model file to declare the {symbol} field; otherwise queries against this column will fail at runtime.",
+  "predicate": "schema_to_orm",
+  "schema_version": 1
+}

--- a/plugins/code-review/tools/python/code_review_helpers.py
+++ b/plugins/code-review/tools/python/code_review_helpers.py
@@ -711,6 +711,76 @@ def cmd_hygiene(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Subcommand: companion-check (PLN-768)
+# ---------------------------------------------------------------------------
+
+# Default rule registry path relative to the plugin tools directory. Operators
+# can override via --rules-dir; production callers always pass an explicit path
+# resolved from CLAUDE_PLUGIN_ROOT.
+_COMPANION_RULES_DEFAULT_DIR = (
+    Path(__file__).resolve().parent.parent / "companion_rules"
+)
+
+
+def cmd_companion_check(args: argparse.Namespace) -> int:
+    """Run the deterministic companion-change rules against a parsed diff.
+
+    PLN-768 Phase 1. Loads JSON rule descriptors from ``--rules-dir``, invokes
+    each predicate against ``diff_data.json``, normalizes raw findings to the
+    canonical schema, and writes ``<cr-dir>/companion_findings.json``.
+
+    Output envelope mirrors hygiene.json: ``{"findings": [...]}``.
+    """
+    # Imported lazily so the helper module stays usable when rule scaffolding
+    # isn't present (e.g. minimal smoke tests of unrelated subcommands).
+    from companion_rules import evaluate_rules
+
+    cr_dir = Path(args.cr_dir)
+    cr_dir.mkdir(parents=True, exist_ok=True)
+    rules_dir = Path(args.rules_dir) if args.rules_dir else _COMPANION_RULES_DEFAULT_DIR
+
+    diff_data_path: str | None = getattr(args, "diff_data", None)
+    diff_data = json.load(open(diff_data_path)) if diff_data_path else json.load(sys.stdin)
+
+    try:
+        raw_findings, evaluated_rules = evaluate_rules(rules_dir, diff_data)
+    except ValueError as exc:
+        # Malformed descriptor: hard fail so a bad rule pack surfaces at
+        # the gate rather than producing silent zero-finding runs.
+        print(f"companion-check: rule load failed: {exc}", file=sys.stderr)
+        return 1
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    canonical: list[dict[str, Any]] = []
+    for idx, raw in enumerate(raw_findings):
+        promoted = normalize_legacy_finding(
+            raw,
+            reviewer="companion-validator",
+            source="companion-validator",
+            index=idx,
+            emitted_at=now_iso,
+        )
+        canonical.append(promoted)
+
+    output_path = cr_dir / "companion_findings.json"
+    with open(output_path, "w") as f:
+        json.dump({"findings": canonical}, f, indent=2)
+
+    json.dump(
+        {
+            "written": str(output_path),
+            "rules_evaluated": len(evaluated_rules),
+            "rule_ids": evaluated_rules,
+            "findings": len(canonical),
+        },
+        sys.stdout,
+        indent=2,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Subcommand: partition
 # ---------------------------------------------------------------------------
 
@@ -5376,7 +5446,7 @@ def _coerce_reviewer_id(raw: Any, fallback: str) -> str:
 
 
 def cmd_collect_findings(args: argparse.Namespace) -> int:
-    """Merge agent findings and hygiene findings into a single JSON file.
+    """Merge agent, hygiene, and companion findings into a single JSON file.
 
     Findings without an ``id`` are assigned a deterministic one of the form
     ``<reviewer_id>_f<index>`` (PLN-719 Section 4). Reviewer id is derived
@@ -5386,6 +5456,7 @@ def cmd_collect_findings(args: argparse.Namespace) -> int:
     cr_dir = Path(args.cr_dir)
     output_filename: str = args.output
     hygiene_path: str | None = getattr(args, "hygiene", None)
+    companion_path: str | None = getattr(args, "companion_findings", None)
 
     findings: list[dict[str, Any]] = []
     agent_files: list[str] = []
@@ -5457,6 +5528,31 @@ def cmd_collect_findings(args: argparse.Namespace) -> int:
         except (OSError, json.JSONDecodeError):
             pass  # hygiene file missing or malformed -- skip silently
 
+    # PLN-768: companion-validator findings (same merge shape as hygiene,
+    # since cmd_companion_check already emits canonical findings).
+    companion_included = False
+    if companion_path:
+        try:
+            with open(companion_path) as f:
+                companion_data = json.load(f)
+            companion_findings = companion_data.get("findings", [])
+            if isinstance(companion_findings, list):
+                for idx, raw in enumerate(companion_findings):
+                    if not isinstance(raw, dict):
+                        continue
+                    findings.append(
+                        normalize_legacy_finding(
+                            raw,
+                            reviewer=raw.get("reviewer", "companion-validator"),
+                            source=raw.get("source", "companion-validator"),
+                            index=idx,
+                            emitted_at=now_iso,
+                        ),
+                    )
+                companion_included = True
+        except (OSError, json.JSONDecodeError):
+            pass  # companion file missing or malformed -- skip silently
+
     # Write combined findings
     output_path = cr_dir / output_filename
     with open(output_path, "w") as f:
@@ -5467,6 +5563,7 @@ def cmd_collect_findings(args: argparse.Namespace) -> int:
             "total_findings": len(findings),
             "agent_files": agent_files,
             "hygiene_included": hygiene_included,
+            "companion_included": companion_included,
         },
         sys.stdout,
         indent=2,
@@ -6213,6 +6310,26 @@ def _build_run_plan_stages(
             "enabled": True,
         },
         {
+            # PLN-768: deterministic companion-change rules. Runs before
+            # any LLM reviewer so findings flow through the standard
+            # collect/validate/verify pipeline. `on_failure: continue`
+            # because the validator is additive — a rule-pack failure
+            # must never abort the LLM pipeline. Distinct from PLN-726's
+            # `stage_13_validate_companions` (LLM-driven cross-file impact).
+            "id": "stage_05a_companion_check",
+            "kind": "helper",
+            "subcommand": "companion-check",
+            "args": [
+                "--cr-dir", cr_dir,
+                "--diff-data", f"{cr_dir}/diff_data.json",
+            ],
+            "stdout": None,
+            "expected_outputs": [f"{cr_dir}/companion_findings.json"],
+            "depends_on": ["stage_05_parse_diff"],
+            "on_failure": "continue",
+            "enabled": True,
+        },
+        {
             "id": "stage_06_extract_patches",
             "kind": "helper",
             "subcommand": "extract-patches",
@@ -6475,10 +6592,11 @@ def _build_run_plan_stages(
             "args": [
                 "--cr-dir", cr_dir,
                 "--hygiene", f"{cr_dir}/hygiene.json",
+                "--companion-findings", f"{cr_dir}/companion_findings.json",
             ],
             "stdout": None,
             "expected_outputs": [f"{cr_dir}/findings.json"],
-            "depends_on": ["stage_20_spawn_reviewers"],
+            "depends_on": ["stage_20_spawn_reviewers", "stage_05a_companion_check"],
             "on_failure": "abort",
             "enabled": True,
         },
@@ -7580,6 +7698,22 @@ def _register_subparsers(subparsers: argparse._SubParsersAction) -> None:  # typ
     p_hyg.add_argument("--workdir", default=None, help="Git working directory for check-ignore")
     p_hyg.set_defaults(func=cmd_hygiene)
 
+    # companion-check (PLN-768)
+    p_cmp = subparsers.add_parser(
+        "companion-check",
+        help="Run deterministic companion-change rules against a parsed diff",
+    )
+    p_cmp.add_argument("--cr-dir", required=True, help="CR session directory (output goes here)")
+    p_cmp.add_argument(
+        "--diff-data", default=None,
+        help="Path to diff_data.json (reads stdin if omitted)",
+    )
+    p_cmp.add_argument(
+        "--rules-dir", default=None,
+        help="Companion rule descriptor directory (defaults to plugin's tools/companion_rules/)",
+    )
+    p_cmp.set_defaults(func=cmd_companion_check)
+
     # partition
     p_part = subparsers.add_parser("partition", help="Bin-pack files into partitions")
     p_part.add_argument("--diff-data", default=None, help="Path to diff_data.json (reads stdin if omitted)")
@@ -7887,10 +8021,14 @@ def _register_subparsers(subparsers: argparse._SubParsersAction) -> None:  # typ
     p_di.set_defaults(func=cmd_detect_injection)
 
     # collect-findings
-    p_cf = subparsers.add_parser("collect-findings", help="Merge agent + hygiene findings")
+    p_cf = subparsers.add_parser("collect-findings", help="Merge agent + hygiene + companion findings")
     p_cf.add_argument("--cr-dir", required=True, help="Directory containing agent_*.json files")
     p_cf.add_argument("--output", default="findings.json", help="Output filename (written to cr-dir)")
     p_cf.add_argument("--hygiene", default=None, help="Path to hygiene.json")
+    p_cf.add_argument(
+        "--companion-findings", default=None,
+        help="Path to companion_findings.json (PLN-768)",
+    )
     p_cf.set_defaults(func=cmd_collect_findings)
 
     # verdict

--- a/plugins/code-review/tools/python/code_review_schema.py
+++ b/plugins/code-review/tools/python/code_review_schema.py
@@ -163,6 +163,9 @@ STAGE_DETERMINISM_TIERS: dict[str, str] = {
     "fetch-intent": DETERMINISM_TIER_DETERMINISTIC,
     "classify-intent": DETERMINISM_TIER_DETERMINISTIC,
     "hygiene": DETERMINISM_TIER_DETERMINISTIC,
+    # PLN-768: deterministic companion-change rules. Distinct from PLN-726's
+    # ``validate-companions`` (LLM-driven cross-file impact analyzer).
+    "companion-check": DETERMINISM_TIER_DETERMINISTIC,
     "validate-companions": DETERMINISM_TIER_DETERMINISTIC,
     "arbitrate-budget": DETERMINISM_TIER_DETERMINISTIC,
     "partition": DETERMINISM_TIER_DETERMINISTIC,

--- a/plugins/code-review/tools/python/companion_rules.py
+++ b/plugins/code-review/tools/python/companion_rules.py
@@ -1,0 +1,222 @@
+"""Companion-Change Validator rule registry + predicates (PLN-768).
+
+A deterministic rules engine that scans a parsed diff for "companion change"
+omissions — places where one half of a cross-file invariant changed without
+the other half. Runs as a helper stage before any LLM reviewer fires.
+
+Phase 1 ships a single rule: ``schema_to_orm`` (migration adds a column but
+no ORM model file in the same diff references it).
+
+Rule descriptors live as JSON files under ``plugins/code-review/tools/companion_rules/``.
+Each descriptor names a predicate function defined in this module via
+``predicate``; the dispatcher binds them at load time. We use JSON rather
+than YAML so this module — like every other helper — has zero non-stdlib
+runtime deps.
+
+Each predicate takes (descriptor, diff_data) and returns a list of raw
+finding dicts that the caller normalizes via ``normalize_legacy_finding``.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+_RULE_DESCRIPTOR_SCHEMA_VERSION = 1
+
+# Required top-level fields in a rule descriptor. Missing/unknown fields
+# fail the loader so a malformed descriptor surfaces at startup rather
+# than producing silent no-op rules at runtime.
+_REQUIRED_DESCRIPTOR_FIELDS: frozenset[str] = frozenset({
+    "id",
+    "name",
+    "severity",
+    "category",
+    "issue_template",
+    "recommendation_template",
+    "predicate",
+    "schema_version",
+})
+
+
+def load_rules(rules_dir: Path) -> list[dict[str, Any]]:
+    """Discover and validate every JSON descriptor under ``rules_dir``.
+
+    Returns descriptors sorted by filename so iteration order is deterministic.
+    Raises ``ValueError`` on the first malformed descriptor — companion-validator
+    is a hard contract; silent skip would let a typo'd rule disappear.
+    """
+    descriptors: list[tuple[str, dict[str, Any]]] = []
+    if not rules_dir.is_dir():
+        return []
+
+    for path in sorted(rules_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Malformed JSON in rule descriptor {path}: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ValueError(f"Rule descriptor {path} is not a JSON object")
+        missing = _REQUIRED_DESCRIPTOR_FIELDS - data.keys()
+        if missing:
+            raise ValueError(
+                f"Rule descriptor {path} missing required fields: {sorted(missing)}",
+            )
+        if data["schema_version"] != _RULE_DESCRIPTOR_SCHEMA_VERSION:
+            raise ValueError(
+                f"Rule descriptor {path} has unsupported schema_version "
+                f"{data['schema_version']!r}; expected {_RULE_DESCRIPTOR_SCHEMA_VERSION}",
+            )
+        if data["predicate"] not in PREDICATES:
+            raise ValueError(
+                f"Rule descriptor {path} references unknown predicate "
+                f"{data['predicate']!r}; registered: {sorted(PREDICATES)}",
+            )
+        descriptors.append((path.name, data))
+
+    return [d for _, d in descriptors]
+
+
+# ---------------------------------------------------------------------------
+# Predicate: schema_to_orm
+# ---------------------------------------------------------------------------
+
+# Matches the most common ADD COLUMN syntaxes across SQL + Python/Rails ORMs.
+# Group 1 captures the column name (snake_case identifier).
+# Conservative for Phase 1; per-language AST extraction is a Phase 2 path.
+_ADD_COLUMN_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # PostgreSQL / generic SQL: ALTER TABLE ... ADD COLUMN foo ...
+    re.compile(r"\bADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?([a-z_][a-z0-9_]*)", re.IGNORECASE),
+    # SQLAlchemy / Alembic: op.add_column('table', sa.Column('foo', ...))
+    re.compile(r"\badd_column\s*\(\s*['\"][^'\"]+['\"]\s*,\s*(?:sa\.)?Column\s*\(\s*['\"]([a-z_][a-z0-9_]*)['\"]"),
+    # Django migrations: migrations.AddField(model_name='X', name='foo', field=...)
+    re.compile(r"\bAddField\s*\([^)]*name\s*=\s*['\"]([a-z_][a-z0-9_]*)['\"]"),
+    # Rails / ActiveRecord: add_column :table, :foo, :type
+    re.compile(r"\badd_column\s*:[a-z_][a-z0-9_]*\s*,\s*:([a-z_][a-z0-9_]*)"),
+)
+
+
+def _is_migration_path(filepath: str) -> bool:
+    """Migration file marker. Substring match keeps the descriptor stdlib-only.
+
+    Phase 1 supports the common Python/Rails layout (``app/migrations/...``,
+    ``db/migrate/...``). Globbed ``path_match`` is a Phase 2 extension.
+    """
+    norm = filepath.replace("\\", "/").lower()
+    return "/migrations/" in norm or "/migrate/" in norm
+
+
+def _is_model_path(filepath: str) -> bool:
+    """ORM model file marker. See ``_is_migration_path`` for the substring rationale."""
+    norm = filepath.replace("\\", "/").lower()
+    return "/models/" in norm or norm.endswith("/models.py")
+
+
+def _camel_case(snake: str) -> str:
+    """Convert ``snake_case`` to ``camelCase`` for cross-language symbol search."""
+    parts = snake.split("_")
+    if len(parts) == 1:
+        return parts[0]
+    return parts[0] + "".join(p[:1].upper() + p[1:] for p in parts[1:])
+
+
+def _model_files_mention_symbol(
+    symbol: str,
+    file_statuses: dict[str, str],
+    patch_lines: dict[str, dict[str, dict[str, str]]],
+) -> bool:
+    """True if any model file's added/modified lines mention the symbol.
+
+    We look in ``added_lines`` only — companion logic targets *new* references
+    in the same PR. A pre-existing reference in an untouched model file is
+    not detectable from the diff alone and is out of scope for v1.
+    """
+    camel = _camel_case(symbol)
+    for filepath, status in file_statuses.items():
+        if status not in ("added", "modified"):
+            continue
+        if not _is_model_path(filepath):
+            continue
+        added = patch_lines.get(filepath, {}).get("added_lines", {})
+        for content in added.values():
+            if symbol in content or (camel != symbol and camel in content):
+                return True
+    return False
+
+
+def schema_to_orm_predicate(
+    descriptor: dict[str, Any],
+    diff_data: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Emit a finding per ADD-COLUMN in a migration that no model file mentions."""
+    file_statuses: dict[str, str] = diff_data.get("file_statuses", {})
+    patch_lines: dict[str, dict[str, dict[str, str]]] = diff_data.get("patch_lines", {})
+
+    findings: list[dict[str, Any]] = []
+    issue_template = descriptor["issue_template"]
+    recommendation_template = descriptor["recommendation_template"]
+    severity = descriptor["severity"]
+    category = descriptor["category"]
+    rule_id = descriptor["id"]
+
+    for filepath, status in file_statuses.items():
+        if status not in ("added", "modified"):
+            continue
+        if not _is_migration_path(filepath):
+            continue
+        added: dict[str, str] = patch_lines.get(filepath, {}).get("added_lines", {})
+        # Deterministic order: sort by integer line number.
+        for line_str in sorted(added, key=lambda s: int(s) if s.isdigit() else 0):
+            content = added[line_str]
+            for pattern in _ADD_COLUMN_PATTERNS:
+                match = pattern.search(content)
+                if not match:
+                    continue
+                symbol = match.group(1)
+                if _model_files_mention_symbol(symbol, file_statuses, patch_lines):
+                    continue
+                findings.append({
+                    "file": filepath,
+                    "line": int(line_str) if line_str.isdigit() else 0,
+                    "severity": severity,
+                    "category": category,
+                    "issue": issue_template.format(symbol=symbol),
+                    "recommendation": recommendation_template.format(symbol=symbol),
+                    "code_snippet": content,
+                    "reviewer_trigger": {"type": "always", "evidence": rule_id},
+                    "subcategory": rule_id,
+                })
+                break  # one finding per migration line is enough
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Predicate registry
+# ---------------------------------------------------------------------------
+
+PredicateFn = Callable[[dict[str, Any], dict[str, Any]], list[dict[str, Any]]]
+
+PREDICATES: dict[str, PredicateFn] = {
+    "schema_to_orm": schema_to_orm_predicate,
+}
+
+
+def evaluate_rules(
+    rules_dir: Path,
+    diff_data: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Load every rule and run its predicate.
+
+    Returns ``(raw_findings, evaluated_rule_ids)``. The caller normalizes
+    raw findings via ``normalize_legacy_finding`` and adds canonical
+    bookkeeping (id, source, reviewer, schema_version, …).
+    """
+    descriptors = load_rules(rules_dir)
+    raw_findings: list[dict[str, Any]] = []
+    evaluated: list[str] = []
+    for descriptor in descriptors:
+        predicate = PREDICATES[descriptor["predicate"]]
+        raw_findings.extend(predicate(descriptor, diff_data))
+        evaluated.append(descriptor["id"])
+    return raw_findings, evaluated

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -70,6 +70,7 @@ from code_review_helpers import (
     cmd_cache_update,
     cmd_classify_intent,
     cmd_collect_findings,
+    cmd_companion_check,
     cmd_compute_hashes,
     cmd_detect_injection,
     cmd_footer,
@@ -6703,17 +6704,18 @@ class TestPrepareRun:
             pr_number=pr_number,
         )
 
-    def test_emits_thirty_two_stages(self, tmp_path: Path) -> None:
-        """PLN-722 v2.8.0 added two helper-wrapper stages around the
-        verifier fleet (``stage_22b_verify_prepare`` and
-        ``stage_24a_verify_consolidate``), bringing the total from 30 to
-        32. The ``_<NN>_`` prefix is a stable label, not a strict ordinal;
-        the lettered suffixes (``_22b_``, ``_24a_``) mark stages inserted
-        between original ordinals.
+    def test_emits_thirty_three_stages(self, tmp_path: Path) -> None:
+        """PLN-768 v2.13.0 added ``stage_05a_companion_check`` between
+        parse-diff and extract-patches, bringing the total from 32 to 33.
+        PLN-722 v2.8.0 had added the two verifier-wrapper stages
+        (``stage_22b_verify_prepare`` and ``stage_24a_verify_consolidate``)
+        that took the count from 30 to 32. The ``_<NN>_`` prefix is a stable
+        label, not a strict ordinal; the lettered suffixes (``_05a_``,
+        ``_22b_``, ``_24a_``) mark stages inserted between original ordinals.
         """
         summary, plan = self._run(tmp_path)
-        assert summary["stage_count"] == 32
-        assert len(plan["stages"]) == 32
+        assert summary["stage_count"] == 33
+        assert len(plan["stages"]) == 33
         # Ordered stage ids
         ids = [s["id"] for s in plan["stages"]]
         assert ids[0] == "stage_01_setup"
@@ -6732,12 +6734,25 @@ class TestPrepareRun:
         )
 
     def test_extract_patches_runs_after_parse_diff(self, tmp_path: Path) -> None:
-        """PLN-719 Section 7: extract-patches MOVED to right after parse-diff."""
+        """PLN-719 Section 7: extract-patches MOVED to early position right after
+        parse-diff. PLN-768 (v2.13.0) slotted ``stage_05a_companion_check``
+        between them — any other early helper inserted between parse-diff
+        and extract-patches must still preserve (a) the ordering and (b)
+        the data dependency.
+        """
         _, plan = self._run(tmp_path)
         ids = [s["id"] for s in plan["stages"]]
         parse_idx = ids.index("stage_05_parse_diff")
         extract_idx = ids.index("stage_06_extract_patches")
-        assert extract_idx == parse_idx + 1
+        # extract-patches must come AFTER parse-diff. Allow other early
+        # deterministic helpers (e.g. companion-check) to slot between.
+        assert parse_idx < extract_idx
+        for intervening in ids[parse_idx + 1 : extract_idx]:
+            stage = next(s for s in plan["stages"] if s["id"] == intervening)
+            assert stage["kind"] == "helper", (
+                f"non-helper stage {intervening!r} between parse-diff and "
+                f"extract-patches would change diff-data semantics"
+            )
         # extract-patches depends on parse-diff
         extract_stage = plan["stages"][extract_idx]
         assert "stage_05_parse_diff" in extract_stage["depends_on"]
@@ -10073,3 +10088,490 @@ class TestPartitionAwareReviewerLabeling:
         out = _verification_by_reviewer(verified, [])
         assert out["bha_p0"]["re_asserted"] == 0
         assert out["bha_p1"]["re_asserted"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Companion-Change Validator (PLN-768 Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def _run_companion_check(
+    tmp_path: Path,
+    diff_data: dict[str, Any],
+    rules_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Invoke cmd_companion_check via a Namespace, return parsed stdout summary.
+
+    Always points --rules-dir at the production registry unless overridden
+    so the most-realistic codepath (descriptor + predicate registration)
+    is exercised by default.
+    """
+    import argparse
+    import io
+    import sys as _sys
+
+    diff_data_path = tmp_path / "diff_data.json"
+    diff_data_path.write_text(json.dumps(diff_data))
+
+    default_rules = (
+        Path(__file__).resolve().parent.parent / "companion_rules"
+    )
+    ns = argparse.Namespace(
+        cr_dir=str(tmp_path),
+        diff_data=str(diff_data_path),
+        rules_dir=str(rules_dir) if rules_dir else str(default_rules),
+    )
+    old_stdout = _sys.stdout
+    _sys.stdout = io.StringIO()
+    try:
+        cmd_companion_check(ns)
+        _sys.stdout.seek(0)
+        return json.load(_sys.stdout)
+    finally:
+        _sys.stdout = old_stdout
+
+
+class TestCompanionRulesLoader:
+    """Loader contract: descriptors are discovered, validated, predicates bound."""
+
+    def test_load_default_rules_dir_finds_schema_to_orm(self) -> None:
+        from companion_rules import load_rules
+        default_rules = Path(__file__).resolve().parent.parent / "companion_rules"
+        descriptors = load_rules(default_rules)
+        ids = [d["id"] for d in descriptors]
+        assert "schema_to_orm" in ids
+
+    def test_missing_field_raises(self, tmp_path: Path) -> None:
+        from companion_rules import load_rules
+        (tmp_path / "bad.json").write_text(json.dumps({"id": "x"}))
+        with pytest.raises(ValueError, match="missing required fields"):
+            load_rules(tmp_path)
+
+    def test_malformed_json_raises(self, tmp_path: Path) -> None:
+        from companion_rules import load_rules
+        (tmp_path / "bad.json").write_text("not json{{{")
+        with pytest.raises(ValueError, match="Malformed JSON"):
+            load_rules(tmp_path)
+
+    def test_unknown_predicate_raises(self, tmp_path: Path) -> None:
+        from companion_rules import load_rules
+        bad_descriptor = {
+            "id": "x", "name": "x", "severity": "HIGH", "category": "CompanionChange",
+            "issue_template": "i", "recommendation_template": "r",
+            "predicate": "no_such_predicate", "schema_version": 1,
+        }
+        (tmp_path / "bad.json").write_text(json.dumps(bad_descriptor))
+        with pytest.raises(ValueError, match="unknown predicate"):
+            load_rules(tmp_path)
+
+    def test_unsupported_schema_version_raises(self, tmp_path: Path) -> None:
+        from companion_rules import load_rules
+        bad_descriptor = {
+            "id": "x", "name": "x", "severity": "HIGH", "category": "CompanionChange",
+            "issue_template": "i", "recommendation_template": "r",
+            "predicate": "schema_to_orm", "schema_version": 999,
+        }
+        (tmp_path / "bad.json").write_text(json.dumps(bad_descriptor))
+        with pytest.raises(ValueError, match="unsupported schema_version"):
+            load_rules(tmp_path)
+
+    def test_missing_dir_returns_empty(self, tmp_path: Path) -> None:
+        from companion_rules import load_rules
+        descriptors = load_rules(tmp_path / "does_not_exist")
+        assert descriptors == []
+
+    def test_descriptors_returned_in_sorted_filename_order(self, tmp_path: Path) -> None:
+        from companion_rules import load_rules
+        good = {
+            "name": "n", "severity": "HIGH", "category": "CompanionChange",
+            "issue_template": "i", "recommendation_template": "r",
+            "predicate": "schema_to_orm", "schema_version": 1,
+        }
+        (tmp_path / "02_b.json").write_text(json.dumps({**good, "id": "b"}))
+        (tmp_path / "01_a.json").write_text(json.dumps({**good, "id": "a"}))
+        descriptors = load_rules(tmp_path)
+        assert [d["id"] for d in descriptors] == ["a", "b"]
+
+
+class TestSchemaToOrmPredicate:
+    """Behavior contract for the schema_to_orm rule."""
+
+    @staticmethod
+    def _diff(
+        migration_added: dict[str, str] | None = None,
+        model_added: dict[str, str] | None = None,
+        migration_path: str = "app/migrations/0042_add_col.py",
+        model_path: str = "app/models/user.py",
+        model_status: str = "modified",
+    ) -> dict[str, Any]:
+        file_statuses: dict[str, str] = {}
+        patch_lines: dict[str, dict[str, dict[str, str]]] = {}
+        if migration_added is not None:
+            file_statuses[migration_path] = "added"
+            patch_lines[migration_path] = {"added_lines": migration_added}
+        if model_added is not None:
+            file_statuses[model_path] = model_status
+            patch_lines[model_path] = {"added_lines": model_added}
+        return {"file_statuses": file_statuses, "patch_lines": patch_lines}
+
+    def test_positive_alembic_add_column_no_model_update(self, tmp_path: Path) -> None:
+        diff = self._diff(
+            migration_added={
+                "10": "    op.add_column('users', sa.Column('email_verified_at', sa.DateTime()))",
+            },
+            model_added={"55": "    full_name = Column(String)"},
+        )
+        summary = _run_companion_check(tmp_path, diff)
+        findings = json.loads((tmp_path / "companion_findings.json").read_text())["findings"]
+        assert summary["findings"] == 1
+        assert findings[0]["category"] == "CompanionChange"
+        assert findings[0]["severity"] == "HIGH"
+        assert findings[0]["source"] == "companion-validator"
+        assert findings[0]["reviewer"] == "companion-validator"
+        assert "email_verified_at" in findings[0]["issue"]
+        assert findings[0]["subcategory"] == "schema_to_orm"
+
+    def test_negative_alembic_add_column_with_model_update(self, tmp_path: Path) -> None:
+        diff = self._diff(
+            migration_added={
+                "10": "    op.add_column('users', sa.Column('email_verified_at', sa.DateTime()))",
+            },
+            model_added={"55": "    email_verified_at = Column(DateTime, nullable=True)"},
+        )
+        summary = _run_companion_check(tmp_path, diff)
+        assert summary["findings"] == 0
+
+    def test_postgres_alter_table_add_column_pattern(self, tmp_path: Path) -> None:
+        diff = self._diff(
+            migration_added={"5": "ALTER TABLE users ADD COLUMN last_login TIMESTAMP;"},
+            model_added={"22": "name = Column(String)"},
+            migration_path="db/migrations/V003__add_last_login.sql",
+        )
+        summary = _run_companion_check(tmp_path, diff)
+        findings = json.loads((tmp_path / "companion_findings.json").read_text())["findings"]
+        assert summary["findings"] == 1
+        assert "last_login" in findings[0]["issue"]
+
+    def test_django_addfield_pattern(self, tmp_path: Path) -> None:
+        diff = self._diff(
+            migration_added={
+                "8": "        migrations.AddField(model_name='User', name='avatar_url', field=models.CharField(max_length=255))",
+            },
+            model_added={"40": "    username = models.CharField(max_length=64)"},
+        )
+        summary = _run_companion_check(tmp_path, diff)
+        findings = json.loads((tmp_path / "companion_findings.json").read_text())["findings"]
+        assert summary["findings"] == 1
+        assert "avatar_url" in findings[0]["issue"]
+
+    def test_rails_add_column_pattern(self, tmp_path: Path) -> None:
+        diff = self._diff(
+            migration_added={"3": "    add_column :users, :referral_code, :string"},
+            model_added={"12": "  validates :email, presence: true"},
+            migration_path="db/migrate/20260601_add_referral_code.rb",
+        )
+        summary = _run_companion_check(tmp_path, diff)
+        findings = json.loads((tmp_path / "companion_findings.json").read_text())["findings"]
+        assert summary["findings"] == 1
+        assert "referral_code" in findings[0]["issue"]
+
+    def test_camelcase_companion_resolves_snake_case_column(self, tmp_path: Path) -> None:
+        """Cross-language companion: snake_case in SQL, camelCase in TS ORM."""
+        diff = self._diff(
+            migration_added={"10": "    op.add_column('users', sa.Column('email_verified_at', sa.DateTime()))"},
+            model_added={"15": "  emailVerifiedAt!: Date | null;"},
+            model_path="app/models/User.ts",
+        )
+        summary = _run_companion_check(tmp_path, diff)
+        assert summary["findings"] == 0  # camelCase variant satisfies the rule
+
+    def test_non_migration_path_not_triggered(self, tmp_path: Path) -> None:
+        """ADD COLUMN mentioned in a non-migration file (e.g. docs) is ignored."""
+        diff = {
+            "file_statuses": {"docs/schema.md": "modified"},
+            "patch_lines": {
+                "docs/schema.md": {
+                    "added_lines": {"3": "Adding a column ADD COLUMN foo via migrations is fine."},
+                },
+            },
+        }
+        summary = _run_companion_check(tmp_path, diff)
+        assert summary["findings"] == 0
+
+    def test_no_diff_data_no_findings(self, tmp_path: Path) -> None:
+        summary = _run_companion_check(tmp_path, {"file_statuses": {}, "patch_lines": {}})
+        assert summary["findings"] == 0
+
+    def test_multiple_columns_one_finding_each(self, tmp_path: Path) -> None:
+        diff = self._diff(
+            migration_added={
+                "10": "    op.add_column('users', sa.Column('first_name', sa.String()))",
+                "11": "    op.add_column('users', sa.Column('last_name', sa.String()))",
+            },
+            model_added={"55": "    age = Column(Integer)"},
+        )
+        summary = _run_companion_check(tmp_path, diff)
+        findings = json.loads((tmp_path / "companion_findings.json").read_text())["findings"]
+        assert summary["findings"] == 2
+        issues = [f["issue"] for f in findings]
+        assert any("first_name" in i for i in issues)
+        assert any("last_name" in i for i in issues)
+
+
+class TestCompanionCheckSubcommand:
+    """Subcommand wiring + output envelope."""
+
+    def test_emits_companion_findings_json(self, tmp_path: Path) -> None:
+        diff = {
+            "file_statuses": {"app/migrations/0042.py": "added"},
+            "patch_lines": {
+                "app/migrations/0042.py": {
+                    "added_lines": {"10": "op.add_column('t', sa.Column('foo', sa.Integer()))"},
+                },
+            },
+        }
+        summary = _run_companion_check(tmp_path, diff)
+        assert summary["written"].endswith("/companion_findings.json")
+        assert (tmp_path / "companion_findings.json").is_file()
+        assert summary["rule_ids"] == ["schema_to_orm"]
+        assert summary["rules_evaluated"] == 1
+
+    def test_findings_have_canonical_ids(self, tmp_path: Path) -> None:
+        diff = {
+            "file_statuses": {"app/migrations/0042.py": "added"},
+            "patch_lines": {
+                "app/migrations/0042.py": {
+                    "added_lines": {"10": "op.add_column('t', sa.Column('a', sa.Integer()))"},
+                },
+            },
+        }
+        _run_companion_check(tmp_path, diff)
+        findings = json.loads((tmp_path / "companion_findings.json").read_text())["findings"]
+        assert findings[0]["id"] == "companion-validator_f0"
+        assert findings[0]["finding_scope"] == "diff"
+        assert findings[0]["reviewer_trigger"] == {"type": "always", "evidence": "schema_to_orm"}
+
+    def test_creates_cr_dir_when_missing(self, tmp_path: Path) -> None:
+        """--cr-dir is mkdir'd when absent so the helper can be invoked
+        before stage_01_setup in tests / ad-hoc usage."""
+        target = tmp_path / "fresh_cr"
+        # Place diff_data outside the cr_dir so cmd has work to do.
+        diff_data_path = tmp_path / "diff_data.json"
+        diff_data_path.write_text(json.dumps({"file_statuses": {}, "patch_lines": {}}))
+        import argparse
+        import io
+        import sys as _sys
+        default_rules = Path(__file__).resolve().parent.parent / "companion_rules"
+        ns = argparse.Namespace(
+            cr_dir=str(target),
+            diff_data=str(diff_data_path),
+            rules_dir=str(default_rules),
+        )
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            cmd_companion_check(ns)
+        finally:
+            _sys.stdout = old_stdout
+        assert target.is_dir()
+        assert (target / "companion_findings.json").is_file()
+
+    def test_malformed_rule_descriptor_returns_nonzero(self, tmp_path: Path) -> None:
+        """Bad rule pack must hard-fail (return 1), not produce a silent zero-finding
+        run. Operator surface: a typo'd descriptor should not look like 'no bugs'."""
+        bad_rules = tmp_path / "rules"
+        bad_rules.mkdir()
+        (bad_rules / "bad.json").write_text("not json{{{")
+        diff_data_path = tmp_path / "diff_data.json"
+        diff_data_path.write_text(json.dumps({"file_statuses": {}, "patch_lines": {}}))
+        import argparse
+        ns = argparse.Namespace(
+            cr_dir=str(tmp_path),
+            diff_data=str(diff_data_path),
+            rules_dir=str(bad_rules),
+        )
+        rc = cmd_companion_check(ns)
+        assert rc == 1
+
+
+class TestCollectFindingsCompanionMerge:
+    """Companion findings flow through cmd_collect_findings the same way hygiene does."""
+
+    def test_merges_companion_with_agents_and_hygiene(self, tmp_path: Path) -> None:
+        import argparse
+        import io
+        import sys as _sys
+
+        (tmp_path / "agent_bha_p0.json").write_text(
+            json.dumps({"findings": [{"file": "a.ts", "severity": "HIGH"}]}),
+        )
+        (tmp_path / "hygiene.json").write_text(
+            json.dumps({"findings": [{"file": "b.ts", "severity": "MEDIUM"}]}),
+        )
+        (tmp_path / "companion_findings.json").write_text(
+            json.dumps({
+                "findings": [{
+                    "id": "companion-validator_f0",
+                    "reviewer": "companion-validator",
+                    "source": "companion-validator",
+                    "file": "app/migrations/0042.py",
+                    "line": 10,
+                    "severity": "HIGH",
+                    "category": "CompanionChange",
+                    "issue": "missing companion",
+                }],
+            }),
+        )
+
+        ns = argparse.Namespace(
+            cr_dir=str(tmp_path),
+            output="findings.json",
+            hygiene=str(tmp_path / "hygiene.json"),
+            companion_findings=str(tmp_path / "companion_findings.json"),
+        )
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            cmd_collect_findings(ns)
+            _sys.stdout.seek(0)
+            result = json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+
+        assert result["total_findings"] == 3
+        assert result["companion_included"] is True
+        merged = json.loads((tmp_path / "findings.json").read_text())
+        sources = {f["source"] for f in merged}
+        assert sources == {"agent", "hygiene", "companion-validator"}
+
+    def test_companion_missing_does_not_abort(self, tmp_path: Path) -> None:
+        """The companion stage is on_failure=continue. If its output file
+        doesn't exist (e.g. a Phase 1 rule pack failure), collect must
+        still merge the agents + hygiene findings and report
+        companion_included=False — not raise."""
+        import argparse
+        import io
+        import sys as _sys
+        (tmp_path / "agent_bha_p0.json").write_text(
+            json.dumps({"findings": [{"file": "a.ts", "severity": "HIGH"}]}),
+        )
+        ns = argparse.Namespace(
+            cr_dir=str(tmp_path),
+            output="findings.json",
+            hygiene=None,
+            companion_findings=str(tmp_path / "nonexistent.json"),
+        )
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            cmd_collect_findings(ns)
+            _sys.stdout.seek(0)
+            result = json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+        assert result["total_findings"] == 1
+        assert result["companion_included"] is False
+
+    def test_companion_arg_absent_back_compat(self, tmp_path: Path) -> None:
+        """Existing callers that built a Namespace without companion_findings
+        must keep working — companion is read via getattr with default None."""
+        import argparse
+        import io
+        import sys as _sys
+        (tmp_path / "agent_bha_p0.json").write_text(
+            json.dumps({"findings": [{"file": "a.ts"}]}),
+        )
+        ns = argparse.Namespace(
+            cr_dir=str(tmp_path),
+            output="findings.json",
+            hygiene=None,
+        )
+        old_stdout = _sys.stdout
+        _sys.stdout = io.StringIO()
+        try:
+            cmd_collect_findings(ns)
+            _sys.stdout.seek(0)
+            result = json.load(_sys.stdout)
+        finally:
+            _sys.stdout = old_stdout
+        assert result["total_findings"] == 1
+        assert result["companion_included"] is False
+
+
+class TestRunPlanCompanionStage:
+    """Run-plan wiring: stage_05a present, correctly slotted, distinct from PLN-726."""
+
+    def _build(self, tmp_path: Path) -> dict[str, Any]:
+        summary, plan = invoke_prepare_run(  # noqa: F841
+            tmp_path,
+            mode="local",
+            hygiene_only="false",
+            since_last_review="false",
+            full_review="false",
+            base_ref_override="",
+            scope_args="",
+            pr_number=None,
+        )
+        return plan
+
+    def test_stage_05a_present_and_enabled(self, tmp_path: Path) -> None:
+        plan = self._build(tmp_path)
+        by_id = {s["id"]: s for s in plan["stages"]}
+        assert "stage_05a_companion_check" in by_id
+        stage = by_id["stage_05a_companion_check"]
+        assert stage["enabled"] is True
+        assert stage["kind"] == "helper"
+        assert stage["subcommand"] == "companion-check"
+        assert stage["on_failure"] == "continue"
+
+    def test_stage_05a_depends_on_parse_diff(self, tmp_path: Path) -> None:
+        plan = self._build(tmp_path)
+        by_id = {s["id"]: s for s in plan["stages"]}
+        assert "stage_05_parse_diff" in by_id["stage_05a_companion_check"]["depends_on"]
+
+    def test_stage_05a_runs_before_extract_patches(self, tmp_path: Path) -> None:
+        plan = self._build(tmp_path)
+        ids = [s["id"] for s in plan["stages"]]
+        parse_idx = ids.index("stage_05_parse_diff")
+        companion_idx = ids.index("stage_05a_companion_check")
+        extract_idx = ids.index("stage_06_extract_patches")
+        assert parse_idx < companion_idx < extract_idx
+
+    def test_stage_05a_emits_companion_findings_json(self, tmp_path: Path) -> None:
+        plan = self._build(tmp_path)
+        by_id = {s["id"]: s for s in plan["stages"]}
+        outputs = by_id["stage_05a_companion_check"]["expected_outputs"]
+        assert any(o.endswith("companion_findings.json") for o in outputs)
+
+    def test_stage_05a_distinct_from_pln726_validate_companions(self, tmp_path: Path) -> None:
+        """The PLN-726 placeholder (LLM-driven cross-file impact) lives at
+        stage_13_validate_companions and stays disabled. PLN-768's
+        deterministic stage is separate and enabled."""
+        plan = self._build(tmp_path)
+        by_id = {s["id"]: s for s in plan["stages"]}
+        assert by_id["stage_05a_companion_check"]["subcommand"] == "companion-check"
+        assert by_id["stage_05a_companion_check"]["enabled"] is True
+        assert by_id["stage_13_validate_companions"]["subcommand"] == "validate-companions"
+        assert by_id["stage_13_validate_companions"]["enabled"] is False
+
+    def test_stage_21_collect_findings_consumes_companion_findings(self, tmp_path: Path) -> None:
+        """The collect-findings stage must pass --companion-findings AND
+        depend on stage_05a so the file is guaranteed present (or absent
+        via on_failure=continue) before merge."""
+        plan = self._build(tmp_path)
+        by_id = {s["id"]: s for s in plan["stages"]}
+        collect = by_id["stage_21_collect_findings"]
+        assert "--companion-findings" in collect["args"]
+        assert any(a.endswith("/companion_findings.json") for a in collect["args"])
+        assert "stage_05a_companion_check" in collect["depends_on"]
+
+
+class TestCompanionCheckDeterminismTier:
+    """Schema registration check — companion-check must be tagged deterministic."""
+
+    def test_companion_check_registered_as_deterministic(self) -> None:
+        from code_review_schema import (
+            DETERMINISM_TIER_DETERMINISTIC,
+            stage_determinism_tier,
+        )
+        assert stage_determinism_tier("companion-check") == DETERMINISM_TIER_DETERMINISTIC


### PR DESCRIPTION
## Summary

PLN-768 Phase 1 lands the **deterministic Companion-Change Validator** architecture end-to-end on a single rule (`schema_to_orm`). This is the smallest viable PR that proves the architecture; Phase 2 will add the remaining 7 rules.

The validator runs as a new helper stage (`stage_05a_companion_check`) **before any LLM reviewer fires**, catching mechanical companion-change omissions deterministically. Findings flow through the existing collect → validate → verify → finalize pipeline with zero schema or envelope changes.

This complements just-merged PR #116 (PLN-774). PLN-774 lets reviewers see both halves of a contract in one context; PLN-768 makes a class of mechanical contract misses unmissable. Together they close the bug class that escaped PR #114.

## What ships (Phase 1)

| Area | Artifact |
|---|---|
| Rule registry | `plugins/code-review/tools/companion_rules/01_schema_to_orm.json` |
| Library | `plugins/code-review/tools/python/companion_rules.py` — loader + `schema_to_orm` predicate |
| Subcommand | `cmd_companion_check` in `code_review_helpers.py`; emits `<cr-dir>/companion_findings.json` |
| Run-plan stage | `stage_05a_companion_check` between parse-diff and extract-patches; `on_failure: continue` |
| Merge path | `--companion-findings` flag on `cmd_collect_findings`; `stage_21` wired to consume + `depends_on` stage_05a |
| Schema | `companion-check` registered `DETERMINISM_TIER_DETERMINISTIC` |
| Version | code-review 2.12.0 → 2.13.0 |

The `schema_to_orm` predicate recognizes Alembic `op.add_column`, PostgreSQL `ALTER TABLE ... ADD COLUMN`, Django `migrations.AddField`, and Rails `add_column` syntax. It resolves `snake_case` ↔ `camelCase` companion symbols across model files (cross-language ORM support).

The new stage is **distinct from PLN-726's still-disabled `stage_13_validate_companions`** (LLM-driven cross-file impact analyzer). Both live in the run-plan; only PLN-768's deterministic version is enabled here.

## Deviation from plan: JSON instead of YAML rule descriptors

PLN-768's plan specified YAML descriptors. Every other helper in `code_review_helpers.py` is stdlib-only at runtime; adding PyYAML as a runtime dep for one new feature was the wrong trade. Switched to JSON — same declarative intent, zero new runtime deps. Predicates remain the source of truth for behavior either way. Documented in the commit message; happy to revert if reviewers prefer YAML and a runtime PyYAML dep.

## Test coverage

26 new tests across 5 classes:

| Class | Tests | Coverage |
|---|---:|---|
| `TestCompanionRulesLoader` | 7 | missing-field, malformed-JSON, unknown-predicate, unsupported-schema-version, missing-dir, sorted-iteration, default-registry-finds-schema_to_orm |
| `TestSchemaToOrmPredicate` | 9 | Alembic +/-, PostgreSQL ALTER TABLE, Django AddField, Rails add_column, camelCase variant, non-migration path ignored, empty diff, multi-column |
| `TestCompanionCheckSubcommand` | 4 | output envelope, canonical finding_ids, cr-dir auto-created, malformed rule pack returns 1 (no silent zero-finding runs) |
| `TestCollectFindingsCompanionMerge` | 3 | three-source merge, missing-companion-file on_failure-safe, Namespace back-compat |
| `TestRunPlanCompanionStage` | 6 | stage present + enabled, depends_on parse-diff, ordering before extract-patches, expected_outputs, distinct from PLN-726, stage_21 consumes + depends_on |

Plus 1 existing test bumped (32→33 stage count) and 1 loosened (`test_extract_patches_runs_after_parse_diff` no longer requires `extract_idx == parse_idx + 1` — that ordinal was an implementation detail, not the architectural constraint; new assertion preserves ordering and helper-only intervening kind).

## Validation

- `pytest plugins/` — **1408 passed, 5 skipped**
- `ruff check .` — **all checks passed**
- `pyright` — **0 errors, 0 warnings**

## Refs

- Plan: [PLN-768](https://app.closedloop.ai/closedloop-ai/implementation-plans/PLN-768) — Phase 1 of 5
- Parent feature: [FEA-1452](https://app.closedloop.ai/closedloop-ai/features/FEA-1452)
- Parent PRD: [PRD-409](https://app.closedloop.ai/closedloop-ai/prds/PRD-409)
- Builds on: PR #116 (PLN-774 — Conditional BHA Partitioning, just merged)

## Test plan

- [x] Unit tests pass: 1408 across plugins/
- [x] Type/lint: pyright + ruff clean
- [x] Smoke test: hand-built `diff_data.json` with Alembic ADD COLUMN reproduces 1 HIGH finding; same diff with matching ORM field reproduces 0 findings
- [x] Run-plan contract: stage_05a present, enabled, depends_on parse-diff, ordering before extract-patches, distinct from PLN-726 placeholder
- [ ] Reviewer to confirm JSON-vs-YAML decision (revert path documented if PyYAML runtime dep is preferred)
- [ ] Reviewer to confirm `on_failure: continue` for the validator stage (matches plan rationale: rule-pack failure must not abort the LLM pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)