### PR TITLE
fix(code-review): align start.md scope wrapper with PLN-779 (v2.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code-review v2.12.2
+
+#### Fixed
+- **PLN-779 scope de-restriction now propagates to the prompt-template wrapper in `commands/start.md` (PR #118 post-merge review, thadeusb).** PLN-779 v2.12.1 edited `shared_prompt.txt` / `premise_prompt.txt` / `bha_suffix.txt` to reframe the diff as the trigger (not a hard boundary), but the orchestrator's per-agent template wrapper at `start.md:378` still emitted `Review ONLY the changed code. ... You may ONLY report findings for files in <files_assigned> below — no exceptions.` directly in every Task call. For partitioned BHA (`>5K LOC` PRs), `<files_assigned>` is a strict subset of the diff and the wrapper's "no exceptions" directly contradicted shared_prompt.txt's new "diff is the TRIGGER, findings on unchanged code the diff demonstrably broke are in scope" framing. Wrapper now defers to `shared_prompt.txt`'s FILE SCOPE rules and references the CAUSATION step explicitly. For unified-mode BHA (`≤5K LOC`) and BHB/Auditor/Premise/Domain/fast-path (which receive ALL diff files in `<files_assigned>`), wrapper semantics are unchanged in practice — the fix removes the textual contradiction that confused reviewers in partitioned mode.
+- **BHB suffix `start.md:423` and fast-path PASS 2 `start.md:576` "discard a bug in an unassigned file while exploring" directives reworded to align with shared_prompt.txt FILE SCOPE.** New wording: findings must concern code AFFECTED by this change — files in `<files_assigned>` including unchanged lines the diff demonstrably broke; bugs in entirely unrelated files (outside `<files_assigned>`) remain out of scope and should surface in a separate PR. Semantics identical to before for BHB and fast-path (their `<files_assigned>` is always the full PR file set), but the phrasing no longer fights the per-reviewer FILE SCOPE block.
+
 ### code-review v2.12.1
 
 #### Changed

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -375,10 +375,14 @@ So `data["partitions"]` is the list. `data[0]` is a `KeyError`. If you do reach 
 ```
 mode: standalone
 
-Review ONLY the changed code. Write findings to a file (not stdout).
-You may ONLY report findings for files in <files_assigned> below — no exceptions.
-If a file includes `[lines X-Y]` in <files_assigned>, report findings for that file only
-within `X..Y` (allow ±3 line tolerance for hunk boundaries).
+Write findings to a file (not stdout). The FILE SCOPE rules in
+`<CR_DIR>/shared_prompt.txt` are authoritative: the diff is the TRIGGER for
+review, and findings on unchanged code that the diff demonstrably broke are in
+scope when the broken code is in <files_assigned>. Findings in files outside
+<files_assigned> are out of scope (surface those in a separate PR).
+If a file includes `[lines X-Y]` in <files_assigned>, focus findings within
+`X..Y` (±3 line tolerance for hunk boundaries) unless cross-line CAUSATION
+applies per shared_prompt.txt's CAUSATION step.
 
 <output_file>{CR_DIR}/agent_{AGENT_ID}.json</output_file>
 
@@ -419,9 +423,11 @@ The BHA suffix text is written ONCE in `stage_02_prep_assets` (`<CR_DIR>/bha_suf
 ```
 You are Bug Hunter B — a codebase-aware reviewer focused on cross-file issues.
 
-You will explore files outside your assigned list for CONTEXT — but every finding you report
-must be filed against a file in your <files_assigned> list. If you discover a bug in an
-unassigned file while exploring, discard it.
+You will explore files outside your assigned list for CONTEXT — but findings
+must concern code AFFECTED by this change. That means findings against files in
+your <files_assigned> list (including unchanged lines the diff demonstrably broke,
+per shared_prompt.txt FILE SCOPE). Bugs in files entirely outside <files_assigned>
+are out of scope even if real — surface those in a separate PR.
 
 Focus areas:
 - DRY: Use Grep to search for similar function/component names. Flag >60% structural
@@ -572,9 +578,11 @@ Use Read, Grep, and Glob for codebase context. Do NOT use Bash.
 === PASS 2: Bug Hunter B / Unified Auditor ===
 You are Bug Hunter B — a codebase-aware reviewer focused on cross-file issues.
 
-You will explore files outside your assigned list for CONTEXT — but every finding you report
-must be filed against a file in your <files_assigned> list. If you discover a bug in an
-unassigned file while exploring, discard it.
+You will explore files outside your assigned list for CONTEXT — but findings
+must concern code AFFECTED by this change. That means findings against files in
+your <files_assigned> list (including unchanged lines the diff demonstrably broke,
+per shared_prompt.txt FILE SCOPE). Bugs in files entirely outside <files_assigned>
+are out of scope even if real — surface those in a separate PR.
 
 Focus areas:
 - DRY: Use Grep to search for similar function/component names. Flag >60% structural


### PR DESCRIPTION
## Summary

Post-merge review of [PR #118](https://github.com/closedloop-ai/claude-plugins/pull/118) (PLN-779 Reviewer Prompt Scope De-Restriction) surfaced a real contradiction by @thadeusb: PLN-779 edited the prompts the agents READ (`shared_prompt.txt`, `premise_prompt.txt`, `bha_suffix.txt`) but not the prompt-template **wrapper** the orchestrator builds in `commands/start.md`. So in production every BHA / BHB / Auditor / Premise / Domain Critic / fast-path agent received both:

- the per-agent wrapper at `start.md:378` saying  
  `Review ONLY the changed code. ... You may ONLY report findings for files in <files_assigned> below — no exceptions.`
- AND a Read of `shared_prompt.txt` saying  
  `The diff is the TRIGGER for your review, not a hard boundary ... bugs on UNCHANGED lines that the diff demonstrably broke ARE in scope.`

For **partitioned BHA** (>5K LOC PRs), `<files_assigned>` is a strict subset of the diff and the wrapper's "no exceptions" actively contradicted the new framing. For **unified-mode BHA** (≤5K LOC) and **BHB/Auditor/Premise/Domain/fast-path** (`<files_assigned>` = ALL diff files in all cases), the wrapper's effective semantics already matched `shared_prompt.txt`'s "ENTIRELY UNRELATED files out of scope" — but the verbatim wording still fought the new framing in every agent's context.

This PR rewords the contradictions to defer to `shared_prompt.txt`'s FILE SCOPE rules (the authoritative source).

## Changes

| Location | Before | After |
|---|---|---|
| `start.md:378` (per-agent template) | `Review ONLY the changed code ... You may ONLY report findings for files in <files_assigned> below — no exceptions.` | Defers to `shared_prompt.txt` FILE SCOPE; references CAUSATION step explicitly. |
| `start.md:423` (BHB suffix) | `If you discover a bug in an unassigned file while exploring, discard it.` | Reworded to align with FILE SCOPE: in-scope code = files in `<files_assigned>` plus unchanged lines the diff demonstrably broke; outside `<files_assigned>` = separate PR. |
| `start.md:576` (fast-path PASS 2) | same text as `:423` | same fix as `:423`. |

Semantics for BHB and fast-path are identical to before (their `<files_assigned>` is always the full PR file set). The fix removes the textual contradiction. For partitioned BHA the effective behavior shifts to match shared_prompt.txt — what PLN-779 was trying to ship in the first place.

## What this does NOT change

- No code logic, no tests, no schema fields, no plugin API surface.
- No change for unified-mode BHA / BHB / Auditor / Premise / Domain Critic / fast-path effective behavior — they already saw `<files_assigned>` covering the whole diff, so the new prompt and the old wrapper agreed on what was in scope.
- Reviewer's other PR #118 review threads (claims that PLN-774 unified mode and PLN-721 `premise_prompt.txt` aren't on `main`) are factually incorrect against current `main` — both are merged (commits `bd726b5` and `7cbe5e0` respectively, both ancestors of `main`). Not addressed by this PR.

## Test plan

- [x] `pytest plugins/code-review/tools/python/` — 639 passed, 5 skipped
- [x] `ruff check plugins/code-review/` — clean
- [x] `pyright plugins/code-review/tools/python/` — 0 errors
- [ ] CI green on push
- [ ] Manual smoke: next `/code-review` run, confirm per-agent wrapper text reads as expected in spawned Task calls (no `<files_assigned>` "no exceptions" line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)