### PR TITLE
feat(code-review): Batch verifier fleet to reduce agent spawns

### DIFF
--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -672,7 +672,19 @@ This stage runs when the walker reaches `stage_23`. It implements PLN-722's find
 
 ### Spawn contract
 
-Group entries in `verify_manifest.json.to_verify[]` into batches of up to `VERIFY_BATCH_SIZE` findings each (default `5`). Batching amortizes the per-agent bootstrap cost and lets the verifier reuse codebase context across findings that touch the same files.
+> **Independence trade-off — read before tuning the batch size.** The whole
+> point of this pass is an *independent* second opinion per finding. Packing
+> N findings into one agent means those N verdicts share a single agent
+> context, so they are no longer independent: one lazy, biased, or anchored
+> pass now taints every finding in the batch instead of one. Batching trades
+> the per-finding falsification guarantee for token/spawn savings — it does
+> not preserve it. When that guarantee matters more than cost, set
+> `verify_batch_size` to `1` (see "Batch size" below) to restore one
+> independent agent per finding.
+
+Read the resolved, already-clamped batch size from `verify_manifest.json.verify_batch_size` (written by `cmd_verify_prepare` — see "Batch size" below; do NOT re-parse the settings file in the walker).
+
+**Group `verify_manifest.json.to_verify[]` by `model` first, then slice each model-group into batches of up to `verify_batch_size` findings.** Grouping by model before slicing guarantees a batch never mixes models, so step 3's single-model assumption holds even after the planned cross-model split (a different verifier model per original reviewer) lands. Today every entry is `sonnet`, so this is a single group. Batching amortizes the per-agent bootstrap cost and lets the verifier reuse codebase context across findings that touch the same files.
 
 For each batch:
 
@@ -694,15 +706,15 @@ For each batch:
    Process each finding independently. Write one output file per finding
    at the path each input file specifies. Do not write anywhere else.
    ```
-   Substitute the resolved paths from the manifest entries (the verifier prompt is at `<CR_DIR>/verifier_prompt.txt`, copied by `stage_02_prep_assets`).
-3. Set `model` to the batch entries' `model` field (currently uniform `sonnet`; all entries in a batch share the same model).
+   Substitute the resolved paths from the manifest entries (the verifier prompt is at `<CR_DIR>/verifier_prompt.txt`, copied by `stage_02_prep_assets`). That prompt is batch-aware: it processes each input file in turn, runs the full protocol against each independently, and writes one verdict file per finding.
+3. Set `model` to the batch's shared `model` field. Because the batch was sliced within a single model-group (see grouping above), all entries share one model by construction — currently uniform `sonnet`.
 
-`VERIFY_BATCH_SIZE` is configurable via `.closedloop-ai/settings/code-review.json` key `verify_batch_size` (integer, min 1, max 20, default 5). Set to `1` to restore one-agent-per-finding behavior.
+**Batch size.** `verify_batch_size` is operator-tunable via `.closedloop-ai/settings/code-review.json`. `cmd_verify_prepare` reads it through `_load_code_review_settings`, which clamps it to the integer range `[1, 20]` (default `5`); a non-integer, boolean, or out-of-range value (e.g. `0` or the string `"5"`) falls back to the default exactly the way `bha_unified_threshold_loc` does. The clamped result is surfaced in the manifest as `verify_batch_size` — the walker uses that, never the raw file. Set it to `1` to restore one-agent-per-finding (fully independent) verification.
 
 ### Collection contract
 
 - Call `TaskOutput` (block: true) for every spawned verifier batch agent before letting the walker proceed past `stage_23`.
-- A missing `agent_verifier_<finding_id>.json` is NOT a fatal error — `cmd_verify_consolidate` tags it as `pending_verification[]` so operators see what didn't get verified. When a batch agent fails, ALL findings in that batch degrade to `pending_verification[]`.
+- A missing `agent_verifier_<finding_id>.json` is NOT a fatal error — `cmd_verify_consolidate` tags that finding as `pending_verification[]` so operators see what didn't get verified. Consolidation keys on **per-finding output files, not on batch success**: if a batch agent writes verdicts for some of its findings and then crashes or times out, the verdicts already on disk are consolidated (and cached) normally, and only the findings with no output file degrade to `pending_verification[]`. Partial batch progress is preserved by design — recovering the verdicts a failed batch did finish is strictly better than discarding the whole batch. (Consequence: a verdict written just before a crash is trusted like any other. The batch-aware verifier prompt writes one finding's output completely before starting the next, so each verdict file is atomic; the failure mode is a *missing* file, never a half-written one.)
 - Do NOT retry verifier agents in the walker. If a verifier fails, the finding's downstream handling already covers the gap (pending) — and verifier retries would burn tokens on a finding already flagged for human review.
 - `stage_23.on_failure == "continue"`: a fleet-wide failure does NOT abort the pipeline; `verify-consolidate` and `finalize-result` produce a usable envelope even when zero verifier outputs land on disk.
 

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -288,7 +288,7 @@ These notes annotate the run-plan stages with anything not obvious from the plan
 - **stage_20_spawn_reviewers**: agent_fleet stage. Dispatch to the "Reviewer Fleet" section below.
 - **stage_22_validate**: writes `<CR_DIR>/findings_validated.json` via `> <CR_DIR>/findings_validated.json` redirection. Phase B will retire this file; it remains during the transition.
 - **stage_22b_verify_prepare** (PLN-722): tier-selects findings for verification per the canonical table — BLOCKING/HIGH always; MEDIUM with confidence < 0.85 yes; MEDIUM with confidence ≥ 0.85 no; LOW (P3) no; `category: "Hygiene"` no; `source: "injection-detector"` no; `category: "Premise"` always (strict adversarial framing). Ranks the eligible set by `severity_weight × confidence`, caps at `VERIFY_MAX_VERIFICATIONS = 50`, and writes (a) `<CR_DIR>/verify_manifest.json` with `to_verify[]` + `skipped_no_verification[]` + `deferred_budget[]` + `cache_hits[]`, and (b) `<CR_DIR>/verifier_inputs/<finding_id>.json` per eligible finding. When `--cache-dir` is set, fresh verifier outputs from a prior run for the same `(finding_id, code_snippet_hash, model, prompt_hash)` tuple are pre-materialized at `agent_verifier_<finding_id>.json` and skipped from `to_verify[]` (logged under `cache_hits[]`). `on_failure: continue` is intentional — verify-prepare failure degrades to "no verifier this run", not a pipeline abort.
-- **stage_23_verify_findings** (PLN-722): agent_fleet stage. Dispatch to the "Verifier Fleet" section below. Each spawned agent reads its `verifier_inputs/<finding_id>.json` (containing the finding + the `verifier_prompt_path` + the canonical `output_path`) and emits one verdict file at `<CR_DIR>/agent_verifier_<finding_id>.json`. `on_failure: continue` so a single agent crash never aborts review.
+- **stage_23_verify_findings** (PLN-722): agent_fleet stage. Dispatch to the "Verifier Fleet" section below. Findings are batched (`VERIFY_BATCH_SIZE`, default 5) so each spawned agent verifies multiple findings in one pass, amortizing bootstrap cost and reusing codebase context. Each agent reads `verifier_inputs/<finding_id>.json` for every finding in its batch and emits one verdict file per finding at `<CR_DIR>/agent_verifier_<finding_id>.json`. `on_failure: continue` so a single agent crash never aborts review.
 - **stage_24a_verify_consolidate** (PLN-722, extended in PLN-721): merges all `agent_verifier_*.json` outputs back into the validated set, applies sensitive-path escalation from `.closedloop-ai/settings/verification-gates.json` (rules: REJECTED on `sensitive_paths` + BLOCKING/HIGH → TENTATIVE with severity capped at HIGH; any finding on `tentative_on_paths` → TENTATIVE; any finding on `mandatory_human_review_paths` → TENTATIVE + `force_human_review: true`), routes JUSTIFIED-VALID verdicts to a new `justified[]` bucket and JUSTIFIED-INVALID verdicts back into `verified[]` (the audited justification was refuted; the original concern stands), and writes `<CR_DIR>/findings_verified.json` with the bucket-split shape `{verified[], rejected[], pending_verification[], justified[], force_human_review}`. `tentative_on_paths` lifts JUSTIFIED-VALID/INVALID to TENTATIVE on the same operator-policy contract as the other verdicts. When `--cache-dir` is set, fresh verifier outputs are written back to the `verifications/` namespace (30-day TTL) for re-use on subsequent runs. Missing fleet outputs degrade to `pending_verification[]`; `on_failure: continue`.
 - **stage_25_finalize_result** (PLN-722 + PLN-721): writes `<CR_DIR>/review_result.json` (the canonical envelope) BEFORE running schema validation. PLN-722: prefers `<CR_DIR>/findings_verified.json` (verify-consolidate output) when present and honors its `force_human_review` flag in the verdict computation; falls back to `findings_validated.json` (everything to `verified[]`) when verify-consolidate didn't run. PLN-721: pipes the consolidate `justified[]` bucket into the envelope, and loads operator-overridable thresholds from `.closedloop-ai/settings/verdict-thresholds.json` (defaults to `premise_cumulative_medium=3`; absent/malformed → built-in default) so `_compute_canonical_verdict` Rule 4 can fire (≥ 3 MEDIUM Premise findings in `verified[]` → NEEDS_ATTENTION). A non-zero exit signals reviewer-emitted category/field drift (e.g. a category not in the canonical enum) but does not block the pipeline — `on_failure: continue` lets `stage_28_verdict` read the structurally complete envelope. Surface the stderr text in the present step so operators can correct prompts/schema; do not abort.
 - **stage_26_cache_update**: gated by **Gate C**.
@@ -672,7 +672,9 @@ This stage runs when the walker reaches `stage_23`. It implements PLN-722's find
 
 ### Spawn contract
 
-For each entry in `verify_manifest.json.to_verify[]`:
+Group entries in `verify_manifest.json.to_verify[]` into batches of up to `VERIFY_BATCH_SIZE` findings each (default `5`). Batching amortizes the per-agent bootstrap cost and lets the verifier reuse codebase context across findings that touch the same files.
+
+For each batch:
 
 1. Spawn one background `Task` with `subagent_type: "code-review:code-review-worker"`. The agent's tool allowlist (`Read`, `Write`, `Grep`, `Glob`) is identical to the Reviewer Fleet's — no permission changes needed.
 2. Prompt template:
@@ -680,20 +682,27 @@ For each entry in `verify_manifest.json.to_verify[]`:
    You are the FINDING VERIFIER. Read your prompt at:
      {VERIFIER_PROMPT_PATH}
 
-   Your input file is at:
-     {INPUT_PATH}
+   You have {N} findings to verify. For each finding below, read its
+   input file, verify the finding using Read/Grep on the codebase, and
+   write the verdict JSON to the output path specified in the input file.
 
-   Read it for the finding to verify, the canonical output path, and the
-   per-output JSON shape. Write your verdict JSON to the output path the
-   input file specifies. Do not write anywhere else.
+   Findings:
+   {for each entry in batch}
+   - Input: {INPUT_PATH}
+   {end for}
+
+   Process each finding independently. Write one output file per finding
+   at the path each input file specifies. Do not write anywhere else.
    ```
-   Substitute the resolved paths from the manifest entry (the verifier prompt is at `<CR_DIR>/verifier_prompt.txt`, copied by `stage_02_prep_assets`).
-3. Set `model` to the entry's `model` field (currently uniform `sonnet`; future revisions may split by original-reviewer model for cross-model independence).
+   Substitute the resolved paths from the manifest entries (the verifier prompt is at `<CR_DIR>/verifier_prompt.txt`, copied by `stage_02_prep_assets`).
+3. Set `model` to the batch entries' `model` field (currently uniform `sonnet`; all entries in a batch share the same model).
+
+`VERIFY_BATCH_SIZE` is configurable via `.closedloop-ai/settings/code-review.json` key `verify_batch_size` (integer, min 1, max 20, default 5). Set to `1` to restore one-agent-per-finding behavior.
 
 ### Collection contract
 
-- Call `TaskOutput` (block: true) for every spawned verifier agent before letting the walker proceed past `stage_23`.
-- A missing `agent_verifier_<finding_id>.json` is NOT a fatal error — `cmd_verify_consolidate` tags it as `pending_verification[]` so operators see what didn't get verified.
+- Call `TaskOutput` (block: true) for every spawned verifier batch agent before letting the walker proceed past `stage_23`.
+- A missing `agent_verifier_<finding_id>.json` is NOT a fatal error — `cmd_verify_consolidate` tags it as `pending_verification[]` so operators see what didn't get verified. When a batch agent fails, ALL findings in that batch degrade to `pending_verification[]`.
 - Do NOT retry verifier agents in the walker. If a verifier fails, the finding's downstream handling already covers the gap (pending) — and verifier retries would burn tokens on a finding already flagged for human review.
 - `stage_23.on_failure == "continue"`: a fleet-wide failure does NOT abort the pipeline; `verify-consolidate` and `finalize-result` produce a usable envelope even when zero verifier outputs land on disk.
 

--- a/plugins/code-review/tools/prompts/verifier_prompt.txt
+++ b/plugins/code-review/tools/prompts/verifier_prompt.txt
@@ -1,9 +1,26 @@
 mode: standalone
 
-You are the FINDING VERIFIER. Your job is to falsify a single code-review
-finding emitted by another reviewer. The default verdict is **TENTATIVE**;
-**REJECTED** requires positive evidence. The cost of a wrongly-accepted
-rejection is high — when in doubt, return TENTATIVE.
+You are the FINDING VERIFIER. Your job is to falsify code-review findings
+emitted by other reviewers, **one finding at a time**. The default verdict
+is **TENTATIVE**; **REJECTED** requires positive evidence. The cost of a
+wrongly-accepted rejection is high — when in doubt, return TENTATIVE.
+
+## Your inputs — one finding, or a batch
+
+Your spawn prompt names one or more input files. A single finding and a
+batch are handled identically: **process every input file you were given,
+one at a time, running the full protocol below against each in turn, and
+write one verdict file per finding** to the `output_path` that finding's
+own input file names. Each finding gets a fresh, fully independent pass —
+never let one finding's evidence, verdict, or fatigue influence another's.
+If you were given a batch, do NOT stop after the first finding: you are
+done only when every input file has its own output file written. Do not
+merge findings into a single output, and write nowhere other than each
+finding's `output_path`.
+
+Everything below describes how to verify **one** finding. Apply it to each
+input file independently; "the finding" / "the input file" means the one
+you are currently processing.
 
 PLN-721 added a justification audit branch: if the input finding carries
 `justified: true` with a populated `justification` object, run the
@@ -15,9 +32,10 @@ protocol below and emit whatever verdict those checks produce. The
 JUSTIFIED-INVALID enum value is reserved for a future extension and is
 not emitted by any current code path.
 
-<input_file>{INPUT_PATH}</input_file>
+The input file path(s) are listed in your spawn prompt — read each one
+you were given.
 
-The input file is JSON with shape:
+Each input file is JSON with shape:
   {
     "finding": { ... canonical finding ... },
     "verifier_prompt_path": "<this file>",
@@ -30,8 +48,8 @@ explanation, recommendation, code_snippet, evidence[], reasoning_certificate,
 finding_scope, source). Some fields may be null — that is normal.
 
 Use Read and Grep for all source-file access. Do NOT use Bash. Do NOT use
-Edit or Write (you write only your single output JSON via the documented
-output_path).
+Edit (you write only verdict JSON — one file per finding, each at that
+finding's documented output_path; do not write anywhere else).
 
 ## Justification Audit (PLN-721 — runs FIRST when applicable)
 
@@ -246,8 +264,8 @@ chain failed).
 
 ## Output
 
-Write a single JSON object to `output_path` (from the input file). The
-shape is:
+Write a single JSON object to the current finding's `output_path` (from
+its input file) — one such file per finding you were given. The shape is:
 
 ```json
 {

--- a/plugins/code-review/tools/python/code_review_helpers.py
+++ b/plugins/code-review/tools/python/code_review_helpers.py
@@ -1613,6 +1613,17 @@ def cmd_validate(args: argparse.Namespace) -> int:
 
 VERIFY_MAX_VERIFICATIONS = 50
 
+# Verifier Fleet batching (stage_23). The walker groups ``to_verify[]`` into
+# batches of up to this many findings per spawned agent to amortize the
+# per-agent bootstrap cost. Operator-tunable via ``code-review.json`` key
+# ``verify_batch_size``; ``_load_code_review_settings`` clamps it to
+# ``[VERIFY_BATCH_SIZE_MIN, VERIFY_BATCH_SIZE_MAX]`` and ``cmd_verify_prepare``
+# surfaces the clamped value in the manifest. ``1`` restores fully
+# independent one-agent-per-finding verification.
+VERIFY_BATCH_SIZE_DEFAULT = 5
+VERIFY_BATCH_SIZE_MIN = 1
+VERIFY_BATCH_SIZE_MAX = 20
+
 # Severity → weight for ranking when MAX_VERIFICATIONS is exceeded. Higher
 # = more likely to retain a verification slot.
 _VERIFY_SEVERITY_WEIGHT: dict[str, float] = {
@@ -2092,6 +2103,7 @@ def cmd_verify_prepare(args: argparse.Namespace) -> int:
             "skipped_no_verification": [...],
             "deferred_budget": [...],
             "max_verifications": int,
+            "verify_batch_size": int,  # clamped [1, 20]; walker batches on this
             "total_eligible": int,
             "verifier_prompt_path": str
           }``
@@ -2109,6 +2121,19 @@ def cmd_verify_prepare(args: argparse.Namespace) -> int:
     findings_path = Path(args.findings)
     cache_dir = Path(args.cache_dir) if getattr(args, "cache_dir", None) else None
     prompt_hash = str(getattr(args, "prompt_hash", "") or "")
+    # Resolve the Verifier Fleet batch size here (the only writer of the
+    # manifest) so the clamp lives in code, not in walker prose. A bad
+    # value (0, "5", 99, negative) falls back to the default — see
+    # _load_code_review_settings. The walker reads the clamped result from
+    # the manifest's ``verify_batch_size`` and never re-parses the file.
+    settings_path = Path(
+        getattr(args, "settings", None) or _CODE_REVIEW_SETTINGS_DEFAULT_PATH,
+    )
+    verify_batch_size = int(
+        _load_code_review_settings(settings_path).get(
+            "verify_batch_size", VERIFY_BATCH_SIZE_DEFAULT,
+        ),
+    )
     no_verify: bool = bool(getattr(args, "no_verify", False))
     no_verify_reason: str = str(getattr(args, "no_verify_reason", "") or "")
     # PLN-774 — Read partitions.json (written by ``cmd_partition`` at
@@ -2288,6 +2313,10 @@ def cmd_verify_prepare(args: argparse.Namespace) -> int:
         "partition_mode": partition_mode,
         "partition_count": partition_count,
         "max_verifications": VERIFY_MAX_VERIFICATIONS,
+        # Resolved, already-clamped Verifier Fleet batch size. The walker
+        # batches ``to_verify[]`` using THIS value (never the raw settings
+        # file) so the [1, 20] clamp is authoritative and single-sourced.
+        "verify_batch_size": verify_batch_size,
         "total_eligible": (
             len(to_verify) + len(deferred) + len(cache_hits) + len(override_hits)
         ),
@@ -2483,13 +2512,20 @@ def _load_code_review_settings(path: Path | None) -> dict[str, Any]:
         cross-region invariants stay visible to one reviewer. Default
         :data:`BHA_UNIFIED_THRESHOLD_LOC` (5000). Setting the value to 0
         forces the historical always-partition behavior (kill switch).
+      - ``verify_batch_size`` (int): number of findings the Verifier Fleet
+        packs into one agent at stage_23. Clamped to
+        ``[VERIFY_BATCH_SIZE_MIN, VERIFY_BATCH_SIZE_MAX]`` (1–20); default
+        :data:`VERIFY_BATCH_SIZE_DEFAULT` (5). ``1`` restores fully
+        independent one-agent-per-finding verification.
 
-    Unknown keys are ignored. Invalid entries (wrong type, negative)
-    fall back to the default — the file is operator-authored and should
-    not crash the pipeline on a typo.
+    Unknown keys are ignored. Invalid entries (wrong type, negative,
+    out of range, or a numeric string like ``"5"``) fall back to the
+    default — the file is operator-authored and should not crash the
+    pipeline on a typo.
     """
     defaults: dict[str, Any] = {
         "bha_unified_threshold_loc": BHA_UNIFIED_THRESHOLD_LOC,
+        "verify_batch_size": VERIFY_BATCH_SIZE_DEFAULT,
     }
     data, out = _load_optional_settings_dict(path, defaults)
     if data is None:
@@ -2501,6 +2537,13 @@ def _load_code_review_settings(path: Path | None) -> dict[str, Any]:
         and raw_threshold >= 0
     ):
         out["bha_unified_threshold_loc"] = raw_threshold
+    raw_batch = data.get("verify_batch_size")
+    if (
+        isinstance(raw_batch, int)
+        and not isinstance(raw_batch, bool)
+        and VERIFY_BATCH_SIZE_MIN <= raw_batch <= VERIFY_BATCH_SIZE_MAX
+    ):
+        out["verify_batch_size"] = raw_batch
     return out
 
 

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -7383,13 +7383,16 @@ def _run_verify_prepare(
     cr_dir: Path | None = None,
     no_verify: bool = False,
     no_verify_reason: str = "",
+    settings: Path | None = None,
 ) -> tuple[int, dict[str, Any]]:
     """Invoke ``cmd_verify_prepare`` with stdout captured into a dict.
 
     PR #114 review fix — ``cr_dir``, ``no_verify``, and ``no_verify_reason``
     were inlined per-test before; the helper now owns them so the
     TestOverrideCache and TestNoVerifyBypass classes can stop duplicating
-    the stdout-capture + Namespace dance.
+    the stdout-capture + Namespace dance. ``settings`` points at a
+    ``code-review.json`` so PR #125 review can exercise ``verify_batch_size``
+    resolution; ``None`` lets the resolver fall back to its default path.
     """
     import io
     import sys as _sys
@@ -7412,6 +7415,7 @@ def _run_verify_prepare(
             prompt_hash=prompt_hash,
             no_verify=no_verify,
             no_verify_reason=no_verify_reason,
+            settings=str(settings) if settings else None,
         )
         rc = cmd_verify_prepare(ns)
         _sys.stdout.seek(0)
@@ -9890,10 +9894,15 @@ class TestLoadCodeReviewSettings:
 
     def test_missing_file_returns_defaults(self, tmp_path: Path) -> None:
         from code_review_helpers import (
-            BHA_UNIFIED_THRESHOLD_LOC, _load_code_review_settings,
+            BHA_UNIFIED_THRESHOLD_LOC,
+            VERIFY_BATCH_SIZE_DEFAULT,
+            _load_code_review_settings,
         )
         out = _load_code_review_settings(tmp_path / "does-not-exist.json")
-        assert out == {"bha_unified_threshold_loc": BHA_UNIFIED_THRESHOLD_LOC}
+        assert out == {
+            "bha_unified_threshold_loc": BHA_UNIFIED_THRESHOLD_LOC,
+            "verify_batch_size": VERIFY_BATCH_SIZE_DEFAULT,
+        }
 
     def test_operator_override_honored(self, tmp_path: Path) -> None:
         from code_review_helpers import _load_code_review_settings
@@ -9940,6 +9949,92 @@ class TestLoadCodeReviewSettings:
         path.write_text(json.dumps({"bha_unified_threshold_loc": True}))
         out = _load_code_review_settings(path)
         assert out["bha_unified_threshold_loc"] == BHA_UNIFIED_THRESHOLD_LOC
+
+    # PR #125 review (thadeusb) — ``verify_batch_size`` must be read and
+    # clamped in code (not just asserted in walker prose) the same way
+    # ``bha_unified_threshold_loc`` is.
+
+    def test_verify_batch_size_in_range_honored(self, tmp_path: Path) -> None:
+        from code_review_helpers import _load_code_review_settings
+        path = tmp_path / "code-review.json"
+        path.write_text(json.dumps({"verify_batch_size": 8}))
+        out = _load_code_review_settings(path)
+        assert out["verify_batch_size"] == 8
+
+    def test_verify_batch_size_boundaries_honored(self, tmp_path: Path) -> None:
+        """Both clamp endpoints (1 and 20) are valid operator values."""
+        from code_review_helpers import _load_code_review_settings
+        for value in (1, 20):
+            path = tmp_path / "code-review.json"
+            path.write_text(json.dumps({"verify_batch_size": value}))
+            out = _load_code_review_settings(path)
+            assert out["verify_batch_size"] == value
+
+    def test_verify_batch_size_zero_falls_back(self, tmp_path: Path) -> None:
+        """``0`` is below the min — there is no such thing as a zero-finding
+        batch, so it falls back to the default rather than disabling the pass."""
+        from code_review_helpers import (
+            VERIFY_BATCH_SIZE_DEFAULT, _load_code_review_settings,
+        )
+        path = tmp_path / "code-review.json"
+        path.write_text(json.dumps({"verify_batch_size": 0}))
+        out = _load_code_review_settings(path)
+        assert out["verify_batch_size"] == VERIFY_BATCH_SIZE_DEFAULT
+
+    def test_verify_batch_size_above_max_falls_back(self, tmp_path: Path) -> None:
+        from code_review_helpers import (
+            VERIFY_BATCH_SIZE_DEFAULT, _load_code_review_settings,
+        )
+        path = tmp_path / "code-review.json"
+        path.write_text(json.dumps({"verify_batch_size": 99}))
+        out = _load_code_review_settings(path)
+        assert out["verify_batch_size"] == VERIFY_BATCH_SIZE_DEFAULT
+
+    def test_verify_batch_size_numeric_string_falls_back(self, tmp_path: Path) -> None:
+        """A quoted ``"5"`` is a string, not an int — falls back."""
+        from code_review_helpers import (
+            VERIFY_BATCH_SIZE_DEFAULT, _load_code_review_settings,
+        )
+        path = tmp_path / "code-review.json"
+        path.write_text(json.dumps({"verify_batch_size": "5"}))
+        out = _load_code_review_settings(path)
+        assert out["verify_batch_size"] == VERIFY_BATCH_SIZE_DEFAULT
+
+    def test_verify_batch_size_bool_falls_back(self, tmp_path: Path) -> None:
+        from code_review_helpers import (
+            VERIFY_BATCH_SIZE_DEFAULT, _load_code_review_settings,
+        )
+        path = tmp_path / "code-review.json"
+        path.write_text(json.dumps({"verify_batch_size": True}))
+        out = _load_code_review_settings(path)
+        assert out["verify_batch_size"] == VERIFY_BATCH_SIZE_DEFAULT
+
+
+class TestVerifyManifestBatchSize:
+    """``cmd_verify_prepare`` resolves + clamps ``verify_batch_size`` and
+    surfaces it in ``verify_manifest.json`` so the walker batches on the
+    authoritative value (PR #125 review)."""
+
+    def test_manifest_carries_default_when_no_settings(self, tmp_path: Path) -> None:
+        from code_review_helpers import VERIFY_BATCH_SIZE_DEFAULT
+        finding = _make_validated_finding("bha_f0", severity="HIGH", confidence=0.9)
+        _, manifest = _run_verify_prepare(tmp_path, [finding])
+        assert manifest["verify_batch_size"] == VERIFY_BATCH_SIZE_DEFAULT
+
+    def test_manifest_carries_operator_value(self, tmp_path: Path) -> None:
+        settings = tmp_path / "code-review.json"
+        settings.write_text(json.dumps({"verify_batch_size": 3}))
+        finding = _make_validated_finding("bha_f0", severity="HIGH", confidence=0.9)
+        _, manifest = _run_verify_prepare(tmp_path, [finding], settings=settings)
+        assert manifest["verify_batch_size"] == 3
+
+    def test_manifest_clamps_out_of_range(self, tmp_path: Path) -> None:
+        from code_review_helpers import VERIFY_BATCH_SIZE_DEFAULT
+        settings = tmp_path / "code-review.json"
+        settings.write_text(json.dumps({"verify_batch_size": 0}))
+        finding = _make_validated_finding("bha_f0", severity="HIGH", confidence=0.9)
+        _, manifest = _run_verify_prepare(tmp_path, [finding], settings=settings)
+        assert manifest["verify_batch_size"] == VERIFY_BATCH_SIZE_DEFAULT
 
 
 class TestVerifyManifestPartitionPropagation:


### PR DESCRIPTION
## Summary

- Batch the verifier fleet (stage_23) from 1-agent-per-finding to `VERIFY_BATCH_SIZE` findings per agent (default 5)
- For a typical 15-finding review: 15 agents → 3 agents (~80% reduction in verifier spawns)
- Each batch agent shares codebase context across findings, eliminating duplicate Read/Grep work
- Configurable via `.closedloop-ai/settings/code-review.json` key `verify_batch_size` (1-20, default 5)
- Set to `1` to restore one-agent-per-finding behavior

## Motivation

Session log analysis showed the verifier fleet as the largest source of sub-agent spawns in code-review runs (up to 50 agents). Each agent independently bootstraps (~2K tokens), reads the verifier prompt, and explores overlapping codebase files. Batching amortizes all three costs.

## Test plan

- [ ] Run code-review on a PR with 10+ findings, verify verifier agents spawn in batches
- [ ] Verify each batch produces one `agent_verifier_<finding_id>.json` per finding
- [ ] Verify `verify_batch_size: 1` in settings restores 1:1 behavior
- [ ] Verify batch agent failure degrades all findings in batch to `pending_verification[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)