### PR TITLE
chore: tighten /update-documentation skill with derivability constraint

### DIFF
--- a/.claude/commands/update-documentation.md
+++ b/.claude/commands/update-documentation.md
@@ -99,6 +99,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 </examples>
 
+<examples id="derivability">
+
+<example type="disallowed">
+- **Case-sensitive migration patterns broke legacy semantics (PR #124, Bug Hunter B HIGH + thadeusb).** Legacy `route` matched `pattern.lower() in path.lower()`.
+</example>
+
+<example type="correct">
+- The migration legacy soft-compat now preserves case-insensitive substring semantics. The migration emits `ignore_case: True` on every migrated trigger, and `_trigger_fires` recompiles the regex with `re.IGNORECASE` when the flag is set.
+</example>
+
+<example type="rationale">
+The disallowed version references the reviewer ("Bug Hunter B"), the human ("thadeusb"), the severity tier ("HIGH"), and the PR-comment thread ("PR #124") — none of which are derivable from git diff + plugin.json + commit subjects. The correct version describes the same code change, plainly, from sources the workflow actually reads.
+</example>
+
+</examples>
+
 <examples id="duplicate-detection">
 
 <example type="duplicate">
@@ -123,6 +139,14 @@ Result: NOT duplicate (different aspects)
 4. **Date format** — YYYY-MM-DD (ISO 8601)
 5. **Version source** — Always read from plugin.json, never guess
 6. **README edits are minimal** — Only fix inaccurate sections, preserve correct prose and formatting
+7. **Derivability** — Every entry must be derivable from the documented source set: git diff (of the files changed), `plugin.json`, and commit subjects. The following are NOT in the source set and MUST NOT appear in entries:
+   - Reviewer identities — names of human reviewers, code-review subagents (e.g. `Bug Hunter A`, `Unified Auditor`, `Premise Reviewer`, `devops-architect`), or PR commenters
+   - Internal finding codes (e.g. `auditor_f0`, `bha_p0_f1`, `domain_0_f0`)
+   - Severity tier names (HIGH / MEDIUM / BLOCKING / etc.) unless the commit subject already contains them
+   - PR-comment thread context, agent verification verdicts, review meta-state
+   - Anything else that came from the conversation but not from `git`/`plugin.json`/commit subjects
+
+   If a fix originated from a code review, describe what the code does differently now — not who flagged it or how it was triaged. See the `derivability` examples in `<data>` for the disallowed-vs-correct phrasing pair.
 
 </constraints>
 
@@ -208,7 +232,7 @@ The file uses a flat newest-first structure. There is no `## [Unreleased]` or `#
 
 1. **Find or create** the plugin subsection `### {plugin} v{version}` at the top of the entry list (below the introductory paragraph, above all existing `### plugin v...` entries)
 2. **Find or create** the category `#### Added/Changed/Fixed/Removed` within the plugin subsection
-3. **Add entries** as bullet points under the appropriate category
+3. **Add entries** as bullet points under the appropriate category. Each entry must satisfy constraint 7 (Derivability) — if you find yourself reaching for a reviewer name, finding code, severity tier, or PR-thread context, drop it and describe the code change instead.
 
 If the version already exists as a `### {plugin} v{version}` heading further down (because that version already shipped), do **not** edit it retroactively — bump the plugin's `plugin.json` to a new version and create a fresh entry for that new version at the top.
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ __pycache__/
 # Token tracking session data
 .claude/.token-stats/
 
+# Claude Code session lock file (PID/sessionId/acquiredAt, regenerated per run)
+.claude/scheduled_tasks.lock
+
 # ClosedLoop session-level artifacts (cleaned up by SessionEnd hook)
 .claude/closedloop-loop.local.md
 .closedloop/


### PR DESCRIPTION
## Summary

Tightens the `/update-documentation` skill prompt so it actively prevents CHANGELOG entries from including content that isn't derivable from git diff + plugin.json + commit subjects. Addresses a recurring violation pattern observed across PR #120, PR #121, and PR #124.

No plugin code changes, no plugin version bumps. Skill prompt only.

## The pattern this addresses

CLAUDE.md has the rule:
> Never hand-write CHANGELOG entries for plugin changes; when reviewing generated release notes, verify the version heading matches `plugin.json` and every `Fixed`/`Replaces` claim maps to behavior that existed before the PR.

Across three consecutive PRs, this rule fired on the CHANGELOG entries even though `/update-documentation` was invoked correctly:

| PR | Violation flagged |
|---|---|
| #120 | hand-written CHANGELOG entries with phantom intermediate versions |
| #121 | reviewer-name parentheticals (multiple) |
| #124 | reviewer-name parentheticals + severity tiers + finding codes |

**What was happening:** the workflow was followed mechanically (read git diff, edit `CHANGELOG.md` via the Edit tool), but the workflow itself didn't constrain the *content* I could inject. So conversation-only context — reviewer identities, agent verification verdicts, finding codes like `auditor_f0` — kept making it into entries even though that content doesn't appear in any of the documented sources (`git diff`, `plugin.json`, commit subjects).

**The fix:** explicit, enumerated forbidden-content constraints at the skill level, with a worked example pair showing disallowed vs correct phrasing.

## What's in this PR

| Change | Location |
|---|---|
| New constraint **#7 (Derivability)** in `<constraints>` block | `.claude/commands/update-documentation.md` |
| New `<examples id=\"derivability\">` block with disallowed/correct/rationale | same file |
| Inline reference to constraint #7 in **Step 4** (Update CHANGELOG.md) | same file |

### Constraint #7 (verbatim)

> Every entry must be derivable from the documented source set: git diff (of the files changed), `plugin.json`, and commit subjects. The following are NOT in the source set and MUST NOT appear in entries:
> - Reviewer identities — names of human reviewers, code-review subagents (e.g. `Bug Hunter A`, `Unified Auditor`, `Premise Reviewer`, `devops-architect`), or PR commenters
> - Internal finding codes (e.g. `auditor_f0`, `bha_p0_f1`, `domain_0_f0`)
> - Severity tier names (HIGH / MEDIUM / BLOCKING / etc.) unless the commit subject already contains them
> - PR-comment thread context, agent verification verdicts, review meta-state
> - Anything else that came from the conversation but not from `git`/`plugin.json`/commit subjects
>
> If a fix originated from a code review, describe what the code does differently now — not who flagged it or how it was triaged.

### Example pair (verbatim)

**Disallowed:**
> - **Case-sensitive migration patterns broke legacy semantics (PR #124, Bug Hunter B HIGH + thadeusb).** Legacy `route` matched `pattern.lower() in path.lower()`.

**Correct:**
> - The migration legacy soft-compat now preserves case-insensitive substring semantics. The migration emits `ignore_case: True` on every migrated trigger, and `_trigger_fires` recompiles the regex with `re.IGNORECASE` when the flag is set.

**Rationale:** the disallowed version references the reviewer (\"Bug Hunter B\"), the human (\"thadeusb\"), the severity tier (\"HIGH\"), and the PR-comment thread (\"PR #124\") — none of which appear in `git diff`, `plugin.json`, or commit subjects. The correct version describes the same code change, plainly, from sources the workflow actually reads.

## Why the skill and not CLAUDE.md

The CLAUDE.md rule is doing its job (the violations get caught at review time). What's missing is *enforcement at edit time* — the constraint only matters at one specific moment, when the CHANGELOG is being written. Tightening at the skill level is more precise and doesn't add prose to a file (CLAUDE.md) that already documents the rule.

If this proves insufficient, the next escalation is to convert `/update-documentation` to a subagent that runs in an isolated context with no conversation history — mechanically preventing the violation. That's a bigger change; this is the cheaper first attempt.

## Validation

- No plugin files touched → `pytest`, `ruff`, `pyright` unaffected (not re-run)
- Skill prompt parses cleanly (no malformed markdown / fenced examples)
- `<examples id=\"derivability\">` block follows the same structural conventions as the existing `<examples id=\"changelog-entries\">` and `<examples id=\"duplicate-detection\">` blocks

## Risk

Skill prompt change only. The next session that invokes `/update-documentation` reads the new constraints. No retroactive effect on existing CHANGELOG entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)