### PR TITLE
docs: clarify pyright runs via uv + add narrowing learned pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,10 @@ pytest plugins/                          # all tests
 pytest plugins/code/tools/python/        # single plugin's tests
 pytest plugins/code/tools/python/test_count_tokens.py -k test_name  # single test
 
-# Linting & type checking
-ruff check .
-pyright
+# Linting & type checking (match CI exactly — local-pyright vs uv-run-pyright
+# divergence can mask reportOptionalMemberAccess and similar diagnostics)
+uv run ruff check .
+uv run pyright
 ```
 
 ## Architecture
@@ -90,6 +91,7 @@ All commits MUST follow the conventions in `CONTRIBUTING.md`. Specifically:
 ### Code Quality
 - **[mistake]**: When modifying behavior, audit adjacent comments and docstrings for accuracy — remove or update references to non-existent files, incomplete field lists, or scope descriptions narrower than actual behavior. (context: comments|docstrings|accuracy)
 - **[mistake]**: Before adding helper logic, grep for adjacent helpers with the same responsibility and delegate instead of duplicating membership checks or fixture factories. (context: duplication|helpers|tests|shell)
+- **[mistake]**: When narrowing an `Any`-typed value with `isinstance`, bind it to a local first; calling the source twice in one expression (e.g. `d.get(k) if isinstance(d.get(k), dict) else {}`) makes pyright treat the two calls as separate evaluations so the narrowing doesn't carry to downstream `.get()` accesses — `reportOptionalMemberAccess` fires under stricter CI pyright settings even when local pyright misses it. (context: pyright|narrowing|ci-divergence)
 
 ### Orchestration & State
 - **[mistake]**: When changing run-loop or self-learning resume/rate-limit logic, preserve persisted state contracts: iteration rows, session IDs, success counts, and terminal statuses. (context: run-loop|resume|state|rate-limit)


### PR DESCRIPTION
## Summary

Two project-wide guidance updates motivated by the v2.23.3 CI typecheck failure on PR #134:

1. **Linting & type checking commands** in CLAUDE.md now use `uv run ruff check .` and `uv run pyright` to match CI exactly. The pre-update `pyright` command relied on whichever pyright was in PATH (often a different version than uv's locked one), which can mask `reportOptionalMemberAccess` diagnostics that fail CI.
2. **New Code Quality learned pattern** captures the v2.23.3 root cause: when narrowing an `Any`-typed value with `isinstance`, bind to a local first — calling the source twice in one expression (`d.get(k) if isinstance(d.get(k), dict) else {}`) makes pyright treat the two calls as separate evaluations so the narrowing doesn't carry to downstream `.get()` accesses.

No plugin files touched, so no version bump required (per CLAUDE.md's "Version Bumps (Required)" section, only changes under `plugins/<name>/` require a manifest bump).

## Test plan
- [x] CLAUDE.md renders correctly (markdown structure preserved, learned-pattern bullet matches the existing format)
- [x] No `plugins/` files touched — `.githooks/pre-push` CHANGELOG enforcement doesn't apply
- [x] `uv run ruff check .` and `uv run pyright` are the same commands CI uses (verified against `.github/workflows/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)