### PR TITLE
fix(code-review): post-merge follow-ups for v2.29.1 (v2.29.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code-review v2.29.2
+
+PATCH bump — documentation/comment accuracy fixes plus one test-helper consolidation and two test-isolation fixes. No production behavior change.
+
+#### Fixed
+- `_check_tier_mismatch_nudge` docstring now describes the MEDIUM severity actually emitted (previously said "Emit a single LOW system-scoped finding" and "severity is fixed at LOW"). Updated text explains the SEVERITY_NORMALIZE rationale (`"low"` → `"DISCARD"`) and notes the `Coverage` category keeps the finding out of Rule 4's cumulative Premise gate.
+- `cmd_hygiene` inline comment "single LOW finding" updated to "single MEDIUM finding" so it matches the emitted severity.
+- `start.md` and `shallow.md` Depth Tiers descriptions now describe the `tier_mismatch_nudge` finding as MEDIUM (category `Coverage`) instead of LOW.
+- `TestPLN807Phase5TierMismatchNudge` class docstring updated to match the MEDIUM assertion the same PR introduced and to record the SEVERITY_NORMALIZE rationale alongside it.
+- `_select_domain_critics` docstring no longer claims the caller surfaces deferred required entries as coverage-gap findings — that emission was removed in v2.29.1. New text describes the actual contract: cap-deferred entries from EITHER bucket land in `deferred_for_budget` with `defer_reason: "domain_critic_cap"`, and the caller does NOT emit coverage-gap findings (doing so would trip `_compute_canonical_verdict` Rule 1).
+- `_validate_stages_config` inline comment corrected: said `min_depth >= max_depth` is "the floor", but the load-time invariant is `min_depth <= max_depth` (`>=` describes the error condition the validator raises on, not the valid band).
+- `test_auto_incremental_skips_when_cached_tier_weaker` now sets `CR_AUTO_INCREMENTAL=1` via `monkeypatch.setenv` before invoking `cmd_auto_incremental`. Without this, a shell with `CR_AUTO_INCREMENTAL=0` would skip the entire tier-gate branch and the test's "tier upgrade" assertion would fail spuriously.
+- `test_auto_incremental_without_depth_preserves_legacy_behavior` now mocks `code_review_helpers._run_git` via `patch(..., return_value="")` so the ancestry check passes deterministically regardless of the test environment's git state. Previously the synthetic `last_sha="abc123"` would raise `CalledProcessError` (git present) or propagate `FileNotFoundError` (git absent) instead of exercising the intended depth-bypass branch.
+
+#### Changed
+- `make_auto_incremental_args` factory in `conftest.py` replaces the two parallel `cmd_auto_incremental` Namespace factories that previously lived in `TestAutoIncremental._make_args` and `TestPLN807ReviewFixes._make_auto_inc_args`. Both classes now delegate to the shared factory; new `depth` and `base_ref` defaults live in one place, so a future field addition updates one factory instead of two.
+
 ### code-review v2.29.1
 
 PR #144 review-feedback follow-ups. PATCH bump — no schema additions; one behavior change (cap-deferred required critics no longer block) and a cluster of correctness, schema-contract, and documentation fixes.

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "2.29.1",
+  "version": "2.29.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/commands/shallow.md
+++ b/plugins/code-review/commands/shallow.md
@@ -32,7 +32,7 @@ This command is shorthand for `/start --depth shallow`. Follow every instruction
 
 ## When NOT to use
 
-If the PR is > 3000 LOC, touches schema/migrations, or modifies public API surfaces (plugin.json, index.ts, __init__.py), shallow will emit a `tier_mismatch_nudge` LOW finding suggesting `--depth standard`. Pay attention to that nudge — those are the cases shallow's missing reviewers commonly catch.
+If the PR is > 3000 LOC, touches schema/migrations, or modifies public API surfaces (plugin.json, index.ts, __init__.py), shallow will emit a `tier_mismatch_nudge` MEDIUM finding (category `Coverage`) suggesting `--depth standard`. Pay attention to that nudge — those are the cases shallow's missing reviewers commonly catch.
 
 ## Execution
 

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -31,7 +31,7 @@ Run a multi-agent code review with partitioned deep review, deterministic hygien
 
 The `--depth` flag selects which reviewer fleet runs. Default `standard`. Bare `/start` invocations preserve historical behavior.
 
-- **shallow** — hygiene + BHA (partitioned at >5000 LOC) + BHB + unified_auditor + verifier. Skips signal extraction, coverage planning/critic, premise_reviewer, and all `critic-gates.json` entries. Static spawn spec; no routing/critic decisions. Hygiene emits a `tier_mismatch_nudge` LOW finding when the PR's diff size, schema/migration paths, or public API surface suggest standard would catch more.
+- **shallow** — hygiene + BHA (partitioned at >5000 LOC) + BHB + unified_auditor + verifier. Skips signal extraction, coverage planning/critic, premise_reviewer, and all `critic-gates.json` entries. Static spawn spec; no routing/critic decisions. Hygiene emits a `tier_mismatch_nudge` MEDIUM finding (category `Coverage`) when the PR's diff size, schema/migration paths, or public API surface suggest standard would catch more.
 - **standard** — current behavior. Full fleet with signal-driven routing, coverage critic, premise, repo-specific critic activation via `critic-gates.json`. Budget arithmetic reserves BHA partitions FIRST (Phase 4) and caps total domain critics at `DOMAIN_CRITIC_CAP = 5` across both required and best-effort buckets. Required critics dropped by the cap emit coverage-gap findings.
 - **deep** — standard plus future heavy reviewers gated by `min_depth: deep` in `stages.json`. Reserved for FEA-1401 Impact Analyzer; today behaves identically to standard.
 

--- a/plugins/code-review/tools/python/code_review_helpers.py
+++ b/plugins/code-review/tools/python/code_review_helpers.py
@@ -732,8 +732,8 @@ def _matches_schema_or_migration_path(filepath: str) -> bool:
 def _check_tier_mismatch_nudge(
     diff_data: dict[str, Any], depth: str | None,
 ) -> list[dict[str, Any]]:
-    """Emit a single LOW system-scoped finding when shallow runs on a
-    PR that would benefit from a higher-tier review (PLN-807 Phase 5).
+    """Emit a single MEDIUM system-scoped finding when shallow runs on
+    a PR that would benefit from a higher-tier review (PLN-807 Phase 5).
 
     Three heuristics fire independently; any one is enough:
 
@@ -748,8 +748,12 @@ def _check_tier_mismatch_nudge(
 
     Runs only when depth=='shallow'. All other tiers no-op. The
     finding's marker (``tier_mismatch_nudge``) makes it easy to
-    auto-dismiss or filter out at the operator's discretion; severity
-    is fixed at LOW so it never escalates the verdict.
+    auto-dismiss or filter out at the operator's discretion. Severity
+    is MEDIUM — the lowest tier that survives validate's
+    SEVERITY_NORMALIZE map (which DISCARDs "low"). Category "Coverage"
+    rather than "Premise" keeps it out of the cumulative Premise
+    MEDIUM gate (Rule 4 of _compute_canonical_verdict) so it cannot
+    escalate the verdict on its own.
     """
     if depth != "shallow":
         return []
@@ -848,8 +852,8 @@ def cmd_hygiene(args: argparse.Namespace) -> int:
 
     # PLN-807 Phase 5: tier-mismatch nudge. Runs once per invocation
     # (not per file) because the heuristics are diff-level. Adds a
-    # single LOW finding when shallow was chosen but heuristics suggest
-    # a higher tier would have caught more.
+    # single MEDIUM finding when shallow was chosen but heuristics
+    # suggest a higher tier would have caught more.
     findings.extend(_check_tier_mismatch_nudge(diff_data, depth))
 
     # Promote to canonical schema (PLN-719 Foundation Section 1).
@@ -9414,8 +9418,9 @@ def _validate_stages_config(config: dict[str, Any]) -> None:
         # new stage added to stages.json without a tier tag fails loud
         # at config-load instead of silently inheriting the implicit
         # ``standard`` default. ``max_depth`` stays optional (most
-        # stages run through to deep); ``min_depth >= max_depth`` is
-        # the floor.
+        # stages run through to deep). The band constraint enforced at
+        # load time is ``min_depth <= max_depth`` (catches swapped
+        # values like ``min=deep, max=shallow``).
         if "min_depth" not in stage:
             raise ValueError(
                 f"stages.json {sid}: missing required ``min_depth`` field; "
@@ -9912,9 +9917,13 @@ def _select_domain_critics(
     even when entries shift declaration position.
 
     Returns ``(selected_required, selected_best_effort, deferred_required,
-    deferred_best_effort)``. Deferred required entries are surfaced
-    via coverage-gap findings by the caller; deferred best-effort
-    entries only appear in ``deferred_for_budget``.
+    deferred_best_effort)``. Cap-deferred entries from EITHER bucket
+    land in ``deferred_for_budget`` with
+    ``defer_reason: "domain_critic_cap"``; the caller does NOT emit
+    coverage-gap findings for cap-deferred required critics (doing so
+    would trip ``_compute_canonical_verdict`` Rule 1 on any repo whose
+    ``critic-gates.json`` resolves more than ``cap`` required domain
+    critics).
     """
     def sort_key(e: dict[str, Any]) -> tuple[int, str]:
         try:

--- a/plugins/code-review/tools/python/conftest.py
+++ b/plugins/code-review/tools/python/conftest.py
@@ -102,6 +102,38 @@ def invoke_prepare_run(
     return summary, run_plan
 
 
+def make_auto_incremental_args(
+    cache_dir: Path,
+    **overrides: Any,
+) -> argparse.Namespace:
+    """Factory for ``cmd_auto_incremental`` argparse.Namespace.
+
+    Shared between ``TestAutoIncremental`` and ``TestPLN807ReviewFixes``
+    so the Namespace shape stays in lock-step with the cmd's expected
+    fields. When ``cmd_auto_incremental`` gains a new arg, this one
+    factory is updated rather than two parallel ones drifting
+    independently.
+
+    Defaults match the legacy local-mode invocation; pass overrides
+    (e.g. ``depth="standard"``, ``mode="github"``,
+    ``original_scope="origin/main..HEAD"``) to exercise specific
+    branches.
+    """
+    defaults: dict[str, Any] = {
+        "cache_dir": str(cache_dir),
+        "key": "branch:main",
+        "diff_tip": "HEAD",
+        "original_scope": "main...HEAD",
+        "full_review": "false",
+        "since_last_review": "false",
+        "mode": "local",
+        "base_ref": "main",
+        "depth": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
 def minimal_diff_finding(**overrides: Any) -> dict[str, Any]:
     """Return a canonical diff-scoped finding with sensible defaults.
 

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -5517,19 +5517,9 @@ class TestComputeHashes:
 
 class TestAutoIncremental:
     def _make_args(self, tmp_path: Path, **overrides: Any) -> Any:
-        import argparse
+        from conftest import make_auto_incremental_args
 
-        defaults: dict[str, Any] = {
-            "cache_dir": str(tmp_path),
-            "key": "branch:main",
-            "diff_tip": "HEAD",
-            "original_scope": "main...HEAD",
-            "full_review": "false",
-            "since_last_review": "false",
-            "mode": "local",
-        }
-        defaults.update(overrides)
-        return argparse.Namespace(**defaults)
+        return make_auto_incremental_args(tmp_path, **overrides)
 
     def test_full_review_flag(self, tmp_path: Path, capsys: Any) -> None:
         ns = self._make_args(tmp_path, full_review="true")
@@ -19775,8 +19765,11 @@ class TestPLN807Phase5TierMismatchNudge:
     """PLN-807 Phase 5: hygiene-stage tier-mismatch nudge.
 
     When shallow runs on a PR that would have benefited from premise
-    or critic-gates entries, a single LOW system-scoped finding is
-    emitted so the user can see what was skipped. Heuristics:
+    or critic-gates entries, a single MEDIUM system-scoped finding
+    (category ``Coverage``) is emitted so the user can see what was
+    skipped. MEDIUM rather than LOW because validate's
+    SEVERITY_NORMALIZE map DISCARDs ``"low"`` — a LOW nudge would
+    never reach the operator. Heuristics:
       - diff > 3000 LOC
       - schema/migration paths
       - public API surface files (plugin.json, index.ts, __init__.py, etc.)
@@ -20136,32 +20129,24 @@ class TestPLN807ReviewFixes:
 
     # ---------- Auto-incremental tier gate ----------
 
-    def _make_auto_inc_args(
-        self, *, cache_dir: Path, key: str, diff_tip: str,
-        full_review: str = "false", since_last_review: str = "false",
-        mode: str = "local", depth: str | None = None,
-        original_scope: str = "origin/main..HEAD",
-    ) -> argparse.Namespace:
-        return argparse.Namespace(
-            cache_dir=str(cache_dir),
-            key=key,
-            diff_tip=diff_tip,
-            base_ref="main",
-            original_scope=original_scope,
-            full_review=full_review,
-            since_last_review=since_last_review,
-            mode=mode,
-            depth=depth,
-        )
-
     def test_auto_incremental_skips_when_cached_tier_weaker(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """A cached shallow entry must not seed a standard run's
         incremental scope."""
         from code_review_helpers import (
             _write_review_state, cmd_auto_incremental,
         )
+        from conftest import make_auto_incremental_args
+
+        # The tier-gate branch lives inside ``if mode == "local" and
+        # auto_enabled and cache_dir:`` where ``auto_enabled`` is
+        # ``os.environ.get("CR_AUTO_INCREMENTAL", "1") == "1"``. CI or
+        # a developer shell with ``CR_AUTO_INCREMENTAL=0`` would skip
+        # the entire block and the test's assertion against
+        # ``"tier upgrade"`` would fail spuriously.
+        monkeypatch.setenv("CR_AUTO_INCREMENTAL", "1")
 
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
@@ -20169,8 +20154,8 @@ class TestPLN807ReviewFixes:
             "sha": "abc123", "tier": "shallow", "success": True,
         }}}
         _write_review_state(cache_dir, state)
-        ns = self._make_auto_inc_args(
-            cache_dir=cache_dir, key="feat:main", diff_tip="HEAD",
+        ns = make_auto_incremental_args(
+            cache_dir, key="feat:main", diff_tip="HEAD",
             depth="standard",
         )
         rc = cmd_auto_incremental(ns)
@@ -20185,14 +20170,15 @@ class TestPLN807ReviewFixes:
         from code_review_helpers import (
             _write_review_state, cmd_auto_incremental,
         )
+        from conftest import make_auto_incremental_args
 
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
         _write_review_state(cache_dir, {"reviews": {"feat:main": {
             "sha": "abc123", "tier": "shallow", "success": True,
         }}})
-        ns = self._make_auto_inc_args(
-            cache_dir=cache_dir, key="feat:main", diff_tip="HEAD",
+        ns = make_auto_incremental_args(
+            cache_dir, key="feat:main", diff_tip="HEAD",
             since_last_review="true", depth="deep",
         )
         rc = cmd_auto_incremental(ns)
@@ -20201,26 +20187,38 @@ class TestPLN807ReviewFixes:
 
     def test_auto_incremental_without_depth_preserves_legacy_behavior(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """When --depth is absent (legacy caller), no tier gating."""
+        from unittest.mock import patch
+
         from code_review_helpers import (
             _write_review_state, cmd_auto_incremental,
         )
+        from conftest import make_auto_incremental_args
+
+        monkeypatch.setenv("CR_AUTO_INCREMENTAL", "1")
 
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
         _write_review_state(cache_dir, {"reviews": {"feat:main": {
             "sha": "abc123", "tier": "shallow", "success": True,
         }}})
-        ns = self._make_auto_inc_args(
-            cache_dir=cache_dir, key="feat:main", diff_tip="HEAD", depth=None,
+        ns = make_auto_incremental_args(
+            cache_dir, key="feat:main", diff_tip="HEAD", depth=None,
         )
-        rc = cmd_auto_incremental(ns)
+        # Mock ``_run_git`` so the ancestry check succeeds deterministically
+        # regardless of the test environment's git state. Without this, a
+        # synthetic SHA like ``"abc123"`` raises ``CalledProcessError`` (git
+        # present) or ``FileNotFoundError`` (git absent), and the test would
+        # exercise the wrong branch — or fail outright. Matches the pattern
+        # in every other cmd_auto_incremental test that reaches this path.
+        with patch("code_review_helpers._run_git", return_value=""):
+            rc = cmd_auto_incremental(ns)
         assert rc == 0
         out = json.loads(capsys.readouterr().out.strip())
-        # Output is mode-detail (either auto-incremental success or
-        # ancestry check fail); the important invariant is that the
-        # "tier upgrade" skip path did NOT fire.
+        # The important invariant: the "tier upgrade" skip path did NOT
+        # fire (depth=None bypasses tier gating regardless of cached tier).
         assert "tier upgrade" not in (out.get("review_mode_line") or "")
 
     # ---------- stage_19c depends on stage_19_cache_check (fast-path safe) ----------


### PR DESCRIPTION
## Summary

Follow-up to the cr-97442 local review of the merged PR #144. Documentation/comment accuracy fixes plus one test-helper consolidation and two test-isolation fixes. No production behavior change.

## Changes

**Stale comments/docstrings — severity rename propagation:**
- `_check_tier_mismatch_nudge` docstring (`code_review_helpers.py:735`)
- `cmd_hygiene` inline comment (`code_review_helpers.py:851`)
- `TestPLN807Phase5TierMismatchNudge` class docstring (`test_code_review_helpers.py:19774`)
- `start.md` Depth Tiers shallow bullet (line 34)
- `shallow.md` "When NOT to use" paragraph (line 35)

All updated from "LOW" to "MEDIUM" (category Coverage) to match the severity that v2.29.1 actually emits.

**Stale contract docstring:**
- `_select_domain_critics` docstring rewritten to describe the v2.29.1 behavior: cap-deferred entries from EITHER bucket land in `deferred_for_budget` with `defer_reason: "domain_critic_cap"`, and the caller does NOT emit coverage-gap findings (Rule 1 trap).

**Inverted inequality comment:**
- `_validate_stages_config` block in `code_review_helpers.py` said `min_depth >= max_depth` is "the floor"; the load-time invariant the validator enforces is `min_depth <= max_depth`.

**Test-helper DRY consolidation:**
- New `make_auto_incremental_args` factory in `conftest.py` replaces the two parallel `cmd_auto_incremental` Namespace factories (`TestAutoIncremental._make_args` and `TestPLN807ReviewFixes._make_auto_inc_args`). Both classes now delegate.

**Test isolation:**
- `test_auto_incremental_skips_when_cached_tier_weaker` sets `CR_AUTO_INCREMENTAL=1` via `monkeypatch.setenv` so the tier-gate branch runs regardless of caller env.
- `test_auto_incremental_without_depth_preserves_legacy_behavior` mocks `code_review_helpers._run_git` so the ancestry check is deterministic regardless of test-environment git state.

## Test plan

- [x] `uv run pytest plugins/code-review/tools/python/test_code_review_helpers.py` — 1057 passed
- [x] `uv run pytest plugins/` — 1886 passed, 5 skipped
- [x] `uv run ruff check .`
- [x] `uv run pyright` — 0 errors
- [x] `plugin.json` bumped 2.29.1 → 2.29.2
- [x] CHANGELOG.md v2.29.2 entry added (via `/update-documentation`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)