### PR TITLE
fix(code-review): suppress out-of-hunk findings from inline posting (v2.31.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code-review v2.31.1
+
+PATCH bump — fix GitHub-mode inline comments silently dropping when a PR moves or renames files. GitHub's `pulls/{pr}/comments` API rejects any inline comment whose line is not part of the PR diff with a 422; reviewers flagging lines outside the changed hunks (common on moved/renamed files) therefore failed to post and survived only in the summary.
+
+#### Fixed
+- `cmd_post_comments` no longer attempts an inline post for findings the validator tagged `out_of_hunk_kept` — those lines are outside the diff and cannot be anchored — and now treats a runtime 422 ("line not in diff") as a non-inline skip rather than a failure, covering moved/renamed files where the diff parser and GitHub disagree on what is in-diff. The affected findings still appear in the summary comment, and the posting tally gains an `out-of-hunk=` counter so the case is visible instead of reported as a failure.
+
+#### Changed
+- `prompts/github-review.md` step 6b documents that the post-comments step owns out-of-hunk suppression, so the findings file must still include every verified finding for the summary's findings list.
+
 ### code-review v2.31.0
 
 MINOR bump — optional `codebase-memory-mcp` knowledge-graph integration for the cross-file reviewers (Impact Analyzer and Bug Hunter B), with a provenance-aware verifier so graph-only callsites are first-class. When the MCP server is connected and this repo is indexed, the graph-aware reviewers use `search_graph`/`trace_path`/`get_code_snippet` to find cross-file usages grep cannot reach — aliased imports, re-exports, dynamic dispatch — and to resolve service/API implementations by qualified name instead of Glob-guessing the file. The integration falls back to grep silently when the server is absent or the repo is unindexed, so behavior is unchanged when the MCP is not installed; reviews never trigger indexing.

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/prompts/github-review.md
+++ b/plugins/code-review/prompts/github-review.md
@@ -157,6 +157,8 @@ Write `.closedloop-ai/code-review-findings.json`:
 
 The `findings` array contains the envelope's `verified[]` only (NOT `rejected[]`, `justified[]`, or `pending_verification[]` — those have separate files; see 6c and 6d). When no envelope exists (verifier disabled / shadow mode), fall back to the legacy validate output. The workflow's `post-comments` step handles formatting, dedup against existing comments, and error handling.
 
+Write all verified findings verbatim — do NOT pre-filter out-of-hunk ones. `post-comments` skips findings tagged `out_of_hunk_kept` (and any line GitHub rejects with a 422 as out-of-diff) from inline posting and lets them surface in the summary instead, so they must remain in the findings file for the summary's findings list.
+
 **Impact Analyzer findings (FEA-1401).** Findings with
 `category: "ImpactAnalysis"` carry a populated `external_impact[]`
 array (file/line/impact_type/description/callsite_snippet/

--- a/plugins/code-review/tools/python/code_review_helpers.py
+++ b/plugins/code-review/tools/python/code_review_helpers.py
@@ -4084,7 +4084,18 @@ def _gh_api(
 
 
 def cmd_post_comments(args: argparse.Namespace) -> int:
-    """Post inline review comments to a GitHub PR."""
+    """Post inline review comments to a GitHub PR.
+
+    Out-of-hunk findings are never posted inline. GitHub's
+    ``pulls/{pr}/comments`` API rejects any comment whose line is not part of
+    the PR diff with a 422, which is exactly the case for companion-change
+    findings the validator kept (``out_of_hunk_kept: True``) and for findings
+    on moved/renamed files whose pre-existing lines are outside every diff
+    hunk. Those findings are dropped from inline posting and surface in the
+    summary comment instead (the summary renders all validated findings). They
+    are pre-skipped when tagged, and a runtime 422 is treated as a non-inline
+    skip rather than a failure to cover parser/GitHub diff disagreements.
+    """
     try:
         with open(args.findings) as f:
             data: dict[str, Any] = json.load(f)
@@ -4133,12 +4144,20 @@ def cmd_post_comments(args: argparse.Namespace) -> int:
     posted = 0
     skipped_dedup = 0
     skipped_no_inline = 0
+    skipped_out_of_hunk = 0
     failed = 0
 
     for finding in findings:
         # Skip findings explicitly marked as non-inline
         if finding.get("inline") is False:
             skipped_no_inline += 1
+            continue
+
+        # Out-of-hunk findings (companion-change survivors the validator tagged)
+        # reference lines outside every diff hunk, so GitHub would 422 the inline
+        # post. Surface them in the summary only and skip the API call.
+        if finding.get("out_of_hunk_kept") is True:
+            skipped_out_of_hunk += 1
             continue
 
         path = finding.get("file") or ""
@@ -4192,18 +4211,29 @@ def cmd_post_comments(args: argparse.Namespace) -> int:
             stdout_lower = (api_result.stdout or "").lower()
             err_text = stderr_lower + stdout_lower
             if "422" in err_text or "validation failed" in err_text:
-                print(f"  Skipped {path}:{line} — line not in diff (422)")
+                # Line is not part of the PR diff — GitHub cannot anchor an
+                # inline comment here (out-of-hunk finding the validator counted
+                # as in-range, or a parser/GitHub diff disagreement on
+                # moved/renamed files). The finding still appears in the summary;
+                # count as a non-inline skip, not a failure.
+                print(f"  Skipped {path}:{line} — line not in diff (422), summary-only")
+                skipped_out_of_hunk += 1
             elif "401" in err_text or "403" in err_text:
                 print(f"  Skipped {path}:{line} — auth error")
+                failed += 1
             else:
                 print(f"  Failed {path}:{line} — {api_result.stderr.strip()}")
-            failed += 1
+                failed += 1
             continue
 
         posted += 1
 
-    total_skipped = skipped_dedup + skipped_no_inline
-    print(f"Posted {posted}, skipped {total_skipped} (dedup={skipped_dedup}, non-inline={skipped_no_inline}), failed {failed}")
+    total_skipped = skipped_dedup + skipped_no_inline + skipped_out_of_hunk
+    print(
+        f"Posted {posted}, skipped {total_skipped} "
+        f"(dedup={skipped_dedup}, non-inline={skipped_no_inline}, "
+        f"out-of-hunk={skipped_out_of_hunk}), failed {failed}"
+    )
     return 0
 
 

--- a/plugins/code-review/tools/python/code_review_helpers.py
+++ b/plugins/code-review/tools/python/code_review_helpers.py
@@ -4219,7 +4219,7 @@ def cmd_post_comments(args: argparse.Namespace) -> int:
                 print(f"  Skipped {path}:{line} — line not in diff (422), summary-only")
                 skipped_out_of_hunk += 1
             elif "401" in err_text or "403" in err_text:
-                print(f"  Skipped {path}:{line} — auth error")
+                print(f"  Failed {path}:{line} — auth error")
                 failed += 1
             else:
                 print(f"  Failed {path}:{line} — {api_result.stderr.strip()}")

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -3787,9 +3787,33 @@ class TestCmdPostComments:
             mock_run.side_effect = [success, fail_422]
             rc = self._run(path)
         assert rc == 0
+        # 1 GET + 1 POST (the POST is attempted, then 422'd into the skip bucket).
+        assert mock_run.call_count == 2
         out = capsys.readouterr().out
         assert "out-of-hunk=1" in out
         assert "failed 0" in out
+
+    def test_auth_error_counted_as_failure(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A 401/403 is a genuine failure (not a skip) — the message and the
+        tally must agree so an operator isn't misled into ignoring an auth
+        problem."""
+        findings = [
+            {"file": "a.ts", "line": 10, "severity": "HIGH", "category": "Bug", "issue": "first"},
+        ]
+        path = _make_findings_file(tmp_path, findings)
+        success = subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr="")
+        fail_401 = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="HTTP 401: Bad credentials")
+        with patch("code_review_helpers.subprocess.run") as mock_run:
+            mock_run.side_effect = [success, fail_401]
+            rc = self._run(path)
+        assert rc == 0
+        # 1 GET + 1 POST (the POST is attempted and fails auth).
+        assert mock_run.call_count == 2
+        out = capsys.readouterr().out
+        assert "failed 1" in out
+        assert "out-of-hunk=0" in out
 
     def test_out_of_hunk_kept_skips_inline_post(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/plugins/code-review/tools/python/test_code_review_helpers.py
+++ b/plugins/code-review/tools/python/test_code_review_helpers.py
@@ -3771,6 +3771,53 @@ class TestCmdPostComments:
         assert rc == 0
         assert mock_run.call_count == 3
 
+    def test_422_counted_as_skip_not_failure(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A 422 (line not in diff) is a non-inline skip, not a failure — the
+        finding still surfaces in the summary. Reviewers flagging unchanged
+        lines on moved/renamed files must not be reported as posting failures."""
+        findings = [
+            {"file": "a.ts", "line": 10, "severity": "HIGH", "category": "Bug", "issue": "first"},
+        ]
+        path = _make_findings_file(tmp_path, findings)
+        success = subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr="")
+        fail_422 = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="422 Validation Failed")
+        with patch("code_review_helpers.subprocess.run") as mock_run:
+            mock_run.side_effect = [success, fail_422]
+            rc = self._run(path)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "out-of-hunk=1" in out
+        assert "failed 0" in out
+
+    def test_out_of_hunk_kept_skips_inline_post(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Findings tagged ``out_of_hunk_kept`` reference lines outside the diff
+        and would 422; the poster must skip them up front (no API call) and
+        count them as non-inline skips, leaving them for the summary."""
+        findings = [
+            {"file": "a.ts", "line": 1, "severity": "MEDIUM", "category": "Bug",
+             "issue": "companion change", "out_of_hunk_kept": True},
+            {"file": "b.ts", "line": 20, "severity": "HIGH", "category": "Bug",
+             "issue": "real inline"},
+        ]
+        path = _make_findings_file(tmp_path, findings)
+        with patch("code_review_helpers.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="[]", stderr=""
+            )
+            rc = self._run(path)
+        assert rc == 0
+        # 1 GET + 1 POST (only b.ts:20 is posted; the out-of-hunk finding never
+        # reaches the API).
+        assert mock_run.call_count == 2
+        out = capsys.readouterr().out
+        assert "Posted 1" in out
+        assert "out-of-hunk=1" in out
+        assert "failed 0" in out
+
     def test_null_line_does_not_crash(self, tmp_path: Path) -> None:
         """PLN-719: schema permits ``line: int | None`` for system + pr_metadata
         scopes. cmd_post_comments must skip those rather than crash on


### PR DESCRIPTION
## Problem

GitHub code reviews stopped leaving inline comments on PRs that **move or rename files**. The summary comment still posted, but no inline (line-anchored) comments appeared.

Root cause: GitHub's `POST /repos/{owner}/{repo}/pulls/{pr}/comments` rejects any inline comment whose line is **not part of the PR diff** with a `422`. On moved/renamed files, reviewers flag pre-existing lines that fall outside every diff hunk. The validator deliberately keeps high-confidence out-of-hunk findings (tagged `out_of_hunk_kept`), but `cmd_post_comments` then tried to post all of them inline — every one `422`'d, yielding `Posted 0, failed N` and zero inline comments. The findings survived only in the summary, which is exactly the "summary posts, no inline" symptom.

Observed in the wild:
```
Skipped packages/app/shared/lib/s3-upload.ts:1 — line not in diff (422)
Skipped packages/app/loops/lib/compute-target-conflict.ts:20 — line not in diff (422)
...
Posted 0, skipped 0 (dedup=0, non-inline=0), failed 4
```

## Fix

`cmd_post_comments` now:
- **Pre-skips** findings tagged `out_of_hunk_kept` (no API call) — those lines are provably outside the diff and cannot be anchored.
- **Reclassifies the runtime 422** ("line not in diff") from `failed` to a non-inline skip, covering moved/renamed files where the `-U0` diff parser and GitHub disagree on what is in-diff even for findings the validator counted as in-range.

These findings still surface in the **summary comment** (it renders all validated findings) — the chosen behavior is summary-only suppression, not a separate inline fallback. The posting tally gains an `out-of-hunk=` counter so the case is visible instead of silently reported as a failure:

```
Posted N, skipped M (dedup=…, non-inline=…, out-of-hunk=K), failed N
```

## Notes / scope

This stops the silent failure and keeps these findings in the summary, but does **not** make moved-file findings appear inline — GitHub fundamentally cannot anchor a comment to a line outside its diff. A better follow-up (separate PR) is upstream: not feeding reviewers the full body of pure-rename files so they stop flagging unchanged lines in the first place.

## Changes

- `tools/python/code_review_helpers.py` — `cmd_post_comments` pre-skip + 422 reclassification + counter
- `prompts/github-review.md` — step 6b documents poster-owned out-of-hunk suppression (findings file must still include all verified findings)
- tests — `test_422_counted_as_skip_not_failure`, `test_out_of_hunk_kept_skips_inline_post`; updated `test_422_continues`
- `plugin.json` — `2.31.0` → `2.31.1` (PATCH)

## Verification

- `uv run pytest plugins/code-review/tools/python/` → `1207 passed, 5 skipped`
- `uv run ruff check` + `uv run pyright` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)