### PR TITLE
fix(code): extract class tokens from expression classNames in CSS slicer

### DIFF
--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/skills/design-inventory/scripts/dist/build-design-pack.mjs
+++ b/plugins/code/skills/design-inventory/scripts/dist/build-design-pack.mjs
@@ -363,6 +363,57 @@ function renderReuseLine(reuse) {
   }
   return String(reuse["resolution"] ?? "");
 }
+function renderInteractions(visual) {
+  const interactions = visual["interactions"] ?? {};
+  const stateRules = Array.isArray(interactions["state_rules"]) ? interactions["state_rules"] : [];
+  const transitions = Array.isArray(interactions["transitions"]) ? interactions["transitions"] : [];
+  const keyframes = Array.isArray(interactions["keyframes"]) ? interactions["keyframes"] : [];
+  if (stateRules.length === 0 && transitions.length === 0 && keyframes.length === 0) {
+    return [];
+  }
+  const lines = [
+    "## Interaction and State Styles",
+    "",
+    "Mirror this interaction behavior from the design. Resolve raw color and spacing values to the tokens in the Visual Spec above.",
+    ""
+  ];
+  if (stateRules.length > 0) {
+    const byPseudo = /* @__PURE__ */ new Map();
+    for (const rule of stateRules) {
+      const pseudo = String(rule["pseudo"]);
+      let bucket = byPseudo.get(pseudo);
+      if (!bucket) {
+        bucket = [];
+        byPseudo.set(pseudo, bucket);
+      }
+      bucket.push(rule);
+    }
+    lines.push("State styles (what each state does):", "");
+    for (const [pseudo, rulesForPseudo] of [...byPseudo.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+      lines.push(`- \`:${pseudo}\``);
+      for (const rule of rulesForPseudo) {
+        lines.push("", "  ```css", `  ${String(rule["selector"])} { ${String(rule["declarations"])} }`, "  ```");
+      }
+      lines.push("");
+    }
+  }
+  if (transitions.length > 0 || keyframes.length > 0) {
+    lines.push("Transitions and animations:", "");
+    for (const entry of transitions) {
+      lines.push(`- \`${String(entry["selector"])}\` -> \`${String(entry["declaration"])}\``);
+    }
+    if (transitions.length > 0) {
+      lines.push("");
+    }
+    for (const frame of keyframes) {
+      lines.push(`- \`@keyframes ${String(frame["name"])}\``, "", "  ```css", `  @keyframes ${String(frame["name"])} { ${String(frame["body"])} }`, "  ```", "");
+    }
+  }
+  if (interactions["truncated"] === true) {
+    lines.push("_(interaction capture truncated to stay within the ticket budget)_", "");
+  }
+  return lines;
+}
 function renderVisualSpec(visual) {
   const lines = ["## Visual Spec (token-resolved)", ""];
   const colors = visual["colors"] ?? {};
@@ -407,12 +458,6 @@ function renderVisualSpec(visual) {
   if (utility.length > 0) {
     lines.push(`Utility classes in design: ${utility.join(" ")}`);
   }
-  const states = visual["state_styles"] ?? {};
-  if (Object.keys(states).length > 0) {
-    lines.push(
-      "State styles present: " + Object.entries(states).map(([k, v]) => `${k} (${Array.isArray(v) ? v.length : 0} selectors)`).join(", ")
-    );
-  }
   for (const propGroup of ["spacing", "typography"]) {
     const values = visual[propGroup] ?? {};
     if (Object.keys(values).length > 0) {
@@ -425,6 +470,7 @@ function renderVisualSpec(visual) {
     }
   }
   lines.push("");
+  lines.push(...renderInteractions(visual));
   return lines;
 }
 var CODE_FENCE_LANG = {

--- a/plugins/code/skills/design-inventory/scripts/dist/extract-visual-spec.mjs
+++ b/plugins/code/skills/design-inventory/scripts/dist/extract-visual-spec.mjs
@@ -69,6 +69,10 @@ var STATE_PSEUDOS = ["hover", "focus", "focus-visible", "active", "disabled"];
 var LAYOUT_CLASS_HINTS = /^(?:sticky|fixed|absolute|relative|flex|grid|overflow-|snap-|scroll-|inset-|z-\d)/;
 var MAX_LIST = 40;
 var MAX_LOCATIONS = 5;
+var MAX_INTERACTION_RULES = 40;
+var MAX_INTERACTION_CHARS = 8192;
+var ANIMATION_PROP_PREFIXES = ["transition", "animation"];
+var KEYFRAMES_RULE = /@(?:-\w+-)?keyframes\s+([\w-]+)\s*\{((?:[^{}]|\{[^{}]*\})*)\}/g;
 function normalizeColor(value) {
   const v = value.trim().toLowerCase();
   if (v.startsWith("#")) {
@@ -321,6 +325,86 @@ function extractStateStyles(rules) {
   }
   return states;
 }
+function pseudoOf(selector) {
+  for (const pseudo of STATE_PSEUDOS) {
+    if (selector.includes(`:${pseudo}`)) {
+      return pseudo;
+    }
+  }
+  return null;
+}
+function animationNamesFrom(prop, value) {
+  if (prop !== "animation" && prop !== "animation-name") {
+    return [];
+  }
+  const names = [];
+  const tokenRe = new RegExp(CLASS_TOKEN.source, "g");
+  let tokenMatch;
+  while ((tokenMatch = tokenRe.exec(value)) !== null) {
+    names.push(tokenMatch[0]);
+  }
+  return names;
+}
+function extractInteractions(rules, rawCssText) {
+  const stateRules = [];
+  const transitions = [];
+  const referencedKeyframes = /* @__PURE__ */ new Set();
+  let charBudget = MAX_INTERACTION_CHARS;
+  let truncated = false;
+  const tryAdd = (cost) => {
+    const total = stateRules.length + transitions.length;
+    if (total >= MAX_INTERACTION_RULES || cost > charBudget) {
+      truncated = true;
+      return false;
+    }
+    charBudget -= cost;
+    return true;
+  };
+  for (const [selector, body] of rules) {
+    const pseudo = pseudoOf(selector);
+    if (pseudo !== null) {
+      const declarations = body.trim();
+      if (tryAdd(selector.length + declarations.length)) {
+        stateRules.push({ pseudo, selector, declarations });
+      }
+    }
+    const declRe = new RegExp(CSS_DECL.source, "g");
+    let declMatch;
+    while ((declMatch = declRe.exec(body)) !== null) {
+      const prop = (declMatch[1] ?? "").toLowerCase();
+      const value = (declMatch[2] ?? "").trim();
+      const isAnimation = ANIMATION_PROP_PREFIXES.some((p) => prop === p || prop.startsWith(`${p}-`));
+      if (!isAnimation) {
+        continue;
+      }
+      const declaration = `${prop}: ${value}`;
+      if (tryAdd(selector.length + declaration.length)) {
+        transitions.push({ selector, declaration });
+      }
+      for (const name of animationNamesFrom(prop, value)) {
+        referencedKeyframes.add(name);
+      }
+    }
+  }
+  const keyframes = [];
+  if (referencedKeyframes.size > 0) {
+    const keyframesRe = new RegExp(KEYFRAMES_RULE.source, "g");
+    let kfMatch;
+    const seen = /* @__PURE__ */ new Set();
+    while ((kfMatch = keyframesRe.exec(rawCssText)) !== null) {
+      const name = kfMatch[1] ?? "";
+      const body = (kfMatch[2] ?? "").trim();
+      if (!referencedKeyframes.has(name) || seen.has(name)) {
+        continue;
+      }
+      seen.add(name);
+      if (tryAdd(name.length + body.length)) {
+        keyframes.push({ name, body });
+      }
+    }
+  }
+  return { state_rules: stateRules, transitions, keyframes, truncated };
+}
 function extractIcons(jsxTexts) {
   const icons = /* @__PURE__ */ new Set();
   for (const text of jsxTexts) {
@@ -387,6 +471,7 @@ function buildSpec(extractDir, repo, unitFiles) {
   const { tokens, files: tokenFiles } = loadRepoTokens(repo);
   const { resolved, drift } = resolveColors(colors, tokens);
   const declarations = extractDeclarations(sliced);
+  const rawCssText = cssPairs.map(([, text]) => text).join("\n");
   const spec = {
     schema_version: SPEC_SCHEMA_VERSION,
     unit_files: unitFiles,
@@ -398,6 +483,7 @@ function buildSpec(extractDir, repo, unitFiles) {
     icons: extractIcons(jsxPairs.map(([, t]) => t)),
     layout: extractLayout(sliced, classTokens),
     state_styles: extractStateStyles(sliced),
+    interactions: extractInteractions(sliced, rawCssText),
     token_sources: { files: tokenFiles, tokens: tokens.size }
   };
   return { spec, sliceText };
@@ -459,6 +545,7 @@ export {
   collectColorLocations,
   extractDeclarations,
   extractIcons,
+  extractInteractions,
   extractLayout,
   extractStateStyles,
   hexToRgb,

--- a/plugins/code/skills/design-inventory/scripts/dist/extract-visual-spec.mjs
+++ b/plugins/code/skills/design-inventory/scripts/dist/extract-visual-spec.mjs
@@ -50,7 +50,9 @@ function walkFiles(root, opts) {
 
 // src/extract-visual-spec.ts
 var SPEC_SCHEMA_VERSION = 1;
-var CLASS_ATTR = /class(?:Name)?\s*=\s*["'{]([^"'}]*)["'}]?/g;
+var CLASS_ATTR_STRING = /class(?:Name)?\s*=\s*(["'])([^"']*)\1/g;
+var CLASS_ATTR_EXPR = /class(?:Name)?\s*=\s*\{((?:[^{}]|\{[^{}]*\})*)\}/g;
+var STRING_LITERAL = /(["'`])((?:\\.|(?!\1)[^\\])*)\1/g;
 var CLASS_TOKEN = /[A-Za-z_][\w-]*/g;
 var CSS_RULE = /([^{}]+)\{([^{}]*)\}/g;
 var CSS_CLASS_IN_SELECTOR = /\.([A-Za-z_][\w-]*)/g;
@@ -96,24 +98,28 @@ function rgbDistance(a, b) {
     (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2
   );
 }
+function addClassTokens(value, tokens) {
+  const tokenRe = new RegExp(CLASS_TOKEN.source, "g");
+  let tokenMatch;
+  while ((tokenMatch = tokenRe.exec(value)) !== null) {
+    tokens.add(tokenMatch[0]);
+  }
+}
 function collectClassTokens(jsxText) {
   const tokens = /* @__PURE__ */ new Set();
-  let attrMatch;
-  const attrRe = new RegExp(CLASS_ATTR.source, "g");
-  while ((attrMatch = attrRe.exec(jsxText)) !== null) {
-    const attr = attrMatch[1] ?? "";
-    const tokenRe = new RegExp(CLASS_TOKEN.source, "g");
-    let tokenMatch;
-    while ((tokenMatch = tokenRe.exec(attr)) !== null) {
-      tokens.add(tokenMatch[0]);
-    }
+  const stringAttrRe = new RegExp(CLASS_ATTR_STRING.source, "g");
+  let stringMatch;
+  while ((stringMatch = stringAttrRe.exec(jsxText)) !== null) {
+    addClassTokens(stringMatch[2] ?? "", tokens);
   }
-  const fragmentRe = /["'`]([^"'`]*)["'`]/g;
-  let fragMatch;
-  while ((fragMatch = fragmentRe.exec(jsxText)) !== null) {
-    const fragment = fragMatch[1] ?? "";
-    if (!fragment.includes(" ") && new RegExp(`^${CLASS_TOKEN.source}$`).test(fragment) && fragment.includes("-")) {
-      tokens.add(fragment);
+  const exprAttrRe = new RegExp(CLASS_ATTR_EXPR.source, "g");
+  let exprMatch;
+  while ((exprMatch = exprAttrRe.exec(jsxText)) !== null) {
+    const body = exprMatch[1] ?? "";
+    const literalRe = new RegExp(STRING_LITERAL.source, "g");
+    let literalMatch;
+    while ((literalMatch = literalRe.exec(body)) !== null) {
+      addClassTokens(literalMatch[2] ?? "", tokens);
     }
   }
   return tokens;

--- a/tools/design-inventory/src/build-design-pack.test.ts
+++ b/tools/design-inventory/src/build-design-pack.test.ts
@@ -91,6 +91,18 @@ describe("build-design-pack", () => {
       icons: ["hand"],
       layout: { sticky: 1, flex: 2, utility_classes: ["sticky"] },
       state_styles: { hover: [".x:hover"] },
+      interactions: {
+        state_rules: [
+          { pseudo: "hover", selector: ".x:hover", declarations: "background: var(--card)" },
+        ],
+        transitions: [
+          { selector: ".y", declaration: "transition: transform .2s ease" },
+        ],
+        keyframes: [
+          { name: "flash", body: "from { opacity: 0; } to { opacity: 1; }" },
+        ],
+        truncated: false,
+      },
       spacing: { padding: ["8px 14px"] },
       typography: { "font-size": ["12px"] },
     };
@@ -125,6 +137,31 @@ describe("build-design-pack", () => {
     expect(uiBody).toContain("`--destructive` (d=1.0)");
     expect(uiBody).toContain("Design-system ticket required: build `ArtifactTopbar`");
     expect(uiBody).toContain("Icons (lucide names): hand");
+    // Interaction CSS is rendered verbatim, not reduced to a selector count.
+    expect(uiBody).toContain("## Interaction and State Styles");
+    expect(uiBody).toContain(".x:hover { background: var(--card) }");
+    expect(uiBody).toContain("transition: transform .2s ease");
+    expect(uiBody).toContain("@keyframes flash { from { opacity: 0; } to { opacity: 1; } }");
+    // The old bare count line is gone.
+    expect(uiBody).not.toContain("State styles present:");
+    expect(uiBody).not.toContain("(1 selectors)");
+  });
+
+  it("omits the interaction section when the spec has no interactions", () => {
+    const tmpPath = mkdtempSync(join(tmpdir(), "bdp-no-int-"));
+    const visual: JsonObject = {
+      colors: { resolved: [], drift: [] },
+      icons: [],
+      layout: { sticky: 0, flex: 0, utility_classes: [] },
+      state_styles: {},
+      interactions: { state_rules: [], transitions: [], keyframes: [], truncated: false },
+      spacing: {},
+      typography: {},
+    };
+    const { rc, pack } = runPack(tmpPath, validDecisions(), visual);
+    expect(rc).toBe(0);
+    const uiBody = readFileSync(join(pack, "ticket-body-ui.md"), "utf-8");
+    expect(uiBody).not.toContain("## Interaction and State Styles");
   });
 
   it("edited decision overrides summary", () => {

--- a/tools/design-inventory/src/build-design-pack.ts
+++ b/tools/design-inventory/src/build-design-pack.ts
@@ -138,6 +138,80 @@ function renderReuseLine(reuse: JsonObject): string {
   return String(reuse["resolution"] ?? "");
 }
 
+/**
+ * Render the "## Interaction and State Styles" section from the visual spec's
+ * `interactions` object: the actual state-style rules (selector + declarations)
+ * grouped by pseudo, then a "Transitions and animations" subsection listing the
+ * transition/animation declarations and any referenced @keyframes bodies.
+ *
+ * Uses bullets and fenced CSS (NEVER numbered lists). Returns [] when there are
+ * no interactions so the caller omits the header entirely. When the capture was
+ * truncated upstream, a note says so.
+ */
+function renderInteractions(visual: JsonObject): string[] {
+  const interactions = (visual["interactions"] as JsonObject | undefined) ?? {};
+  const stateRules = Array.isArray(interactions["state_rules"])
+    ? (interactions["state_rules"] as JsonObject[])
+    : [];
+  const transitions = Array.isArray(interactions["transitions"])
+    ? (interactions["transitions"] as JsonObject[])
+    : [];
+  const keyframes = Array.isArray(interactions["keyframes"])
+    ? (interactions["keyframes"] as JsonObject[])
+    : [];
+  if (stateRules.length === 0 && transitions.length === 0 && keyframes.length === 0) {
+    return [];
+  }
+
+  const lines: string[] = [
+    "## Interaction and State Styles",
+    "",
+    "Mirror this interaction behavior from the design. Resolve raw color and spacing " +
+    "values to the tokens in the Visual Spec above.",
+    "",
+  ];
+
+  if (stateRules.length > 0) {
+    const byPseudo = new Map<string, JsonObject[]>();
+    for (const rule of stateRules) {
+      const pseudo = String(rule["pseudo"]);
+      let bucket = byPseudo.get(pseudo);
+      if (!bucket) {
+        bucket = [];
+        byPseudo.set(pseudo, bucket);
+      }
+      bucket.push(rule);
+    }
+    lines.push("State styles (what each state does):", "");
+    for (const [pseudo, rulesForPseudo] of [...byPseudo.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+      lines.push(`- \`:${pseudo}\``);
+      for (const rule of rulesForPseudo) {
+        lines.push("", "  ```css", `  ${String(rule["selector"])} { ${String(rule["declarations"])} }`, "  ```");
+      }
+      lines.push("");
+    }
+  }
+
+  if (transitions.length > 0 || keyframes.length > 0) {
+    lines.push("Transitions and animations:", "");
+    for (const entry of transitions) {
+      lines.push(`- \`${String(entry["selector"])}\` -> \`${String(entry["declaration"])}\``);
+    }
+    if (transitions.length > 0) {
+      lines.push("");
+    }
+    for (const frame of keyframes) {
+      lines.push(`- \`@keyframes ${String(frame["name"])}\``, "", "  ```css", `  @keyframes ${String(frame["name"])} { ${String(frame["body"])} }`, "  ```", "");
+    }
+  }
+
+  if (interactions["truncated"] === true) {
+    lines.push("_(interaction capture truncated to stay within the ticket budget)_", "");
+  }
+
+  return lines;
+}
+
 function renderVisualSpec(visual: JsonObject): string[] {
   const lines: string[] = ["## Visual Spec (token-resolved)", ""];
   const colors = (visual["colors"] as JsonObject | undefined) ?? {};
@@ -189,15 +263,6 @@ function renderVisualSpec(visual: JsonObject): string[] {
   if (utility.length > 0) {
     lines.push(`Utility classes in design: ${utility.join(" ")}`);
   }
-  const states = (visual["state_styles"] as JsonObject | undefined) ?? {};
-  if (Object.keys(states).length > 0) {
-    lines.push(
-      "State styles present: " +
-      Object.entries(states)
-        .map(([k, v]) => `${k} (${Array.isArray(v) ? v.length : 0} selectors)`)
-        .join(", ")
-    );
-  }
   for (const propGroup of ["spacing", "typography"] as const) {
     const values = (visual[propGroup] as JsonObject | undefined) ?? {};
     if (Object.keys(values).length > 0) {
@@ -210,6 +275,7 @@ function renderVisualSpec(visual: JsonObject): string[] {
     }
   }
   lines.push("");
+  lines.push(...renderInteractions(visual));
   return lines;
 }
 

--- a/tools/design-inventory/src/extract-visual-spec.test.ts
+++ b/tools/design-inventory/src/extract-visual-spec.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildSpec,
   collectClassTokens,
+  extractInteractions,
   hexToRgb,
   main,
   normalizeColor,
@@ -184,6 +185,84 @@ describe("TestSpec", () => {
     expect(spec.spacing["border-radius"]).toContain("999px");
     expect(spec.typography["font-size"]).toContain("12px");
     expect((spec.spacing["margin"] ?? []).includes("40px")).toBe(false); // unrelated rule sliced away
+  });
+});
+
+const INTERACTIONS_JSX = `
+function Anim() {
+  return (
+    <div className="x y z">interactive</div>
+  );
+}
+`;
+
+const INTERACTIONS_CSS = `
+.x:hover { background: var(--card); }
+.y { transition: transform .2s ease; }
+.z { animation: flash 1.1s; }
+@keyframes flash { from { opacity: 0; } to { opacity: 1; } }
+.unused { color: red; }
+@keyframes unused-spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }
+`;
+
+function interactionsSpecFor(tmpPath: string): ReturnType<typeof buildSpec>["spec"] {
+  const extractDir = join(tmpPath, "extracted");
+  mkdirSync(join(extractDir, "ui_kits/app"), { recursive: true });
+  writeFileSync(join(extractDir, "ui_kits/app/Anim.jsx"), INTERACTIONS_JSX, "utf-8");
+  writeFileSync(join(extractDir, "ui_kits/app/anim.css"), INTERACTIONS_CSS, "utf-8");
+  const repo = join(tmpPath, "repo");
+  mkdirSync(repo, { recursive: true });
+  const { spec } = buildSpec(extractDir, repo, ["ui_kits/app/Anim.jsx"]);
+  return spec;
+}
+
+describe("TestInteractions", () => {
+  it("captures state rule declarations, not just selectors", () => {
+    const tmpPath = mkdtempSync(join(tmpdir(), "evs-int-"));
+    const spec = interactionsSpecFor(tmpPath);
+    const hoverRule = spec.interactions.state_rules.find((r) => r.selector === ".x:hover");
+    expect(hoverRule).toBeDefined();
+    expect(hoverRule?.pseudo).toBe("hover");
+    expect(hoverRule?.declarations).toContain("background: var(--card)");
+  });
+
+  it("captures transition declarations with their selector", () => {
+    const tmpPath = mkdtempSync(join(tmpdir(), "evs-int-"));
+    const spec = interactionsSpecFor(tmpPath);
+    const transition = spec.interactions.transitions.find((t) => t.selector === ".y");
+    expect(transition).toBeDefined();
+    expect(transition?.declaration).toBe("transition: transform .2s ease");
+    // The animation shorthand on .z is also captured as a transition/animation decl.
+    expect(spec.interactions.transitions.some((t) => t.declaration.startsWith("animation:"))).toBe(true);
+  });
+
+  it("captures a referenced @keyframes body and skips unreferenced ones", () => {
+    const tmpPath = mkdtempSync(join(tmpdir(), "evs-int-"));
+    const spec = interactionsSpecFor(tmpPath);
+    const flash = spec.interactions.keyframes.find((k) => k.name === "flash");
+    expect(flash).toBeDefined();
+    expect(flash?.body).toContain("opacity: 0");
+    expect(flash?.body).toContain("opacity: 1");
+    // unused-spin is not referenced by any animation declaration in the slice.
+    expect(spec.interactions.keyframes.some((k) => k.name === "unused-spin")).toBe(false);
+  });
+
+  it("flags truncation when the rule cap is exceeded", () => {
+    const rules: Array<[string, string]> = [];
+    for (let i = 0; i < 60; i++) {
+      rules.push([`.r${i}:hover`, `color: #${(i % 9) + 1}${(i % 9) + 1}${(i % 9) + 1}`]);
+    }
+    const interactions = extractInteractions(rules, "");
+    expect(interactions.truncated).toBe(true);
+    expect(interactions.state_rules.length).toBeLessThanOrEqual(40);
+  });
+
+  it("empty when the slice has no interaction CSS", () => {
+    const interactions = extractInteractions([[".plain", "color: red"]], "");
+    expect(interactions.state_rules).toEqual([]);
+    expect(interactions.transitions).toEqual([]);
+    expect(interactions.keyframes).toEqual([]);
+    expect(interactions.truncated).toBe(false);
   });
 });
 

--- a/tools/design-inventory/src/extract-visual-spec.test.ts
+++ b/tools/design-inventory/src/extract-visual-spec.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildSpec,
+  collectClassTokens,
   hexToRgb,
   main,
   normalizeColor,
@@ -81,6 +82,32 @@ describe("TestNormalization", () => {
   });
 });
 
+describe("TestCollectClassTokens", () => {
+  it("plain_string_classname_tokens", () => {
+    const tokens = collectClassTokens('<div className="sess-topbar sticky flex" />');
+    expect(tokens.has("sess-topbar")).toBe(true);
+    expect(tokens.has("sticky")).toBe(true);
+    expect(tokens.has("flex")).toBe(true);
+  });
+
+  it("expression_conditional_classname_tokens", () => {
+    // Regression: the conditional modifier pattern. The old extractor stopped the
+    // attribute capture at the first quote inside {...} and dropped these tokens,
+    // so rules like .st-msg.left were sliced away from every ticket.
+    const jsx = '<div className={"st-msg " + (x ? "left st-hasav" : "right")}>hi</div>';
+    const tokens = collectClassTokens(jsx);
+    expect(tokens.has("st-msg")).toBe(true);
+    expect(tokens.has("left")).toBe(true);
+    expect(tokens.has("right")).toBe(true);
+    expect(tokens.has("st-hasav")).toBe(true);
+  });
+
+  it("expression_without_string_literals_yields_nothing", () => {
+    const tokens = collectClassTokens("<div className={styles.foo} />");
+    expect(tokens.size).toBe(0);
+  });
+});
+
 describe("TestCssSlice", () => {
   it("slice_keeps_only_used_classes_and_roots", () => {
     const rules = sliceCss(UNIT_CSS, new Set(["sess-topbar", "sess-awaiting-chip", "pin-btn"]));
@@ -90,6 +117,25 @@ describe("TestCssSlice", () => {
     expect(selectors.every((s) => !s.includes("unrelated-class"))).toBe(true);
     // media-query inner rule survives flattening
     expect(selectors.filter((s) => s === ".sess-topbar").length).toBe(2);
+  });
+
+  it("expression_classname_keeps_conditional_modifier_rules", () => {
+    // End-to-end: tokens mined from an expression className must let sliceCss keep
+    // the base rule and all compound modifier rules. Without the extraction fix
+    // these four rules were dropped from every slice (and thus every ticket).
+    const jsx = '<div className={"st-msg " + (x ? "left st-hasav" : "right")}>hi</div>';
+    const css =
+      ".st-msg{display:flex}" +
+      ".st-msg.left{justify-content:flex-start}" +
+      ".st-msg.right{justify-content:flex-end}" +
+      ".st-msg.st-hasav{gap:8px}";
+    const tokens = collectClassTokens(jsx);
+    const selectors = sliceCss(css, tokens).map(([s]) => s);
+    expect(selectors).toContain(".st-msg");
+    expect(selectors).toContain(".st-msg.left");
+    expect(selectors).toContain(".st-msg.right");
+    expect(selectors).toContain(".st-msg.st-hasav");
+    expect(selectors.length).toBe(4);
   });
 });
 

--- a/tools/design-inventory/src/extract-visual-spec.ts
+++ b/tools/design-inventory/src/extract-visual-spec.ts
@@ -33,7 +33,16 @@ import { walkFiles } from "./fs-walk.js";
 
 export const SPEC_SCHEMA_VERSION = 1;
 
-const CLASS_ATTR = /class(?:Name)?\s*=\s*["'{]([^"'}]*)["'}]?/g;
+// Plain string-literal classNames: className="a b" or className='a b'.
+const CLASS_ATTR_STRING = /class(?:Name)?\s*=\s*(["'])([^"']*)\1/g;
+// Expression classNames: className={ ...anything... }. Captures the full brace
+// body so we can mine every quoted string literal inside (the conditional
+// modifier pattern, e.g. {"st-msg " + (cond ? "left st-hasav" : "right")}).
+// Allows one level of nested braces (template-literal interpolations, nested
+// objects) which covers the common cases.
+const CLASS_ATTR_EXPR = /class(?:Name)?\s*=\s*\{((?:[^{}]|\{[^{}]*\})*)\}/g;
+// Quoted string literals inside an expression value (single, double, backtick).
+const STRING_LITERAL = /(["'`])((?:\\.|(?!\1)[^\\])*)\1/g;
 const CLASS_TOKEN = /[A-Za-z_][\w-]*/g;
 const CSS_RULE = /([^{}]+)\{([^{}]*)\}/g;
 const CSS_CLASS_IN_SELECTOR = /\.([A-Za-z_][\w-]*)/g;
@@ -131,27 +140,46 @@ function rgbDistance(a: [number, number, number], b: [number, number, number]): 
   );
 }
 
+function addClassTokens(value: string, tokens: Set<string>): void {
+  const tokenRe = new RegExp(CLASS_TOKEN.source, "g");
+  let tokenMatch: RegExpExecArray | null;
+  while ((tokenMatch = tokenRe.exec(value)) !== null) {
+    tokens.add(tokenMatch[0]);
+  }
+}
+
 export function collectClassTokens(jsxText: string): Set<string> {
   const tokens = new Set<string>();
-  let attrMatch: RegExpExecArray | null;
-  const attrRe = new RegExp(CLASS_ATTR.source, "g");
-  while ((attrMatch = attrRe.exec(jsxText)) !== null) {
-    const attr = attrMatch[1] ?? "";
-    const tokenRe = new RegExp(CLASS_TOKEN.source, "g");
-    let tokenMatch: RegExpExecArray | null;
-    while ((tokenMatch = tokenRe.exec(attr)) !== null) {
-      tokens.add(tokenMatch[0]);
+
+  // Plain string-literal classNames: className="a b" / className='a b'.
+  // The whole attribute value is class tokens; split on whitespace via CLASS_TOKEN.
+  const stringAttrRe = new RegExp(CLASS_ATTR_STRING.source, "g");
+  let stringMatch: RegExpExecArray | null;
+  while ((stringMatch = stringAttrRe.exec(jsxText)) !== null) {
+    addClassTokens(stringMatch[2] ?? "", tokens);
+  }
+
+  // Expression classNames: className={...}. Mine every quoted string literal
+  // inside the expression body and tokenize each as class tokens. This recovers
+  // the conditional modifier pattern, e.g.
+  //   className={"st-msg " + (cond ? "left st-hasav" : "right")}
+  // where the literals "st-msg ", "left st-hasav", and "right" all contribute
+  // class tokens. Over-inclusion (a stray non-class word from a text literal) is
+  // harmless for slicing: no CSS rule will match it. Under-inclusion drops real
+  // rules, so we bias to inclusion.
+  const exprAttrRe = new RegExp(CLASS_ATTR_EXPR.source, "g");
+  let exprMatch: RegExpExecArray | null;
+  while ((exprMatch = exprAttrRe.exec(jsxText)) !== null) {
+    const body = exprMatch[1] ?? "";
+    // String literals contribute static class names; expressions without any
+    // (e.g. className={styles.foo} or className={cls}) yield nothing to recover.
+    const literalRe = new RegExp(STRING_LITERAL.source, "g");
+    let literalMatch: RegExpExecArray | null;
+    while ((literalMatch = literalRe.exec(body)) !== null) {
+      addClassTokens(literalMatch[2] ?? "", tokens);
     }
   }
-  // Template-literal classes: best effort, pick string fragments too.
-  const fragmentRe = /["'`]([^"'`]*)["'`]/g;
-  let fragMatch: RegExpExecArray | null;
-  while ((fragMatch = fragmentRe.exec(jsxText)) !== null) {
-    const fragment = fragMatch[1] ?? "";
-    if (!fragment.includes(" ") && new RegExp(`^${CLASS_TOKEN.source}$`).test(fragment) && fragment.includes("-")) {
-      tokens.add(fragment);
-    }
-  }
+
   return tokens;
 }
 

--- a/tools/design-inventory/src/extract-visual-spec.ts
+++ b/tools/design-inventory/src/extract-visual-spec.ts
@@ -64,6 +64,21 @@ const LAYOUT_CLASS_HINTS = /^(?:sticky|fixed|absolute|relative|flex|grid|overflo
 const MAX_LIST = 40;
 const MAX_LOCATIONS = 5;
 
+// Interaction-capture bounds: the actual interaction CSS (state-style rule
+// bodies, transition/animation declarations, referenced @keyframes) is inlined
+// into the ticket body, so it must stay bounded. Cap both the number of rules
+// and the total text recorded; when either is hit, keep the first N and flag
+// truncation so the renderer can say so.
+const MAX_INTERACTION_RULES = 40;
+const MAX_INTERACTION_CHARS = 8192;
+// Animation/transition properties whose values we surface verbatim. Matched by
+// prefix so the shorthand and every longhand (transition-property,
+// animation-name, ...) are captured.
+const ANIMATION_PROP_PREFIXES = ["transition", "animation"] as const;
+// @keyframes NAME { ... }; the body capture allows nested {} (the from/to or
+// percentage frames each carry their own brace block).
+const KEYFRAMES_RULE = /@(?:-\w+-)?keyframes\s+([\w-]+)\s*\{((?:[^{}]|\{[^{}]*\})*)\}/g;
+
 export interface ColorEntry {
   value: string;
   count: number;
@@ -77,6 +92,29 @@ export interface ResolvedColor extends ColorEntry {
 export interface DriftColor extends ColorEntry {
   nearest_token?: string;
   distance?: number;
+}
+
+export interface StateRule {
+  pseudo: string;
+  selector: string;
+  declarations: string;
+}
+
+export interface TransitionEntry {
+  selector: string;
+  declaration: string;
+}
+
+export interface KeyframesEntry {
+  name: string;
+  body: string;
+}
+
+export interface Interactions {
+  state_rules: StateRule[];
+  transitions: TransitionEntry[];
+  keyframes: KeyframesEntry[];
+  truncated: boolean;
 }
 
 export interface VisualSpec {
@@ -100,6 +138,7 @@ export interface VisualSpec {
     utility_classes: string[];
   };
   state_styles: Record<string, string[]>;
+  interactions: Interactions;
   token_sources: {
     files: string[];
     tokens: number;
@@ -396,6 +435,117 @@ export function extractStateStyles(rules: Array<[string, string]>): Record<strin
   return states;
 }
 
+function pseudoOf(selector: string): string | null {
+  for (const pseudo of STATE_PSEUDOS) {
+    if (selector.includes(`:${pseudo}`)) {
+      return pseudo;
+    }
+  }
+  return null;
+}
+
+/**
+ * Collect the animation-name(s) a transition/animation declaration references so
+ * the matching @keyframes block can be surfaced. The `animation` shorthand puts
+ * the name among other tokens (duration, timing, etc.); we take every identifier
+ * token as a candidate and let the @keyframes name lookup filter out the ones
+ * (durations, timing keywords) that match no defined keyframes block.
+ */
+function animationNamesFrom(prop: string, value: string): string[] {
+  if (prop !== "animation" && prop !== "animation-name") {
+    return [];
+  }
+  const names: string[] = [];
+  const tokenRe = new RegExp(CLASS_TOKEN.source, "g");
+  let tokenMatch: RegExpExecArray | null;
+  while ((tokenMatch = tokenRe.exec(value)) !== null) {
+    names.push(tokenMatch[0]);
+  }
+  return names;
+}
+
+/**
+ * Capture the actual interaction CSS the designer expressed -- not just that a
+ * state exists but what it does:
+ *
+ * - state_rules: every sliced rule whose selector carries a state pseudo
+ *   (:hover/:focus/:focus-visible/:active/:disabled), with its declaration block.
+ * - transitions: every `transition`/`animation` declaration (shorthand or
+ *   longhand) in the slice, paired with its selector.
+ * - keyframes: each @keyframes block in the slice that is referenced by an
+ *   `animation`/`animation-name` declaration, with its full body.
+ *
+ * Bounded by MAX_INTERACTION_RULES and MAX_INTERACTION_CHARS across the combined
+ * captured text; on overflow the first entries are kept and `truncated` is set.
+ */
+export function extractInteractions(
+  rules: Array<[string, string]>,
+  rawCssText: string
+): Interactions {
+  const stateRules: StateRule[] = [];
+  const transitions: TransitionEntry[] = [];
+  const referencedKeyframes = new Set<string>();
+  let charBudget = MAX_INTERACTION_CHARS;
+  let truncated = false;
+
+  const tryAdd = (cost: number): boolean => {
+    const total = stateRules.length + transitions.length;
+    if (total >= MAX_INTERACTION_RULES || cost > charBudget) {
+      truncated = true;
+      return false;
+    }
+    charBudget -= cost;
+    return true;
+  };
+
+  for (const [selector, body] of rules) {
+    const pseudo = pseudoOf(selector);
+    if (pseudo !== null) {
+      const declarations = body.trim();
+      if (tryAdd(selector.length + declarations.length)) {
+        stateRules.push({ pseudo, selector, declarations });
+      }
+    }
+    const declRe = new RegExp(CSS_DECL.source, "g");
+    let declMatch: RegExpExecArray | null;
+    while ((declMatch = declRe.exec(body)) !== null) {
+      const prop = (declMatch[1] ?? "").toLowerCase();
+      const value = (declMatch[2] ?? "").trim();
+      const isAnimation = ANIMATION_PROP_PREFIXES.some((p) => prop === p || prop.startsWith(`${p}-`));
+      if (!isAnimation) {
+        continue;
+      }
+      const declaration = `${prop}: ${value}`;
+      if (tryAdd(selector.length + declaration.length)) {
+        transitions.push({ selector, declaration });
+      }
+      for (const name of animationNamesFrom(prop, value)) {
+        referencedKeyframes.add(name);
+      }
+    }
+  }
+
+  const keyframes: KeyframesEntry[] = [];
+  if (referencedKeyframes.size > 0) {
+    const keyframesRe = new RegExp(KEYFRAMES_RULE.source, "g");
+    let kfMatch: RegExpExecArray | null;
+    const seen = new Set<string>();
+    while ((kfMatch = keyframesRe.exec(rawCssText)) !== null) {
+      const name = kfMatch[1] ?? "";
+      const body = (kfMatch[2] ?? "").trim();
+      if (!referencedKeyframes.has(name) || seen.has(name)) {
+        continue;
+      }
+      seen.add(name);
+      if (tryAdd(name.length + body.length)) {
+        keyframes.push({ name, body });
+      }
+    }
+  }
+
+  return { state_rules: stateRules, transitions, keyframes, truncated };
+}
+
 export function extractIcons(jsxTexts: string[]): string[] {
   const icons = new Set<string>();
   for (const text of jsxTexts) {
@@ -471,6 +621,10 @@ export function buildSpec(
   const { tokens, files: tokenFiles } = loadRepoTokens(repo);
   const { resolved, drift } = resolveColors(colors, tokens);
   const declarations = extractDeclarations(sliced);
+  // Keyframes blocks are not in the sliced rules (selectors starting with "@"
+  // are skipped by sliceCss), so resolve referenced @keyframes against the raw
+  // CSS text of the unit's stylesheets.
+  const rawCssText = cssPairs.map(([, text]) => text).join("\n");
 
   const spec: VisualSpec = {
     schema_version: SPEC_SCHEMA_VERSION,
@@ -483,6 +637,7 @@ export function buildSpec(
     icons: extractIcons(jsxPairs.map(([, t]) => t)),
     layout: extractLayout(sliced, classTokens),
     state_styles: extractStateStyles(sliced),
+    interactions: extractInteractions(sliced, rawCssText),
     token_sources: { files: tokenFiles, tokens: tokens.size },
   };
   return { spec, sliceText };


### PR DESCRIPTION
## The bug

The design-inventory CSS slicer (`tools/design-inventory/src/extract-visual-spec.ts`, `collectClassTokens`) dropped real style rules whose selector classes appear **only** inside JSX expression classNames. This is the very common conditional modifier pattern:

```jsx
className={"st-msg " + (cond ? "left st-hasav" : "right")}
```

Confirmed real example: `.st-msg`, `.st-msg.left`, `.st-msg.right`, and `.st-msg.st-hasav` existed in the design source but were sliced out of every slice.

## Root cause

Two compounding faults in `collectClassTokens`:

1. **`CLASS_ATTR` treated `{` as an opening string delimiter** (`/class(?:Name)?\s*=\s*["'{]([^"'}]*)["'}]?/g`). For `className={"st-msg " + ...}` the value capture stopped at the first inner quote and was **empty**, so no class tokens were extracted.
2. **The template-literal fragment fallback over-filtered**: `if (!fragment.includes(" ") && /^CLASS_TOKEN$/.test(fragment) && fragment.includes("-"))`. It dropped any fragment containing a space (`"st-msg "`, `"left st-hasav"`) and any without a hyphen (`"right"`, `"left"`, `"open"`, `"err"`), discarding valid classes.

## Why it propagated to every ticket

`build-design-pack` attaches the CSS slice to **every generated ticket**, so any rule lost from the slice is lost from all tickets derived from that design.

## The fix

Rewrote the extraction to handle both className forms:

- **Plain string classNames** (`className="a b"`): tokenize the whole attribute value.
- **Expression classNames** (`className={...}`): capture the full brace body (allowing one level of nested braces) and mine **every quoted string literal** inside it, tokenizing each as class tokens.

Dropped the space-gate and hyphen-gate entirely. Tokenization already splits on spaces, and short hyphenless utility classes (`left`, `right`, `open`, `err`) are valid. Biased to inclusion: over-inclusion is harmless for slicing (no CSS rule matches a stray word from a text literal) while under-inclusion (the original bug) drops real rules.

`sliceCss`'s compound-selector handling is unchanged; it already keeps `.st-msg.left` when either class is in the token set.

## Tests

Added regression coverage in `extract-visual-spec.test.ts`:

- `collectClassTokens` on `className={"st-msg " + (x ? "left st-hasav" : "right")}` asserts the set contains `st-msg`, `left`, `right`, `st-hasav`.
- An expression className with no string literals (`className={styles.foo}`) yields no tokens.
- Plain string className tokenization still works.
- End-to-end: given that JSX plus CSS with `.st-msg{...}` `.st-msg.left{...}` `.st-msg.right{...}` `.st-msg.st-hasav{...}`, `sliceCss` keeps all four rules.

All existing tests stay green. No existing test encoded the old buggy behavior, so none needed updating.

## Validation

- `npm ci` (hermetic install from this worktree's `package-lock`).
- `npm test`: 362 passed (was 358; +4 new tests).
- `npm run typecheck`: clean.
- `npm run build`: regenerated dist bundles. Among the dist bundles, **only `extract-visual-spec.mjs` changed** (verified via `git status --short` / `git diff --stat`); no unrelated dist churn and no machine-specific absolute paths in the bundle.
- Bumped `plugins/code/.claude-plugin/plugin.json` version `1.14.1` -> `1.14.2` for the CI Plugin Version Bump check.

---

## Follow-up: render interaction and state CSS into ticket bodies (commit 679a69a)

### The gap

The pipeline detected interaction behavior but flattened it before it reached the ticket. `extractStateStyles` returned `state_styles: Record<string, string[]>` (state pseudo -> selector strings only; no declarations), captured no transitions, animations, or `@keyframes`, and `renderVisualSpec` emitted only a count line (`State styles present: hover (N selectors)`). Scroll, hover, transition, and animation behavior the designer expressed was reduced to a number in the generated ticket.

### The change

- `extract-visual-spec.ts` now captures the actual interaction CSS into a new `interactions` object on the visual spec:
  - `state_rules: Array<{ pseudo, selector, declarations }>` — each sliced rule whose selector carries a state pseudo (`:hover`/`:focus`/`:focus-visible`/`:active`/`:disabled`), with its declaration block.
  - `transitions: Array<{ selector, declaration }>` — every `transition`/`animation` declaration (shorthand or longhand) in the slice, paired with its selector.
  - `keyframes: Array<{ name, body }>` — each `@keyframes` block referenced by an `animation`/`animation-name` declaration in the slice, with its full body (resolved from the raw stylesheet text, since `sliceCss` skips `@`-prefixed selectors).
  - `truncated: boolean` — capture is bounded (40 rules, ~8 KB combined); on overflow the first entries are kept and the flag is set.
  - The existing `state_styles` field is preserved unchanged for backward compatibility (`build-context-pack` still reads it).
- `build-design-pack.ts` `renderVisualSpec` replaces the bare count line with a real `## Interaction and State Styles` section: state-style rules (selector + declarations) grouped by pseudo as fenced CSS, then a "Transitions and animations" subsection listing the transition declarations and any keyframes bodies. Bullets and fenced CSS only (never numbered lists). The section is omitted entirely when the spec has no interactions, and notes truncation when flagged.

### Tests

- `extract-visual-spec.test.ts`: a CSS fixture with `.x:hover{background:var(--card)}`, `.y{transition:transform .2s ease}`, `.z{animation:flash 1.1s}`, and `@keyframes flash{from{...}to{...}}` asserts the hover rule declarations, the transition declaration, and the referenced `flash` keyframes body are captured (and an unreferenced keyframes block is skipped); plus truncation-flag and empty-slice cases.
- `build-design-pack.test.ts`: asserts the rendered UI body contains the `## Interaction and State Styles` section with the hover rule text, the transition, and the keyframes body, and **does not** contain the old `State styles present:` / `(N selectors)` count line; plus a no-interactions case that omits the header. No existing test asserted the old count line, so none needed rewriting.

### Validation

- `npm test`: 368 passed (was 362; +6 new tests). `npm run typecheck`: clean.
- `npm run build`: among the dist bundles, **only `extract-visual-spec.mjs` and `build-design-pack.mjs` changed** (the two sources touched here), verified via `git status --short` / `git diff --stat`; no unrelated dist churn and no machine-specific absolute paths in either bundle.
- Bumped `plugins/code/.claude-plugin/plugin.json` version `1.14.2` -> `1.14.3`.
