### PR TITLE
fix(code): address three inline review comments from PR #159

### DIFF
--- a/tools/design-inventory/src/build-design-pack.test.ts
+++ b/tools/design-inventory/src/build-design-pack.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { main, validateManifestPath } from "./build-design-pack.js";
 import { applyInlineImages } from "./apply-inline-images.js";
-import { validDecisions, validFindings } from "./test-fixtures.js";
+import { validDecisions, validFindings, backendGapFinding } from "./test-fixtures.js";
 import type { JsonObject } from "./design-findings-schema.js";
 
 function makeExtractDir(tmpPath: string): string {
@@ -318,33 +318,6 @@ describe("build-design-pack", () => {
   // Data provenance: data_flow on backend-gap findings drives a data-source ticket
   // -------------------------------------------------------------------------
 
-  /** A backend-gap finding with a data_flow at the given gap layer. */
-  function backendGap(
-    id: string,
-    gapLayer: "capture" | "ingestion" | "model" | "serving" | "unknown",
-  ): JsonObject {
-    const upstreamMissing = gapLayer === "capture" || gapLayer === "ingestion";
-    return {
-      id,
-      title: `Backend gap ${id}`,
-      category: "backend-gap",
-      intent: "likely-intentional",
-      intent_rationale: "backend needed",
-      theme: null,
-      state: { summary: "No endpoint", refs: [] },
-      spec: { summary: "UI reads per-session cost", refs: [] },
-      data_flow: {
-        gap_layer: gapLayer,
-        origin: "apps/desktop agent harness session telemetry",
-        captured_today: !upstreamMissing,
-        ingested_today: !upstreamMissing,
-        refs: ["apps/desktop/src/server/operations/run-session.ts"],
-      },
-      decision: { state: "accepted" },
-      summary: `Capture and serve data for ${id}`,
-    };
-  }
-
   function runPackWithBackendGap(
     tmpPath: string,
     gap: JsonObject,
@@ -368,7 +341,7 @@ describe("build-design-pack", () => {
 
   it("API body contains a Data Provenance section tracing the gap to its origin", () => {
     const tmpPath = mkdtempSync(join(tmpdir(), "bdp-prov-"));
-    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGap("CHG-sessions-page-03", "capture"));
+    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGapFinding("CHG-sessions-page-03", "capture", { decision: { state: "accepted" } }));
     expect(rc).toBe(0);
     const apiBody = readFileSync(join(pack, "ticket-body-api.md"), "utf-8");
     expect(apiBody).toContain("## Data Provenance");
@@ -387,7 +360,7 @@ describe("build-design-pack", () => {
 
   it("API body Data Provenance reports a serving gap as already captured/ingested and adds no BLOCKS note", () => {
     const tmpPath = mkdtempSync(join(tmpdir(), "bdp-provserv-"));
-    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGap("CHG-sessions-page-03", "serving"));
+    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGapFinding("CHG-sessions-page-03", "serving", { decision: { state: "accepted" } }));
     expect(rc).toBe(0);
     const apiBody = readFileSync(join(pack, "ticket-body-api.md"), "utf-8");
     expect(apiBody).toContain("## Data Provenance");
@@ -399,7 +372,7 @@ describe("build-design-pack", () => {
 
   it("ticket-body-data.md is written for a capture-layer gap and names origin and a RELATES note", () => {
     const tmpPath = mkdtempSync(join(tmpdir(), "bdp-data-"));
-    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGap("CHG-sessions-page-03", "capture"));
+    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGapFinding("CHG-sessions-page-03", "capture", { decision: { state: "accepted" } }));
     expect(rc).toBe(0);
     expect(existsSync(join(pack, "ticket-body-data.md"))).toBe(true);
     const dataBody = readFileSync(join(pack, "ticket-body-data.md"), "utf-8");
@@ -428,14 +401,14 @@ describe("build-design-pack", () => {
 
   it("ticket-body-data.md is written for an ingestion-layer gap", () => {
     const tmpPath = mkdtempSync(join(tmpdir(), "bdp-dataing-"));
-    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGap("CHG-sessions-page-03", "ingestion"));
+    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGapFinding("CHG-sessions-page-03", "ingestion", { decision: { state: "accepted" } }));
     expect(rc).toBe(0);
     expect(existsSync(join(pack, "ticket-body-data.md"))).toBe(true);
   });
 
   it("ticket-body-data.md is ABSENT for a serving-only gap (api body still written)", () => {
     const tmpPath = mkdtempSync(join(tmpdir(), "bdp-noserv-"));
-    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGap("CHG-sessions-page-03", "serving"));
+    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGapFinding("CHG-sessions-page-03", "serving", { decision: { state: "accepted" } }));
     expect(rc).toBe(0);
     // The API/serving ticket is still produced...
     expect(existsSync(join(pack, "ticket-body-api.md"))).toBe(true);
@@ -445,7 +418,7 @@ describe("build-design-pack", () => {
 
   it("ticket-body-data.md is ABSENT for a model-only gap", () => {
     const tmpPath = mkdtempSync(join(tmpdir(), "bdp-nomodel-"));
-    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGap("CHG-sessions-page-03", "model"));
+    const { rc, pack } = runPackWithBackendGap(tmpPath, backendGapFinding("CHG-sessions-page-03", "model", { decision: { state: "accepted" } }));
     expect(rc).toBe(0);
     expect(existsSync(join(pack, "ticket-body-data.md"))).toBe(false);
   });
@@ -455,7 +428,7 @@ describe("build-design-pack", () => {
     const outDir = join(tmpPath, "packs");
     const pack = join(outDir, "scr-sessions-page");
     const doc = validFindings();
-    (doc["findings"] as JsonObject[]).push(backendGap("CHG-sessions-page-03", "capture"));
+    (doc["findings"] as JsonObject[]).push(backendGapFinding("CHG-sessions-page-03", "capture", { decision: { state: "accepted" } }));
     const findingsPath = join(tmpPath, "unit.json");
     writeFileSync(findingsPath, JSON.stringify(doc), "utf-8");
     const decisionsPath = join(tmpPath, "decisions.json");

--- a/tools/design-inventory/src/design-findings-schema.ts
+++ b/tools/design-inventory/src/design-findings-schema.ts
@@ -48,7 +48,8 @@ export const FINDING_CATEGORIES = [
  *   serving   - the data exists in the platform DB but no API/endpoint serves it to the UI.
  *   unknown   - the provenance could not be traced.
  * A capture- or ingestion-layer gap means nobody tickets where the data comes
- * from; it becomes a separate data-source ticket that blocks the serving/API ticket.
+ * from; it becomes a separate data-source ticket related to the serving/API ticket
+ * (the layers build in parallel and the UI renders empty states until the data lands).
  */
 export const GAP_LAYERS = ["capture", "ingestion", "model", "serving", "unknown"] as const;
 export const INTENTS = ["likely-intentional", "likely-unintentional", "unclear"] as const;

--- a/tools/design-inventory/src/plan-ticket-graph.test.ts
+++ b/tools/design-inventory/src/plan-ticket-graph.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 
 import { buildTicketGraph, main } from "./plan-ticket-graph.js";
 import type { JsonObject } from "./design-findings-schema.js";
-import { validFindings, validDecisions } from "./test-fixtures.js";
+import { validFindings, validDecisions, backendGapFinding } from "./test-fixtures.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -134,27 +134,6 @@ function makeFinding(
   return finding;
 }
 
-/**
- * A backend-gap finding carrying a data_flow at the given gap layer. capture and
- * ingestion layers drive a separate data-source ticket; serving and model do not.
- */
-function makeBackendGap(
-  id: string,
-  gapLayer: "capture" | "ingestion" | "model" | "serving" | "unknown",
-  decisionState: "accepted" | "declined" | "edited" = "accepted",
-): JsonObject {
-  const upstreamMissing = gapLayer === "capture" || gapLayer === "ingestion";
-  const finding = makeFinding(id, "backend-gap", decisionState);
-  finding["data_flow"] = {
-    gap_layer: gapLayer,
-    origin: "apps/desktop agent harness session telemetry",
-    captured_today: !upstreamMissing,
-    ingested_today: !upstreamMissing,
-    refs: ["apps/desktop/src/server/operations/run-session.ts"],
-  };
-  return finding;
-}
-
 function allAcceptedDecisions(): Record<string, JsonObject> {
   return {};
 }
@@ -260,7 +239,7 @@ describe("buildTicketGraph", () => {
 
   it("backend-gap findings go to API ticket, not UI ticket criteria", () => {
     const visual = makeFinding("CHG-scr-dash-01", "visual");
-    const backend = makeFinding("CHG-scr-dash-02", "backend-gap");
+    const backend = backendGapFinding("CHG-scr-dash-02", "serving", { decision: { state: "accepted" } });
     const doc = screenDoc("scr-dash", "Dashboard", [visual, backend]);
     const plan = buildTicketGraph([doc], allAcceptedDecisions(), ["scr-dash"]);
 
@@ -283,7 +262,7 @@ describe("buildTicketGraph", () => {
   });
 
   it("UI ticket is absent when all accepted findings are backend-gap", () => {
-    const backend = makeFinding("CHG-scr-api-only-01", "backend-gap");
+    const backend = backendGapFinding("CHG-scr-api-only-01", "serving", { decision: { state: "accepted" } });
     const doc = screenDoc("scr-api-only", "ApiOnly", [backend]);
     const plan = buildTicketGraph([doc], allAcceptedDecisions(), ["scr-api-only"]);
 
@@ -295,7 +274,7 @@ describe("buildTicketGraph", () => {
 
   it("API ticket RELATES_TO UI ticket when both exist", () => {
     const visual = makeFinding("CHG-scr-b-01", "visual");
-    const backend = makeBackendGap("CHG-scr-b-02", "serving");
+    const backend = backendGapFinding("CHG-scr-b-02", "serving", { decision: { state: "accepted" } });
     const doc = screenDoc("scr-b", "B", [visual, backend]);
     const plan = buildTicketGraph([doc], allAcceptedDecisions(), ["scr-b"]);
 
@@ -309,7 +288,7 @@ describe("buildTicketGraph", () => {
 
   it("emits a data ticket for a capture-layer backend gap with data->api->ui RELATES_TO edges", () => {
     const visual = makeFinding("CHG-scr-cap-01", "visual");
-    const backend = makeBackendGap("CHG-scr-cap-02", "capture");
+    const backend = backendGapFinding("CHG-scr-cap-02", "capture", { decision: { state: "accepted" } });
     const doc = screenDoc("scr-cap", "Capture Screen", [visual, backend]);
     const plan = buildTicketGraph([doc], allAcceptedDecisions(), ["scr-cap"]);
 
@@ -336,7 +315,7 @@ describe("buildTicketGraph", () => {
   });
 
   it("emits a data ticket for an ingestion-layer backend gap", () => {
-    const backend = makeBackendGap("CHG-scr-ing-01", "ingestion");
+    const backend = backendGapFinding("CHG-scr-ing-01", "ingestion", { decision: { state: "accepted" } });
     const doc = screenDoc("scr-ing", "Ingest Screen", [backend]);
     const plan = buildTicketGraph([doc], allAcceptedDecisions(), ["scr-ing"]);
 
@@ -351,7 +330,7 @@ describe("buildTicketGraph", () => {
   });
 
   it("does NOT emit a data ticket when the only backend gap is serving-layer", () => {
-    const backend = makeBackendGap("CHG-scr-srv-01", "serving");
+    const backend = backendGapFinding("CHG-scr-srv-01", "serving", { decision: { state: "accepted" } });
     const doc = screenDoc("scr-srv", "Serving Screen", [backend]);
     const plan = buildTicketGraph([doc], allAcceptedDecisions(), ["scr-srv"]);
 
@@ -362,7 +341,7 @@ describe("buildTicketGraph", () => {
   });
 
   it("does NOT emit a data ticket when the only backend gap is model-layer", () => {
-    const backend = makeBackendGap("CHG-scr-mdl-01", "model");
+    const backend = backendGapFinding("CHG-scr-mdl-01", "model", { decision: { state: "accepted" } });
     const doc = screenDoc("scr-mdl", "Model Screen", [backend]);
     const plan = buildTicketGraph([doc], allAcceptedDecisions(), ["scr-mdl"]);
 
@@ -370,8 +349,8 @@ describe("buildTicketGraph", () => {
   });
 
   it("emits a data ticket once when capture and serving gaps coexist in one unit", () => {
-    const capture = makeBackendGap("CHG-scr-mix-01", "capture");
-    const serving = makeBackendGap("CHG-scr-mix-02", "serving");
+    const capture = backendGapFinding("CHG-scr-mix-01", "capture", { decision: { state: "accepted" } });
+    const serving = backendGapFinding("CHG-scr-mix-02", "serving", { decision: { state: "accepted" } });
     const doc = screenDoc("scr-mix", "Mixed Screen", [capture, serving]);
     const plan = buildTicketGraph([doc], allAcceptedDecisions(), ["scr-mix"]);
 


### PR DESCRIPTION
## Summary

Addresses the three inline review comments left by thadeusb on the now-merged PR #159:

- **Stale BLOCKS docstring in `design-findings-schema.ts`** (line 51): the `GAP_LAYERS` JSDoc said a capture/ingestion data-source ticket "blocks the serving/API ticket", contradicting the PR's RELATES_TO model. Updated to: "it becomes a separate data-source ticket related to the serving/API ticket (the layers build in parallel and the UI renders empty states until the data lands)."

- **Schema-invalid backend-gap fixtures in `plan-ticket-graph.test.ts`**: two calls to `makeFinding("CHG-...", "backend-gap")` produced backend-gap findings missing the now-required `data_flow` block. Replaced with `backendGapFinding("CHG-...", "serving", { decision: { state: "accepted" } })` from the shared factory, making both fixtures schema-valid.

- **Consolidate three duplicate backend-gap factories into `test-fixtures.ts`**: deleted `makeBackendGap` from `plan-ticket-graph.test.ts` (7 call sites migrated) and `backendGap` from `build-design-pack.test.ts` (7 call sites migrated). All call sites now use the canonical `backendGapFinding(id, gapLayer, overrides?)` from `test-fixtures.ts`. Decision state differences handled via the existing `overrides` parameter.

## Test plan

- [ ] `npm test` in `tools/design-inventory` passes (393 tests, count unchanged)
- [ ] `npm run typecheck` clean
- [ ] `npm run build` then `git status --short` shows zero `plugins/**` changes (comment edits and test files are not bundled by esbuild)