### PR TITLE
fix(code-review): collect fast-path reviewer synchronously in headless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code-review v2.34.1
+
+#### Fixed
+- GitHub-mode code review (`/code-review:shallow --github <pr>`) no longer exits before producing any review artifacts on the fast path. On small PRs the orchestrator routes to a single fast-path reviewer; it previously launched that reviewer as a background task and then ended its turn to wait for it, but under headless `claude -p` there is no asynchronous subagent-completion notification, so the run terminated (`terminal_reason: "completed"`) before the collect, validate, verify, finalize, and output stages executed, leaving the PR with an empty fallback summary and no `.closedloop-ai/code-review-*` artifacts. The `spawn-reviewers` skill now spawns and collects the single fast-path reviewer synchronously and documents the headless-mode constraint for both the fast path and the standard reviewer fleet, so the orchestrator never ends its turn while a reviewer is still running.
+
 ### code v1.14.7
 
 #### Changed

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "2.34.0",
+  "version": "2.34.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/skills/spawn-reviewers/SKILL.md
+++ b/plugins/code-review/skills/spawn-reviewers/SKILL.md
@@ -352,7 +352,7 @@ graph tools when GRAPH_PROJECT is non-empty. Do NOT use Bash.
 
 **Write-denied fallback:** If an agent's Write tool is denied (restrictive project permissions), the agent outputs findings in `<findings_json>` tags in its response with `DONE findings=N file=WRITE_DENIED`. When collecting, if a response contains `WRITE_DENIED`, extract the JSON from `<findings_json>` tags and write it to `<CR_DIR>/agent_{AGENT_ID}.json` yourself.
 
-**Collect all agents (MANDATORY):** Call `TaskOutput` (block: true) for every spawned agent. You MUST collect ALL agents before the walker proceeds past `stage_20`. Do NOT read disk files or start validation until every `TaskOutput` call has returned.
+**Collect all agents (MANDATORY):** Call `TaskOutput` (block: true) for every spawned agent. You MUST collect ALL agents before the walker proceeds past `stage_20`. Do NOT read disk files or start validation until every `TaskOutput` call has returned. In headless GitHub mode there is no asynchronous completion notification, so ending your turn to "wait" for a backgrounded agent terminates the run before stages 21 through 30 (see the "Headless mode warning" in the Fast Path section); the blocking `TaskOutput` calls are what keep the turn alive.
 
 Call all `TaskOutput` calls in a **single message** (parallel) so they resolve together. Check each response:
 1. `DONE findings=N file=...` (not WRITE_DENIED) — output file is on disk, nothing to do.
@@ -380,7 +380,7 @@ The fast-path spawns a single agent that performs all review passes in one run. 
 **Fast-Path Agent settings:**
 - `subagent_type`: `"code-review:code-review-worker-graph"` (the fast-path agent runs a BHB cross-file pass, so it gets the graph-aware worker; pass the resolved `GRAPH_PROJECT` into its prompt)
 - `model`: from `spawn.json.route -> models.fast_path_reviewer` (NOT hardcoded)
-- `run_in_background`: `true`
+- `run_in_background`: `false` (spawn the single fast-path agent SYNCHRONOUSLY; backgrounding one agent buys no parallelism and is fatal in headless mode, see "Fast-Path Spawn + Collection" below)
 - `AGENT_ID`: `"fast"`
 - `<output_file>`: `{CR_DIR}/agent_fast.json`
 - `<patches_file>`: `{CR_DIR}/patches_all.txt`
@@ -484,7 +484,9 @@ Standard severity/priority rules apply.
 If `domain_critics` is empty, remove the `{DOMAIN_CRITIC_PASS}` placeholder entirely.
 
 **Fast-Path Spawn + Collection:**
-- Spawn exactly one background task (`AGENT_ID: "fast"`).
+- Spawn exactly ONE agent (`AGENT_ID: "fast"`) and collect it SYNCHRONOUSLY (MANDATORY). Either spawn the Task with `run_in_background: false` (omitted is fine), in which case the call blocks and returns the `DONE`/findings status directly, or, if you do background it, your VERY NEXT action MUST be a blocking `TaskOutput` for `AGENT_ID: "fast"`. Do NOT emit a final summary, mark a todo complete, or end your turn until the fast-path agent has returned and the remaining stages (`stage_21_collect_findings` through `stage_30_footer`) have run. Backgrounding one agent provides no parallelism and, in headless mode, lets the run exit before those stages execute (see the headless warning below).
 - `DONE ... file=WRITE_DENIED` is a success path, not a failure. Extract `<findings_json>` from `TaskOutput` and write it to `<CR_DIR>/agent_fast.json`. Retry only when the task fails to return `DONE`, times out/crashes, or returns malformed findings with no usable output file.
 - On failure (not WRITE_DENIED): retry once with `model: "haiku"`, same `AGENT_ID: "fast"`, same output file `<CR_DIR>/agent_fast.json`. Delete any existing `agent_fast.json` before retrying. Do NOT create `agent_fast_retry.json`.
 - If retry also fails: warn and continue with zero fast-path findings.
+
+**Headless mode warning (applies to BOTH the standard flow and the fast path).** In GitHub mode the review runs under headless `claude -p`, where there is NO asynchronous subagent-completion notification: when the orchestrator's assistant turn ends with no pending synchronous tool call, the process terminates immediately (`terminal_reason: "completed"`). If you background a reviewer and then end your turn to "wait" for it, the run dies before `stage_21_collect_findings` through `stage_30_footer` execute, so no `.closedloop-ai/code-review-*` artifacts are written and the workflow posts an empty fallback summary. The synchronous spawn (fast path) and the blocking `TaskOutput` collection (standard flow) are what keep the turn alive until reviewers finish; never substitute either with "I'll continue when notified."


### PR DESCRIPTION
## Summary

Fixes the GitHub code review pipeline exiting before producing any artifacts on the fast path (FEA-1970).

On small PRs, `/code-review:shallow --github <pr>` routes to a single fast-path reviewer. The `spawn-reviewers` skill spawned that reviewer as a **background task** and the orchestrator then ended its turn to "wait" for it. Under headless `claude -p` (the GitHub Action) there is **no asynchronous subagent-completion notification**, so the run terminated (`terminal_reason: "completed"`) before `stage_21_collect_findings` through `stage_30_footer` ran. No `.closedloop-ai/code-review-*` artifacts were written, and the workflow posted the generic fallback comment ("Review completed but no summary was generated").

Observed in: closedloop-ai/symphony-alpha Actions run 27783427204 (PR #1725, a 3-file / 43-LOC migration).

## Root cause

`plugins/code-review/skills/spawn-reviewers/SKILL.md` had a mandatory blocking-collection contract in the **Standard Flow** but not in the **Fast Path** section, which told the orchestrator to spawn one background task and never restated "block until it returns." Backgrounding a single agent gives no parallelism and exposed the run to a fire-and-forget exit.

## Changes

- **Fast Path**: spawn and collect the single reviewer **synchronously** (`run_in_background: false`), or, if backgrounded, require a blocking `TaskOutput` as the very next action before any final summary or turn end.
- **Headless-mode warning** added to the skill, applicable to both the fast path and the standard fleet: ending the turn to await a backgrounded reviewer terminates the run in headless mode before the output stages execute.
- **Standard Flow** collection note now points at the headless warning.
- Version bump `code-review` 2.34.0 -> 2.34.1 (PATCH) and CHANGELOG entry.

## Acceptance

A re-run of `/code-review:shallow --github <small-pr>` proceeds through stages 21 to 30 and writes `code-review-summary.md` / `code-review-findings.json` instead of exiting after spawning the reviewer.

Feature: FEA-1970 (https://app.closedloop.ai/closedloop-ai/features/FEA-1970)