### PR TITLE
fix(code-review): drop model:sonnet override — 1M-context billing footgun (v2.37.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code-review v2.37.1
+
+#### Fixed
+- Removed the `model: sonnet` frontmatter override from the `/start`, `/deep`, and `/shallow` commands (added in v2.37.0). A per-command model override inherits the session's context-window tier, so on a 1M-context session the orchestrator resolved to Sonnet-with-1M, which bills as extra pay-as-you-go API usage outside a Pro/Max subscription — the opposite of the intended saving, with no per-command way to opt out. The orchestrator now runs on the session model again; the turn-and-context discipline rules from v2.37.0 (which are model-independent) are retained, and `start.md`/`README.md` now document running `/code-review` from a standard-context Sonnet session as the way to get the cheaper orchestrator.
+
 ### code-review v2.37.0
 
 #### Changed

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "2.37.0",
+  "version": "2.37.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -7,7 +7,7 @@ A multi-agent code review plugin for Claude Code that performs deep, partitioned
 - **Multi-agent parallel review**: Splits changed files into partitions and spawns concurrent reviewer agents (Bug Hunter A, plus domain specialists) to review each partition independently
 - **Deterministic hygiene checks**: Pattern-based checks for CI artifacts, sensitive file exposure, and path leakage — zero LLM tokens required
 - **Risk-based model routing**: Scores each file partition by risk (size, file type, LOC) and routes high-risk partitions to more capable models
-- **Cost-optimized orchestration**: The orchestrator command runs on Sonnet (the walk is mechanical — run helper, read JSON, honor gates), while spawned reviewer and verifier subagents keep their own route-assigned models, so review quality is unchanged while the orchestration spine costs a fraction of an all-Opus run
+- **Cost-optimized orchestration**: The orchestrator walk is mechanical (run helper, read JSON, honor gates) and carries no diff or large artifacts in its own context, so it is cheap to run on a lower-cost session model while spawned reviewer and verifier subagents keep their own route-assigned models — run `/code-review` from a standard-context Sonnet session for the cheapest orchestrator without changing review quality
 - **Finding validation and deduplication**: Normalizes severity, filters low-confidence findings, deduplicates near-duplicate issues via Jaccard similarity, and validates line numbers against the actual diff
 - **Incremental reviews**: Tracks prior review state to diff only new commits since the last successful review (auto-incremental mode)
 - **Caching**: Content-addressed cache keyed on prompt hash and diff tip to skip re-reviewing unchanged partitions

--- a/plugins/code-review/commands/deep.md
+++ b/plugins/code-review/commands/deep.md
@@ -1,7 +1,6 @@
 ---
 description: Deep code review — standard fleet plus Impact Analyzer (FEA-1401) when changed exported symbols are detected
 argument-hint: "[scope] [--github] [--base <ref>] [--since-last-review] [--full-review]"
-model: sonnet
 ---
 
 # Deep Code Review (PLN-807 + FEA-1401)

--- a/plugins/code-review/commands/shallow.md
+++ b/plugins/code-review/commands/shallow.md
@@ -1,7 +1,6 @@
 ---
 description: Shallow code review — built-in reviewers only (BHA + BHB + auditor + verifier); no critic-gates, no signal extraction
 argument-hint: "[scope] [--github] [--base <ref>] [--since-last-review] [--full-review]"
-model: sonnet
 ---
 
 # Shallow Code Review (PLN-807)

--- a/plugins/code-review/commands/start.md
+++ b/plugins/code-review/commands/start.md
@@ -1,7 +1,6 @@
 ---
 description: Run comprehensive code review — locally or on GitHub PRs with inline comments
 argument-hint: "[scope] [--github] [--hygiene-only] [--base <ref>] [--since-last-review] [--full-review] [--depth shallow|standard|deep]"
-model: sonnet
 ---
 
 # Comprehensive Code Review
@@ -57,7 +56,7 @@ The walk is hybrid:
 - **Agent fleet stages** — spawn parallel sub-agent Tasks. `stage_20_spawn_reviewers` invokes the `code-review:spawn-reviewers` skill; `stage_23_verify_findings` invokes the `code-review:verify-findings` skill.
 - **Present stage** (`stage_29_present`) — invoke the `code-review:present-local` skill (MODE=local) or follow `github-review.md` (MODE=github).
 
-**Model split (cost).** The orchestrator runs on **Sonnet** (`model: sonnet` in this command's frontmatter) — the walk is mechanical (run helper, read JSON, honor gates), so it needs no Opus reasoning, and the spine is ~65% of historical review cost at ~180 turns/deep-review dominated by cache reads. The judgment lives in the **subagents**, which keep their own route-assigned models regardless of the orchestrator's: BHA defaults Opus (Sonnet on test-only partitions), domain critics Sonnet, Impact Analyzer Opus, verifiers per the verify skill. A subagent's `model` (definition frontmatter or per-Task override from `spawn.json.spec`) outranks the session model, so the Sonnet spine never downgrades a reviewer. If an org `availableModels` allowlist excludes Sonnet, the session keeps its current model and the run still completes — the split is an optimization, not a hard dependency.
+**Orchestrator model (cost).** The orchestrator runs on the **session model** — there is intentionally no `model:` frontmatter override. The walk is mechanical (run helper, read JSON, honor gates) with no Opus-grade reasoning, so it is safe on a cheaper model; the judgment lives in the **subagents**, which keep their own route-assigned models regardless (BHA Opus / Sonnet on test-only partitions, domain critics Sonnet, Impact Analyzer Opus, verifiers per the verify skill). The spine is ~65% of historical review cost (~180 turns/deep-review, cache-read dominated), so for the cheapest run invoke `/code-review` from a standard-context **Sonnet** session (`/model sonnet`) — the reviewers stay on their assigned models either way. A `model: sonnet` frontmatter override is **deliberately avoided**: a per-command model override inherits the session's context-window tier, so on a **1M-context** session it resolves to Sonnet-with-1M and bills as extra pay-as-you-go API usage outside a Pro/Max subscription (a known Claude Code limitation with no per-command opt-out) — which would invert the saving.
 
 **Turn & context discipline (cost).** Cache cost scales with carried context × turn count, so keep both small:
 - **Never read large artifacts into the orchestrator's context.** `diff_data.json`, `patches_*.txt`, and per-file diffs are passed to helpers and reviewers as **file-path arguments**, never `cat`/`Read` into the walk. Reviewers read patches themselves (see the spawn skill's anti-inline rule). The only large file the orchestrator reads is `review_result.json` at the present stage, once, with the per-section display caps the present skill already applies.


### PR DESCRIPTION
## The bug

PR #167 added `model: sonnet` to the `/start`, `/deep`, `/shallow` command frontmatter to run the orchestrator on Sonnet. But a per-command **model override inherits the session's context-window tier** — so on a **1M-context session** (e.g. a default of *"Opus 4.8 (1M context)"*) the override resolves to **`claude-sonnet-4-6[1m]`**, which bills as **extra pay-as-you-go API usage outside a Pro/Max subscription**.

Verified against current Claude Code behavior + docs:
- Sonnet 4.6 has **no long-context rate premium** ($3/$15 at any size) — the harm is **subscription inclusion**: Opus-1M is included in Pro/Max entitlement, but Sonnet-1M is **not** (extra usage).
- There is **no per-command escape** from the session's 1M tier — not via frontmatter, model ID, env var, or setting. Known Claude Code issues: anthropics/claude-code#45847, #45169.

So for anyone whose default session is a 1M model, #167 silently moved the orchestrator *out of the subscription into billable API usage* — and Opus-1M (included) is actually **cheaper for them** than Sonnet-1M (extra). The "optimization" inverted.

## The fix

Remove the `model: sonnet` override from all three commands. The orchestrator runs on the **session model** again.

- The **model-independent** wins from #167 — never carrying the diff/large artifacts in orchestrator context, batching deterministic stages, narrating sparingly — are **retained**.
- `start.md` and `README.md` now document the supported path to the cheaper orchestrator: run `/code-review` from a **standard-context Sonnet session** (`/model sonnet`), where Sonnet bills normally and is genuinely cheaper than Opus. The docs also explain *why* the frontmatter override is deliberately avoided, so it isn't re-added.

## Scope / sequencing

6-file change (frontmatter + docs + version + CHANGELOG), no code. **2.37.0 → 2.37.1 (PATCH)**.

Branched from `main` (which has #167). Independent of the open #168 (premise category excision, v3.0.0) — they touch different sections of `start.md`. This hotfix should merge **first** (it's an active billing regression); #168 then rebases and re-bumps from 2.37.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)