### PR TITLE
docs(code-review): correct stale prefix-harness "Phase 4b" comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the claude-plugins project will be documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Entries are listed newest-first; each plugin section is treated as released when merged to `main`.
 
+### code-review v3.4.1
+
+#### Fixed
+- Corrected stale documentation that described the deterministic-prefix golden harness as unbuilt future work. The `golden_fixture_harness.py` and `cmd_prepare_run` docstrings and the `SCHEMA.md` golden-fixture section now point at the delivered prefix harness (`prefix_golden_harness.py`) and its subprocess A/B parity oracle, and note that the orchestrator runs the deterministic prefix in-process via `run-prefix` rather than walking those stages one at a time.
+
 ### code-review v3.4.0
 
 #### Changed

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Code review plugin",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code-review/SCHEMA.md
+++ b/plugins/code-review/SCHEMA.md
@@ -719,8 +719,10 @@ The remaining 3 fixtures requiring plans 03/05/06
 (`golden_impact_with_callsites`, `golden_coverage_gap`,
 `golden_budget_exceeded`) have reserved directories with READMEs and
 are skipped via a `_DEFERRED_FIXTURES` map in the test module until
-their dependent plans land. Phase 4b will extend the harness to walk
-`run_plan.json` end-to-end through a declarative stage runner.
+their dependent plans land. The deterministic prefix (stages `01` through
+Gate B) is pinned separately by `prefix_golden_harness.py` (PLN-1229
+Phase 0); its subprocess A/B parity oracle guards the in-process
+`run-prefix` batch runner byte-for-byte.
 
 ---
 

--- a/plugins/code-review/tools/python/code_review_helpers.py
+++ b/plugins/code-review/tools/python/code_review_helpers.py
@@ -11013,7 +11013,8 @@ def cmd_prepare_run(args: argparse.Namespace) -> int:
     """Emit ``run_plan.json`` describing the full review pipeline.
 
     PLN-719 Section 6. The output is consumed by the ``/start`` orchestrator,
-    which walks the plan stage-by-stage (Phase 4b).
+    which runs the deterministic prefix in-process via ``run-prefix``
+    (PLN-1229) and walks the reviewer tail stage-by-stage.
 
     Determinism: same inputs produce byte-identical output **except for the
     ``review_id`` field**, which is a fresh ``uuid.uuid4()`` per invocation.

--- a/plugins/code-review/tools/python/golden_fixture_harness.py
+++ b/plugins/code-review/tools/python/golden_fixture_harness.py
@@ -17,8 +17,11 @@ Non-deterministic fields (``review_id`` UUID, ``emitted_at`` ISO timestamps,
 the wall-clock telemetry block) are normalized before diff/write so the
 expected files stay stable across runs.
 
-Phase 8 ships the post-collection harness only. Phase 4b will extend it to
-walk ``run_plan.json`` end-to-end through a declarative stage runner.
+This module pins the post-collection half only (``collect-findings`` →
+``validate`` → ``finalize-result``). The deterministic prefix — stages ``01``
+through Gate B — is pinned separately by ``prefix_golden_harness.py``
+(PLN-1229 Phase 0), whose subprocess A/B parity oracle guards the in-process
+``run-prefix`` batch runner byte-for-byte.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What

Docs-only cleanup closing out **PLN-1229** (in-process `run-prefix` batch runner). PLN-1229 delivered the deterministic-prefix golden harness (`prefix_golden_harness.py`) and its subprocess A/B parity oracle, but three spots still described that work as an unbuilt future **"Phase 4b"** that *"will extend"* the post-collection harness:

| File | Was | Now |
|---|---|---|
| `golden_fixture_harness.py` docstring | *"Phase 4b will extend it to walk run_plan.json end-to-end…"* | points at `prefix_golden_harness.py` + parity oracle |
| `cmd_prepare_run` docstring (`code_review_helpers.py`) | *"walks the plan stage-by-stage (Phase 4b)"* | *"runs the deterministic prefix in-process via `run-prefix` … and walks the reviewer tail stage-by-stage"* |
| `SCHEMA.md` §12 (golden fixture harness) | *"Phase 4b will extend the harness to walk run_plan.json…"* | points at the delivered prefix harness + parity oracle |

Left untouched: the accurate historical labels (`prefix_golden_harness.py`'s own docstring already says Phase 4b "was never built. This module builds it"; the `start.md` §header and a test docstring are attribution, not false claims), and the *unrelated* genuine deferrals (`_DEFERRED_FIXTURES` gated on plans 03/05/06; cross-run analytics).

## Why

Surfaced by a cleanup audit before closing FEA-2385. Leaving future-tense "will extend" comments for work that's already merged is exactly the stale-comment drift the repo guards against — and the plan itself quoted one of these comments as its motivation.

## Validation

- No stale `will extend` / `Phase 4b will` claims remain (grep clean).
- `ruff check` clean on both changed `.py` files.
- 75 targeted run-prefix / prefix-harness tests pass.
- Docs/comment-only — no runtime behavior change. Version bump `3.4.0 → 3.4.1` (PATCH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)