### PR TITLE
fix(code): treat a missing plan.json at COMPLETE as a spurious completion

### DIFF
--- a/plugins/code/.claude-plugin/plugin.json
+++ b/plugins/code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code",
   "description": "Code and planning framework plugin",
-  "version": "1.14.7",
+  "version": "1.14.8",
   "author": {
     "name": "ClosedLoop",
     "email": "support@closedloop.ai"

--- a/plugins/code/scripts/run-loop.sh
+++ b/plugins/code/scripts/run-loop.sh
@@ -147,6 +147,11 @@ fail_loop_user_visible() {
 # fail_loop_user_visible.
 detect_spurious_complete() {
   local workdir="$1"
+  # Defaults to the global so the existing single-argument call site is
+  # unchanged; passed explicitly by tests. Non-empty means this run was asked to
+  # draft a plan from a PRD, which is what makes a missing plan.json a broken
+  # promise rather than a run that never owed one.
+  local prd_file="${2-${PRD_FILE:-}}"
   local plan_file="$workdir/plan.json"
   local state_file="$workdir/state.json"
 
@@ -166,6 +171,29 @@ detect_spurious_complete() {
   fi
 
   if [[ ! -f "$plan_file" ]]; then
+    # A --prd run exists to produce plan.json. Claiming COMPLETE without one is
+    # the strongest spurious-completion signal there is, and this branch used to
+    # wave it through: the checks below only validate pendingTasks INSIDE an
+    # existing plan, so "no plan at all" -- the case that actually happens --
+    # was the one case nothing could catch.
+    #
+    # Observed: the orchestrator launched plan-draft-writer in the BACKGROUND,
+    # said "Plan-draft-writer is running in the background. Waiting for
+    # completion.", and that same turn carried the completion promise. The loop
+    # ended, the writer was abandoned mid-flight, post-loop code review passed
+    # vacuously over an empty diff ("the base ref you passed equals HEAD, so
+    # nothing was examined"), and the run exited 0 having produced nothing. The
+    # user got an implementation-plan artifact that looked done and was empty.
+    #
+    # Scoped to runs that were asked for a plan: a run with no PRD never owed
+    # one, and is left alone.
+    if [[ -n "$prd_file" ]]; then
+      jq -n -c \
+        --arg subcode "PLAN_MISSING_AT_COMPLETION" \
+        --arg message "Loop emitted COMPLETE but no plan.json was ever written. The planning phase did not finish -- a background plan-draft-writer that is still running when the completion promise fires is abandoned. Inspect state.json and the loop output, then re-run /code:code to continue." \
+        '{subcode:$subcode,message:$message}'
+      return
+    fi
     echo '{}'
     return
   fi

--- a/plugins/code/scripts/tests/test_spurious_complete.sh
+++ b/plugins/code/scripts/tests/test_spurious_complete.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Tests for detect_spurious_complete() in run-loop.sh.
+#
+# The case that motivated these: a PLAN run emitted the completion promise while
+# plan-draft-writer was still running in the BACKGROUND. The loop ended, the
+# writer was abandoned, post-loop code review passed vacuously over an empty
+# diff, and the run exited 0 having written no plan.json at all -- so the user's
+# implementation-plan artifact looked done and was empty. The guard could not
+# see it: its checks only validate pendingTasks INSIDE an existing plan.json.
+#
+# run-loop.sh guards main() with [[ "${BASH_SOURCE[0]}" == "$0" ]], so sourcing
+# it defines the functions without running the loop.
+#
+# Usage:
+#   bash plugins/code/scripts/tests/test_spurious_complete.sh
+#
+# Exit code: 0 if all tests pass, 1 if any test fails.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_LOOP="$SCRIPT_DIR/../run-loop.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS_COUNT=$(( PASS_COUNT + 1 ))
+}
+
+fail() {
+  echo "  FAIL: $1 -- $2"
+  FAIL_COUNT=$(( FAIL_COUNT + 1 ))
+}
+
+assert_subcode() {
+  local name="$1" json="$2" expected="$3"
+  local actual
+  actual=$(echo "$json" | jq -r '.subcode // ""' 2>/dev/null || echo "")
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$name (subcode=$actual)"
+  else
+    fail "$name" "expected subcode '$expected', got '$actual' in: $json"
+  fi
+}
+
+assert_not_spurious() {
+  local name="$1" json="$2"
+  local actual
+  actual=$(echo "$json" | jq -r '.subcode // ""' 2>/dev/null || echo "")
+  if [[ -z "$actual" ]]; then
+    pass "$name (not flagged)"
+  else
+    fail "$name" "expected no subcode, got '$actual' in: $json"
+  fi
+}
+
+# shellcheck source=/dev/null
+source "$RUN_LOOP"
+
+echo "detect_spurious_complete"
+
+# --- A --prd run that produced no plan is the reported defect ---------------
+WORKDIR=$(mktemp -d)
+printf '%s' '{"phase":"Phase 1: Planning","status":"IN_PROGRESS"}' > "$WORKDIR/state.json"
+assert_subcode "COMPLETE with no plan.json on a --prd run is spurious" \
+  "$(detect_spurious_complete "$WORKDIR" "/tmp/prd.md")" \
+  "PLAN_MISSING_AT_COMPLETION"
+rm -rf "$WORKDIR"
+
+# --- A run that never owed a plan is left alone ----------------------------
+WORKDIR=$(mktemp -d)
+assert_not_spurious "COMPLETE with no plan.json and no PRD is not spurious" \
+  "$(detect_spurious_complete "$WORKDIR" "")"
+rm -rf "$WORKDIR"
+
+# --- The AWAITING_USER hard stop must keep winning -------------------------
+# A drafted plan parked for review legitimately has no finished plan yet; the
+# new branch must not turn that documented stop into a failure.
+WORKDIR=$(mktemp -d)
+printf '%s' '{"phase":"Phase 1.1","status":"AWAITING_USER"}' > "$WORKDIR/state.json"
+assert_not_spurious "AWAITING_USER outranks the missing-plan check" \
+  "$(detect_spurious_complete "$WORKDIR" "/tmp/prd.md")"
+rm -rf "$WORKDIR"
+
+# --- Existing behaviour: a complete plan is still clean ---------------------
+WORKDIR=$(mktemp -d)
+printf '%s' '{"pendingTasks":[],"openQuestions":[]}' > "$WORKDIR/plan.json"
+assert_not_spurious "a plan with no pending tasks is not spurious" \
+  "$(detect_spurious_complete "$WORKDIR" "/tmp/prd.md")"
+rm -rf "$WORKDIR"
+
+# --- Existing behaviour: pending tasks still flagged, and not as the new code -
+WORKDIR=$(mktemp -d)
+printf '%s' '{"pendingTasks":[{"id":"T-1.1"}],"openQuestions":[]}' > "$WORKDIR/plan.json"
+assert_subcode "pending tasks at completion still flagged" \
+  "$(detect_spurious_complete "$WORKDIR" "/tmp/prd.md")" \
+  "PENDING_TASKS_AT_COMPLETION"
+rm -rf "$WORKDIR"
+
+WORKDIR=$(mktemp -d)
+printf '%s' '{"pendingTasks":[{"id":"T-1.1"}],"openQuestions":[{"id":"Q-1"}]}' > "$WORKDIR/plan.json"
+assert_subcode "pending tasks blocked by open questions still flagged" \
+  "$(detect_spurious_complete "$WORKDIR" "/tmp/prd.md")" \
+  "PENDING_TASKS_BLOCKED_BY_QUESTIONS"
+rm -rf "$WORKDIR"
+
+echo
+echo "passed: $PASS_COUNT  failed: $FAIL_COUNT"
+[[ "$FAIL_COUNT" -eq 0 ]]


### PR DESCRIPTION
## Summary

**Generate Implementation Plan silently produces nothing.** The run completes, exits 0, and the user is left with an implementation-plan artifact that looks done and is empty.

Reproduced 2026-08-10 (symphony-alpha PLN-1688). From the loop's own output, in order:

```
No plan-source.md found. Launching plan-draft-writer to create the plan.
Plan-draft-writer is running in the background. Waiting for completion.
...
Completion promise detected: COMPLETE
Loop complete after 1 iterations!
→ Post-Loop Code Review
```

The orchestrator launched `plan-draft-writer` as a **background** agent, said in plain text that it was waiting for it, and that same turn carried the completion promise. The loop ended, the writer was abandoned mid-flight, and the post-loop code review then passed vacuously over an empty diff — *"No findings — but this is a vacuous pass... The base ref you passed equals HEAD, so nothing was examined"* — and the process exited 0.

Corroborating state left in the worktree: `state.json` still reads `{"phase":"Phase 1: Planning","status":"IN_PROGRESS"}` while `runs.log` records `plan_execute` → `review_approve`. Pre-exploration **did** finish (`code-map.json` 17.6K, `investigation-log.md` 16.4K, `requirements-extract.json` 14.1K) — the run stopped exactly at the plan-writing step.

**`detect_spurious_complete` had the hole backwards.** Its checks validate `pendingTasks` *inside an existing* `plan.json`, and its first branch returned "not spurious" whenever the file was absent:

```bash
if [[ ! -f "$plan_file" ]]; then
  echo '{}'   # <- let COMPLETE through
  return
fi
```

So "no plan at all" — the case that actually happens — was the one case nothing could catch. A `--prd` run exists to produce `plan.json`; claiming COMPLETE without one is the strongest spurious-completion signal there is.

## Change

- A missing `plan.json` at COMPLETE is now flagged as `PLAN_MISSING_AT_COMPLETION`, routed through the existing `handle_spurious_complete` path (telemetry, lock release, user-visible failure, exit 1) — so it bails **before** the post-loop code review rather than compounding misleading state, exactly as the sibling subcodes do.
- **Scoped:** only fires when the run was asked for a plan (`--prd` / `PRD_FILE`). A run with no PRD never owed a plan and is untouched.
- **The `AWAITING_USER` hard stop still outranks it**, so a plan drafted and parked at the Phase 1.1 review checkpoint is not turned into a failure.
- `detect_spurious_complete` takes the PRD path as an optional second argument defaulting to the global, so the existing call site is unchanged and tests can be explicit.
- `plugins/code` version bumped 1.14.7 → 1.14.8 per the Plugin Version Bump gate.

## Test plan

New `plugins/code/scripts/tests/test_spurious_complete.sh` (6 cases). `run-loop.sh` guards `main` with `[[ "${BASH_SOURCE[0]}" == "$0" ]]`, so the suite sources it and calls the function directly:

- COMPLETE with no `plan.json` on a `--prd` run → `PLAN_MISSING_AT_COMPLETION` (the reported defect)
- COMPLETE with no `plan.json` and no PRD → not flagged (scope guard)
- `AWAITING_USER` + no plan → not flagged (the documented hard stop still wins)
- a plan with no pending tasks → not flagged
- pending tasks → still `PENDING_TASKS_AT_COMPLETION`
- pending tasks + open questions → still `PENDING_TASKS_BLOCKED_BY_QUESTIONS`

```
passed: 6  failed: 0
```

**Counterfactual:** neutering only the new branch fails exactly the first case and leaves the other five green — so the new code is doing the work, and the four pre-existing behaviours are provably unchanged.

**Known gap:** CI runs ruff/pyright/pytest and the TS suite; there is no bash-test job, so this suite (like the existing `plugins/code/hooks/tests/*.sh`) is not gated. Run it with `bash plugins/code/scripts/tests/test_spurious_complete.sh`. Wiring the bash suites into CI is worth doing separately.

## Related

The other half of this failure is in `closedloop-ai/symphony-alpha` (ISS-5872, URGENT): the desktop loop harness computes `missingRequired` via `validateResultBundle`, logs `Missing required artifacts for PLAN: plan.json`, then discards the result and finalizes the loop as COMPLETED with `error: null`. Either layer alone would have caught this; both failed open. This PR closes the upstream one.
